### PR TITLE
M2-5489 Add HEIC to JPG converter for Android

### DIFF
--- a/android/app/src/main/java/lab/childmindinstitute/data/MainApplication.java
+++ b/android/app/src/main/java/lab/childmindinstitute/data/MainApplication.java
@@ -13,6 +13,8 @@ import lab.childmindinstitute.data.newarchitecture.MainApplicationReactNativeHos
 import java.lang.reflect.InvocationTargetException;
 import java.util.List;
 
+import lab.childmindinstitute.data.image_conversion.ImageConversionPackage;
+
 public class MainApplication extends Application implements ReactApplication {
 
   private final ReactNativeHost mReactNativeHost =
@@ -26,6 +28,7 @@ public class MainApplication extends Application implements ReactApplication {
         protected List<ReactPackage> getPackages() {
           @SuppressWarnings("UnnecessaryLocalVariable")
           List<ReactPackage> packages = new PackageList(this).getPackages();
+          packages.add(new ImageConversionPackage());
           // Packages that cannot be autolinked yet can be added manually here, for example:
           // packages.add(new MyReactNativePackage());
           return packages;

--- a/android/app/src/main/java/lab/childmindinstitute/data/image_conversion/ImageConversionModule.java
+++ b/android/app/src/main/java/lab/childmindinstitute/data/image_conversion/ImageConversionModule.java
@@ -1,0 +1,84 @@
+package lab.childmindinstitute.data.image_conversion;
+
+import android.graphics.Bitmap;
+import android.graphics.BitmapFactory;
+import android.graphics.Matrix;
+import android.media.ExifInterface;
+
+import com.facebook.react.bridge.Promise;
+import com.facebook.react.bridge.ReactApplicationContext;
+import com.facebook.react.bridge.ReactContextBaseJavaModule;
+import com.facebook.react.bridge.ReactMethod;
+
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+
+public class ImageConversionModule extends ReactContextBaseJavaModule {
+
+    public ImageConversionModule(ReactApplicationContext reactContext) {
+        super(reactContext);
+    }
+
+    @Override
+    public String getName() {
+        return "ImageConversionModule";
+    }
+
+    @ReactMethod
+    public void convertHeicToJpg(String heicFilePath, Promise promise) {
+        try {
+            File heicFile = new File(heicFilePath);
+
+            File cacheDir = getReactApplicationContext().getCacheDir();
+
+            String jpgFileName = heicFile.getName().replace(".heic", ".jpg");
+            File jpgFile = new File(cacheDir, jpgFileName);
+            String jpgFilePath = jpgFile.getAbsolutePath();
+
+            BitmapFactory.Options options = new BitmapFactory.Options();
+            Bitmap bitmap = BitmapFactory.decodeFile(heicFile.getAbsolutePath(), options);
+
+            if (bitmap == null) {
+                promise.reject("DECODE_ERROR", "Failed to decode HEIC file into Bitmap");
+                return;
+            }
+
+            int orientation = getOrientation(heicFilePath);
+            if (orientation != 0) {
+                Matrix matrix = new Matrix();
+                matrix.postRotate(orientation);
+                bitmap = Bitmap.createBitmap(bitmap, 0, 0, bitmap.getWidth(), bitmap.getHeight(), matrix, true);
+            }
+
+            FileOutputStream outputStream = new FileOutputStream(jpgFile);
+            bitmap.compress(Bitmap.CompressFormat.JPEG, 100, outputStream);
+            outputStream.flush();
+            outputStream.close();
+
+            promise.resolve(jpgFilePath);
+        } catch (IOException e) {
+            promise.reject("CONVERSION_ERROR", e.getMessage());
+        }
+    }
+
+    private int getOrientation(String filePath) {
+        try {
+            ExifInterface exifInterface = new ExifInterface(filePath);
+            int orientation = exifInterface.getAttributeInt(ExifInterface.TAG_ORIENTATION, ExifInterface.ORIENTATION_NORMAL);
+            switch (orientation) {
+                case ExifInterface.ORIENTATION_ROTATE_90:
+                    return 90;
+                case ExifInterface.ORIENTATION_ROTATE_180:
+                    return 180;
+                case ExifInterface.ORIENTATION_ROTATE_270:
+                    return 270;
+                default:
+                    return 0;
+            }
+        } catch (IOException e) {
+            e.printStackTrace();
+            return 0;
+        }
+    }
+}

--- a/android/app/src/main/java/lab/childmindinstitute/data/image_conversion/ImageConversionPackage.java
+++ b/android/app/src/main/java/lab/childmindinstitute/data/image_conversion/ImageConversionPackage.java
@@ -1,0 +1,26 @@
+package lab.childmindinstitute.data.image_conversion;
+
+import com.facebook.react.ReactPackage;
+import com.facebook.react.bridge.NativeModule;
+import com.facebook.react.bridge.ReactApplicationContext;
+import com.facebook.react.uimanager.ViewManager;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+public class ImageConversionPackage implements ReactPackage {
+    @Override
+    public List<ViewManager> createViewManagers(ReactApplicationContext reactContext) {
+        return Collections.emptyList();
+    }
+
+    @Override
+    public List<NativeModule> createNativeModules(ReactApplicationContext reactContext) {
+        List<NativeModule> modules = new ArrayList<>();
+
+        modules.add(new ImageConversionModule(reactContext));
+
+        return modules;
+    }
+}

--- a/src/shared/lib/constants/index.ts
+++ b/src/shared/lib/constants/index.ts
@@ -58,7 +58,7 @@ export const GALLERY_IOS_PERMISSIONS = PERMISSIONS.IOS.PHOTO_LIBRARY;
 
 export const GALLERY_PHOTO_OPTIONS: ImageLibraryOptions = {
   mediaType: 'photo',
-  quality: 0.8,
+  quality: 1,
   maxWidth: 800,
   maxHeight: 800,
   selectionLimit: 1,

--- a/src/shared/lib/utils/imageConverter.ts
+++ b/src/shared/lib/utils/imageConverter.ts
@@ -1,0 +1,37 @@
+import { NativeModules } from 'react-native';
+
+import { FileSystem } from 'react-native-file-access';
+import { Asset } from 'react-native-image-picker';
+
+import { IS_IOS } from '../constants';
+import { Logger } from '../services';
+
+export const ImageConverter = {
+  async convertHeicToJpg(heicImage: Asset): Promise<Asset> {
+    if (IS_IOS) {
+      Logger.info(
+        '[ImageConverter] Unexpected attempt to convert HEIC image on iOS',
+      );
+      return Promise.resolve(heicImage);
+    }
+
+    const pathPrefix = 'file://';
+    const filePath = heicImage.uri!.replace(pathPrefix, '');
+
+    const convertedFilePath: string =
+      await NativeModules.ImageConversionModule.convertHeicToJpg(filePath);
+
+    const newFileUri = pathPrefix + convertedFilePath;
+    const fileStat = await FileSystem.stat(newFileUri);
+
+    const jpegImage: Asset = {
+      ...heicImage,
+      uri: newFileUri,
+      fileName: fileStat.filename,
+      fileSize: fileStat.size,
+      type: 'image/jpg',
+    };
+
+    return jpegImage;
+  },
+};

--- a/src/shared/lib/utils/index.ts
+++ b/src/shared/lib/utils/index.ts
@@ -7,3 +7,5 @@ export * from './networkHelpers';
 export * from './observable';
 export * from './file';
 export * from './calculator';
+export * from './calculator';
+export * from './imageConverter';


### PR DESCRIPTION
### 📝 Description

<!-- Contributions are welcome! If there is a corresponding      -->
<!-- JIRA ticket, link to it by replacing `#` with ticket number -->

🔗 [Jira Ticket M2-5489](https://mindlogger.atlassian.net/browse/M2-5489)

This PR changes:

- the way the app handles images added from library on some Android 13 devices

This PR adds:
- a native Android module that is capable of converting HEIC images into JPG ones.

### ✏️ Notes
[react-native-image-picker](https://github.com/react-native-image-picker/react-native-image-picker) does this conversion under the hood but it works on iOS devices only. Modern Android devices on Android 13, such as Samsung A52 can take photos and store them in HEIC format. react-native-image-picker does not cover this case (yet) and has not been updated since Dec 4, 2023 at the time of writing.
Writing a converter on the backend / DevOps side is possible but it seems too asynchronous (the conversion would have taken place on S3) and unreliable in terms of error handling, so it would be better to write a simple converter on the mobile side to avoid Data Loss issues by any means.