### PR TITLE
fix(notification): Removed unused styles for android texts

### DIFF
--- a/src/entities/notification/model/mappers/mapToTriggerNotifications.ts
+++ b/src/entities/notification/model/mappers/mapToTriggerNotifications.ts
@@ -1,8 +1,4 @@
-import notifee, {
-  AndroidStyle,
-  TriggerType,
-  AndroidImportance,
-} from '@notifee/react-native';
+import notifee, { TriggerType, AndroidImportance } from '@notifee/react-native';
 
 import { colors } from '@shared/lib';
 
@@ -50,10 +46,6 @@ export async function mapToTriggerNotifications(
         channelId,
         pressAction: {
           id: 'default',
-        },
-        style: {
-          type: AndroidStyle.BIGTEXT,
-          text: notification.notificationBody ?? '',
         },
         smallIcon: 'ic_notification',
         color: colors.primary,


### PR DESCRIPTION
The android styling cause the following error: Error: notifee.createTriggerNotification(*) 'notification.android.style' BigTextStyle: 'text' expected a valid string value.]  It may have something to do with Notifee as we had a guard that checked if notificationBody is undefined or null then pass empty string to the 'text' property.

https://mindlogger.atlassian.net/browse/M2-1757