### PR TITLE
M2-4992, M2-4999: Mixpanel Tracking: Mobile App Re-Open ; Upload logs screen

### DIFF
--- a/src/features/applets-refresh/model/hooks/useRefresh.ts
+++ b/src/features/applets-refresh/model/hooks/useRefresh.ts
@@ -20,6 +20,7 @@ function useRefresh(onSuccess: () => void) {
     },
     { enabled: IS_IOS && isRefreshing },
   );
+
   const onRefresh = () => {
     refresh().then(() => setIsRefreshing(false));
     setIsRefreshing(true);

--- a/src/features/enter-foreground/model/hooks/index.ts
+++ b/src/features/enter-foreground/model/hooks/index.ts
@@ -1,1 +1,2 @@
 export { default as useRestackNotifications } from './useRestackNotifications';
+export { default as useAnalyticsEventTrack } from './useAnalyticsEventTrack';

--- a/src/features/enter-foreground/model/hooks/useAnalyticsEventTrack.ts
+++ b/src/features/enter-foreground/model/hooks/useAnalyticsEventTrack.ts
@@ -1,0 +1,9 @@
+import { AnalyticsService, MixEvents, useOnForeground } from '@app/shared/lib';
+
+function useAnalyticsEventTrack() {
+  useOnForeground(() => {
+    AnalyticsService.track(MixEvents.AppReOpen);
+  });
+}
+
+export default useAnalyticsEventTrack;

--- a/src/features/send-application-logs/ui/SendApplicationLogsForm.tsx
+++ b/src/features/send-application-logs/ui/SendApplicationLogsForm.tsx
@@ -2,7 +2,7 @@ import { FC, useState } from 'react';
 
 import { useTranslation } from 'react-i18next';
 
-import { Logger } from '@shared/lib';
+import { AnalyticsService, Logger, MixEvents } from '@shared/lib';
 import { SubmitButton, Box, Text, Center, ActivityIndicator } from '@shared/ui';
 
 const SendApplicationLogsForm: FC = () => {
@@ -13,7 +13,17 @@ const SendApplicationLogsForm: FC = () => {
 
   const onSendLogs = async () => {
     setIsLoading(true);
+
+    AnalyticsService.track(MixEvents.UploadLogsPressed);
+
     const result = await Logger.send();
+
+    if (result) {
+      AnalyticsService.track(MixEvents.UploadedLogsSuccessfully);
+    } else {
+      AnalyticsService.track(MixEvents.UploadLogsError);
+    }
+
     setUploadStatus(result);
     setIsLoading(false);
   };

--- a/src/screens/ui/RootNavigator.tsx
+++ b/src/screens/ui/RootNavigator.tsx
@@ -90,6 +90,7 @@ export default () => {
     },
   });
 
+  EnterForegroundModel.useAnalyticsEventTrack();
   EnterForegroundModel.useRestackNotifications();
 
   useBackHandler(() => {

--- a/src/shared/lib/analytics/AnalyticsService.ts
+++ b/src/shared/lib/analytics/AnalyticsService.ts
@@ -30,10 +30,14 @@ export const MixEvents = {
   LoginSuccessful: 'Login Successful',
   SignupSuccessful: 'Signup Successful',
   AppOpen: 'App Open',
+  AppReOpen: 'App Re-Open',
   ActivityRestart: 'Activity Restart Button Pressed',
   ActivityResume: 'Activity Resume Button Pressed',
   AppletSelected: 'Applet Selected',
   ReturnToActivitiesPressed: 'Return to Activities pressed',
+  UploadLogsPressed: 'Upload Logs Pressed',
+  UploadedLogsSuccessfully: 'Uploaded Logs Successfully',
+  UploadLogsError: 'Upload Logs Error Occurred',
 };
 
 const AnalyticsService = {


### PR DESCRIPTION
### 📝 Description

🔗 [Jira Ticket M2-4992](https://mindlogger.atlassian.net/browse/M2-4992)
🔗 [Jira Ticket M2-4999](https://mindlogger.atlassian.net/browse/M2-4999)

This PR adds some new mixpanel events

This PR changes:
-  adds mixpanel events for the case when the app switched from background to foreground state
- adds mixpanel events for the cases when user sends logs from the upload-logs screen
