### PR TITLE
Fixed M2-4225 AppletBottomTabBar paddingBottom issues on Ipad 7th

### DIFF
--- a/src/screens/config/theme.tsx
+++ b/src/screens/config/theme.tsx
@@ -41,7 +41,7 @@ export const getScreenOptions = ({ navigation }: ScreenOptions) => {
 
 export const getAppletDetailsScreenOptions = (
   appletTheme: AppletTheme | null,
-  bottomInset: number,
+  hasBottomInset: boolean,
 ) => {
   return ({ route }: BottomScreenOptions): BottomTabNavigationOptions => {
     const tabBarIcon = (color: string) => {
@@ -86,9 +86,9 @@ export const getAppletDetailsScreenOptions = (
         backgroundColor: colors.lightBlue,
         paddingTop: 3,
         ...(IS_ANDROID ? { paddingBottom: 5 } : {}),
-        ...(bottomInset
+        ...(hasBottomInset
           ? { height: 85, paddingBottom: 20 }
-          : { height: 65, paddingBottom: 0 }),
+          : { height: 70, paddingBottom: 5 }),
       },
       tabBarLabel: ({ color, focused, children }) => {
         return (

--- a/src/screens/ui/AppletBottomTabNavigator.tsx
+++ b/src/screens/ui/AppletBottomTabNavigator.tsx
@@ -70,7 +70,7 @@ const AppletBottomTabNavigator = ({ route, navigation }: Props) => {
       <Tab.Navigator
         screenOptions={getAppletDetailsScreenOptions(
           appletTheme ?? null,
-          bottom,
+          Boolean(bottom),
         )}
         initialRouteName="ActivityList"
       >


### PR DESCRIPTION
[M2-4225](https://mindlogger.atlassian.net/browse/M2-4225)
AppletBottomTabBar paddingBottom issues on Ipad 7th (because safeAreaBottom = 0)

[M2-4225]: https://mindlogger.atlassian.net/browse/M2-4225?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ



Before

![image](https://github.com/ChildMindInstitute/mindlogger-app-refactor/assets/120190555/580d03d9-a77e-46bd-9887-17dd67a9a762)


After

![image](https://github.com/ChildMindInstitute/mindlogger-app-refactor/assets/120190555/28f28635-683b-4aba-9978-2b4e37152744)
