### PR TITLE
[M2-5044] [M2-4793] 'outside of' rule for slider works incorrectly

### DIFF
--- a/src/features/pass-survey/model/AnswerValidator.ts
+++ b/src/features/pass-survey/model/AnswerValidator.ts
@@ -34,7 +34,7 @@ function AnswerValidator(params?: AnswerValidatorArgs) {
     isOutsideOfValues(min: number, max: number) {
       const answer = currentAnswer?.answer as Maybe<number>;
 
-      return ConditionalLogicModel.isBetweenValues(answer, min, max);
+      return ConditionalLogicModel.isOutsideOfValues(answer, min, max);
     },
 
     isEqualToValue(value: any) {

--- a/src/features/pass-survey/model/hooks/useActivityStepper.ts
+++ b/src/features/pass-survey/model/hooks/useActivityStepper.ts
@@ -4,7 +4,6 @@ import {
   onIncorrectAnswerGiven,
 } from '../../lib';
 import AnswerValidator from '../AnswerValidator';
-import StepperUtils from '../StepperUtils';
 
 const ConditionalLogicItems: ActivityItemType[] = [
   'Radio',
@@ -65,19 +64,7 @@ function useActivityStepper(state: ActivityState | undefined) {
   }
 
   function getNextButtonText() {
-    const stepperUtils = new StepperUtils(state!);
-    const shift = stepperUtils.getNextStepShift();
-    const nextStep = step + shift;
-
-    if (nextStep >= items.length) {
-      return 'activity_navigation:done';
-    }
-
-    return isLastStep
-      ? 'activity_navigation:done'
-      : canSkip
-      ? 'activity_navigation:skip'
-      : 'activity_navigation:next';
+    return canSkip ? 'activity_navigation:skip' : 'activity_navigation:next';
   }
 
   return {


### PR DESCRIPTION
### 📝 Description

🔗 [Jira Ticket M2-5044](https://mindlogger.atlassian.net/browse/M2-5044)
🔗 [Jira Ticket M2-4793](https://mindlogger.atlassian.net/browse/M2-4793)

This PR fixes the logic within `AnswerValidator.isOutsideOfValues` which was using `ConditionalLogicModel.isBetweenValues` instead of `ConditionalLogicModel.isOutsideOfValues`.

I also took the opportunity to update the logic for the `Next` button because I noticed while testing that the respondent may discover the logic for how to unlock some steps that they may other not have, just by playing with the slider. This brings the mobile app in line with web (see https://github.com/ChildMindInstitute/mindlogger-web-refactor/pull/358).

### 📸 Screenshots

#### Before

The logic is incorrect. It advances to the next question on the value 3, when it should only advance when the value is outside the range 2 - 4

https://github.com/ChildMindInstitute/mindlogger-app-refactor/assets/14842108/1e9444bd-f481-4be5-acf4-2edf3b8f5ad5

#### After

The logic is correct. It advances to the next question on the value 1

https://github.com/ChildMindInstitute/mindlogger-app-refactor/assets/14842108/71b46ebf-cbc4-470a-ad81-4554b210f26f

### 🪤 Peer Testing

- Launch the admin web app
- Create a test applet with the following items
  - A slider with values 0 to 10
    - Enable *Show Tick Marks*
    - Enable *Show Tick Marks Labels*
    
    Your slider preview should look like this:
    <img width="360" alt="image" src="https://github.com/ChildMindInstitute/mindlogger-app-refactor/assets/14842108/fbcb86a2-75e7-4026-bfba-55e4917cfe65">
  - A text item
- Add an item flow conditional as follows
  - If item slider is outside of the range 2 - 4
  - If any of the “if” rules above are true, show text
  <img width="480" alt="image" src="https://github.com/ChildMindInstitute/mindlogger-app-refactor/assets/14842108/a62bbaee-a24d-4004-9fb7-48ee3ade6a0b">
- Build and launch the mobile app
- Navigate to the slider item
- Adjust the slider to 1 and click **Next**
  **Expected outcome**: The activity should proceed to the text item
- Click **Back**
- Adjust the slider to 3
  **Expected outcome**: The activity should complete and submit the answers