### PR TITLE
M2-5363,M2-5364,M2-5365: [Mobile] Unit tests for AlertsExtractor for not stacked items

### DIFF
--- a/src/features/pass-survey/model/AlertsExtractor.ts
+++ b/src/features/pass-survey/model/AlertsExtractor.ts
@@ -20,7 +20,7 @@ import {
   StackedSliderResponse,
 } from '../lib';
 
-class AlertsExtractor {
+export class AlertsExtractor {
   private logger: ILogger;
 
   constructor(logger: ILogger) {

--- a/src/features/pass-survey/model/tests/AlertsExtractor.extractFromCheckbox.test.ts
+++ b/src/features/pass-survey/model/tests/AlertsExtractor.extractFromCheckbox.test.ts
@@ -40,11 +40,11 @@ describe('AlertsExtractor: test extractFromRadio', () => {
 
     const expected: AnswerAlerts = [
       {
-        activityItemId: checkboxesItem.id!,
+        activityItemId: 'mock-checkbox-id',
         message: 'mock-alert-1',
       },
       {
-        activityItemId: checkboxesItem.id!,
+        activityItemId: 'mock-checkbox-id',
         message: 'mock-alert-2',
       },
     ];
@@ -68,7 +68,7 @@ describe('AlertsExtractor: test extractFromRadio', () => {
 
     const expected: AnswerAlerts = [
       {
-        activityItemId: checkboxesItem.id!,
+        activityItemId: 'mock-checkbox-id',
         message: 'mock-alert-1',
       },
     ];

--- a/src/features/pass-survey/model/tests/AlertsExtractor.extractFromCheckbox.test.ts
+++ b/src/features/pass-survey/model/tests/AlertsExtractor.extractFromCheckbox.test.ts
@@ -13,7 +13,7 @@ jest.mock('@app/shared/lib/constants', () => ({
   STORE_ENCRYPTION_KEY: '12345',
 }));
 
-describe('AlertsExtractor: test extractFromRadio', () => {
+describe('AlertsExtractor: test extractFromCheckbox', () => {
   let extractor: AlertsExtractor;
 
   beforeEach(() => {

--- a/src/features/pass-survey/model/tests/AlertsExtractor.extractFromCheckbox.test.ts
+++ b/src/features/pass-survey/model/tests/AlertsExtractor.extractFromCheckbox.test.ts
@@ -1,0 +1,111 @@
+import { ILogger } from '@app/shared/lib';
+import { Item } from '@app/shared/ui';
+
+import {
+  fillOptionsForCheckboxes,
+  getEmptyCheckboxesItem,
+} from './testHelpers';
+import { AnswerAlerts } from '../../lib';
+import { AlertsExtractor } from '../AlertsExtractor';
+
+jest.mock('@app/shared/lib/constants', () => ({
+  ...jest.requireActual('@app/shared/lib/constants'),
+  STORE_ENCRYPTION_KEY: '12345',
+}));
+
+describe('AlertsExtractor: test extractFromRadio', () => {
+  let extractor: AlertsExtractor;
+
+  beforeEach(() => {
+    extractor = new AlertsExtractor({
+      log: jest.fn(),
+      warn: jest.fn(),
+      error: jest.fn(),
+      info: jest.fn(),
+    } as unknown as ILogger);
+  });
+
+  it('Should return two alerts from the selected items when alerts are set in both', () => {
+    const checkboxesItem = getEmptyCheckboxesItem('item-checkboxes');
+    fillOptionsForCheckboxes(checkboxesItem, 0);
+
+    const checkboxesAnswer: Item[] = [
+      checkboxesItem.payload.options[1],
+      checkboxesItem.payload.options[2],
+    ];
+
+    const result: AnswerAlerts = extractor.extractFromCheckbox(checkboxesItem, {
+      answer: checkboxesAnswer,
+    });
+
+    const expected: AnswerAlerts = [
+      {
+        activityItemId: checkboxesItem.id!,
+        message: 'mock-alert-1',
+      },
+      {
+        activityItemId: checkboxesItem.id!,
+        message: 'mock-alert-2',
+      },
+    ];
+
+    expect(result).toEqual(expected);
+  });
+
+  it('Should return a single alert from the selected items when alert is set in one of two', () => {
+    const checkboxesItem = getEmptyCheckboxesItem('item-checkboxes');
+    fillOptionsForCheckboxes(checkboxesItem, 0);
+
+    const checkboxesAnswer: Item[] = [
+      checkboxesItem.payload.options[1],
+      checkboxesItem.payload.options[2],
+    ];
+    checkboxesItem.payload.options[2].alert = null;
+
+    const result: AnswerAlerts = extractor.extractFromCheckbox(checkboxesItem, {
+      answer: checkboxesAnswer,
+    });
+
+    const expected: AnswerAlerts = [
+      {
+        activityItemId: checkboxesItem.id!,
+        message: 'mock-alert-1',
+      },
+    ];
+
+    expect(result).toEqual(expected);
+  });
+
+  it('Should return empty array from the selected items when alerts are not set in both', () => {
+    const checkboxesItem = getEmptyCheckboxesItem('item-checkboxes');
+    fillOptionsForCheckboxes(checkboxesItem, 0, false);
+
+    const checkboxesAnswer: Item[] = [
+      checkboxesItem.payload.options[1],
+      checkboxesItem.payload.options[2],
+    ];
+
+    const result: AnswerAlerts = extractor.extractFromCheckbox(checkboxesItem, {
+      answer: checkboxesAnswer,
+    });
+
+    const expected: AnswerAlerts = [];
+
+    expect(result).toEqual(expected);
+  });
+
+  it('Should return empty array when nothing selected', () => {
+    const checkboxesItem = getEmptyCheckboxesItem('item-checkboxes');
+    fillOptionsForCheckboxes(checkboxesItem, 0);
+
+    const checkboxesAnswer: Item[] = [];
+
+    const result: AnswerAlerts = extractor.extractFromCheckbox(checkboxesItem, {
+      answer: checkboxesAnswer,
+    });
+
+    const expected: AnswerAlerts = [];
+
+    expect(result).toEqual(expected);
+  });
+});

--- a/src/features/pass-survey/model/tests/AlertsExtractor.extractFromRadio.test.ts
+++ b/src/features/pass-survey/model/tests/AlertsExtractor.extractFromRadio.test.ts
@@ -1,0 +1,58 @@
+import { ILogger } from '@app/shared/lib';
+
+import { fillOptionsForRadio, getEmptyRadioItem } from './testHelpers';
+import { AnswerAlerts, RadioResponse } from '../../lib';
+import { AlertsExtractor } from '../AlertsExtractor';
+
+jest.mock('@app/shared/lib/constants', () => ({
+  ...jest.requireActual('@app/shared/lib/constants'),
+  STORE_ENCRYPTION_KEY: '12345',
+}));
+
+describe('AlertsExtractor: test extractFromRadio', () => {
+  let extractor: AlertsExtractor;
+
+  beforeEach(() => {
+    extractor = new AlertsExtractor({
+      log: jest.fn(),
+      warn: jest.fn(),
+      error: jest.fn(),
+      info: jest.fn(),
+    } as unknown as ILogger);
+  });
+
+  it('Should return alert from the selected item when alert is set', () => {
+    const radiosItem = getEmptyRadioItem('item-radio');
+    fillOptionsForRadio(radiosItem, 0);
+
+    const radioAnswer: RadioResponse = radiosItem.payload.options[2];
+
+    const result: AnswerAlerts = extractor.extractFromRadio(radiosItem, {
+      answer: radioAnswer,
+    });
+
+    const expected: AnswerAlerts = [
+      {
+        activityItemId: radiosItem.id!,
+        message: 'mock-alert-2',
+      },
+    ];
+
+    expect(result).toEqual(expected);
+  });
+
+  it('Should return empty array when alert is not set', () => {
+    const radiosItem = getEmptyRadioItem('item-radio');
+    fillOptionsForRadio(radiosItem, 1, false);
+
+    const radioAnswer: RadioResponse = radiosItem.payload.options[2];
+
+    const result: AnswerAlerts = extractor.extractFromRadio(radiosItem, {
+      answer: radioAnswer,
+    });
+
+    const expected: AnswerAlerts = [];
+
+    expect(result).toEqual(expected);
+  });
+});

--- a/src/features/pass-survey/model/tests/AlertsExtractor.extractFromRadio.test.ts
+++ b/src/features/pass-survey/model/tests/AlertsExtractor.extractFromRadio.test.ts
@@ -33,7 +33,7 @@ describe('AlertsExtractor: test extractFromRadio', () => {
 
     const expected: AnswerAlerts = [
       {
-        activityItemId: radiosItem.id!,
+        activityItemId: 'mock-radio-id',
         message: 'mock-alert-2',
       },
     ];

--- a/src/features/pass-survey/model/tests/AlertsExtractor.extractFromSlider.test.ts
+++ b/src/features/pass-survey/model/tests/AlertsExtractor.extractFromSlider.test.ts
@@ -1,0 +1,156 @@
+import { ILogger } from '@app/shared/lib';
+
+import { fillAlertsForSlider, getEmptySliderItem } from './testHelpers';
+import { AnswerAlerts, SliderResponse } from '../../lib';
+import { AlertsExtractor } from '../AlertsExtractor';
+
+jest.mock('@app/shared/lib/constants', () => ({
+  ...jest.requireActual('@app/shared/lib/constants'),
+  STORE_ENCRYPTION_KEY: '12345',
+}));
+
+describe('AlertsExtractor: test extractFromRadio', () => {
+  let extractor: AlertsExtractor;
+
+  beforeEach(() => {
+    extractor = new AlertsExtractor({
+      log: jest.fn(),
+      warn: jest.fn(),
+      error: jest.fn(),
+      info: jest.fn(),
+    } as unknown as ILogger);
+  });
+
+  it('Should return alert when slider value is equal to min-value', () => {
+    const sliderItem = getEmptySliderItem('item-slider');
+
+    fillAlertsForSlider(sliderItem);
+
+    const sliderAnswer: SliderResponse = 2;
+
+    const result: AnswerAlerts = extractor.extractFromSlider(sliderItem, {
+      answer: sliderAnswer,
+    });
+
+    const expected: AnswerAlerts = [
+      {
+        activityItemId: 'mock-slider-id',
+        message: 'alert-2',
+      },
+    ];
+
+    expect(result).toEqual(expected);
+  });
+
+  it('Should return alert when slider value is equal to max-value', () => {
+    const sliderItem = getEmptySliderItem('item-slider');
+
+    fillAlertsForSlider(sliderItem);
+
+    const sliderAnswer: SliderResponse = 9;
+
+    const result: AnswerAlerts = extractor.extractFromSlider(sliderItem, {
+      answer: sliderAnswer,
+    });
+
+    const expected: AnswerAlerts = [
+      {
+        activityItemId: 'mock-slider-id',
+        message: 'alert-9',
+      },
+    ];
+
+    expect(result).toEqual(expected);
+  });
+
+  it('Should return alert when slider value is equal to any value between min-max', () => {
+    const sliderItem = getEmptySliderItem('item-slider');
+
+    fillAlertsForSlider(sliderItem);
+
+    const sliderAnswer: SliderResponse = 3;
+
+    const result: AnswerAlerts = extractor.extractFromSlider(sliderItem, {
+      answer: sliderAnswer,
+    });
+
+    const expected: AnswerAlerts = [
+      {
+        activityItemId: 'mock-slider-id',
+        message: 'alert-3',
+      },
+    ];
+
+    expect(result).toEqual(expected);
+  });
+
+  it('Should return empty array when slider value is equal to any between min-max and alert is not set for that value', () => {
+    const sliderItem = getEmptySliderItem('item-slider');
+
+    fillAlertsForSlider(sliderItem);
+
+    const sliderAnswer: SliderResponse = 4;
+
+    const result: AnswerAlerts = extractor.extractFromSlider(sliderItem, {
+      answer: sliderAnswer,
+    });
+
+    const expected: AnswerAlerts = [];
+
+    expect(result).toEqual(expected);
+  });
+
+  it('Should return empty array when slider value is less than min-value', () => {
+    const sliderItem = getEmptySliderItem('item-slider');
+
+    fillAlertsForSlider(sliderItem);
+
+    const sliderAnswer: SliderResponse = 1;
+
+    const result: AnswerAlerts = extractor.extractFromSlider(sliderItem, {
+      answer: sliderAnswer,
+    });
+
+    const expected: AnswerAlerts = [];
+
+    expect(result).toEqual(expected);
+  });
+
+  it('Should return empty array when slider value is more than max-value', () => {
+    const sliderItem = getEmptySliderItem('item-slider');
+
+    fillAlertsForSlider(sliderItem);
+
+    const sliderAnswer: SliderResponse = 10;
+
+    const result: AnswerAlerts = extractor.extractFromSlider(sliderItem, {
+      answer: sliderAnswer,
+    });
+
+    const expected: AnswerAlerts = [];
+
+    expect(result).toEqual(expected);
+  });
+
+  it('Should return alert when slider is continuous', () => {
+    const sliderItem = getEmptySliderItem('item-slider');
+    sliderItem.payload.isContinuousSlider = true;
+
+    fillAlertsForSlider(sliderItem);
+
+    const sliderAnswer: SliderResponse = 7.5;
+
+    const result: AnswerAlerts = extractor.extractFromSlider(sliderItem, {
+      answer: sliderAnswer,
+    });
+
+    const expected: AnswerAlerts = [
+      {
+        activityItemId: 'mock-slider-id',
+        message: 'alert-7-8',
+      },
+    ];
+
+    expect(result).toEqual(expected);
+  });
+});

--- a/src/features/pass-survey/model/tests/AlertsExtractor.extractFromSlider.test.ts
+++ b/src/features/pass-survey/model/tests/AlertsExtractor.extractFromSlider.test.ts
@@ -9,7 +9,7 @@ jest.mock('@app/shared/lib/constants', () => ({
   STORE_ENCRYPTION_KEY: '12345',
 }));
 
-describe('AlertsExtractor: test extractFromRadio', () => {
+describe('AlertsExtractor: test extractFromSlider', () => {
   let extractor: AlertsExtractor;
 
   beforeEach(() => {

--- a/src/features/pass-survey/model/tests/ScoresCalculator.collectMaxScores.test.ts
+++ b/src/features/pass-survey/model/tests/ScoresCalculator.collectMaxScores.test.ts
@@ -1,44 +1,11 @@
 import {
-  AudioPipelineItem,
-  CheckboxPipelineItem,
-  PipelineItem,
-  RadioPipelineItem,
-  SliderPipelineItem,
-} from '../../lib';
+  fillOptionsForCheckboxes,
+  fillOptionsForRadio,
+  getEmptyCheckboxesItem,
+  getEmptyRadioItem,
+} from './testHelpers';
+import { AudioPipelineItem, PipelineItem, SliderPipelineItem } from '../../lib';
 import { IScoresCalculator, ScoresCalculator } from '../ScoresCalculator';
-
-const getEmptyCheckboxesItem = (name: string): CheckboxPipelineItem => {
-  const result: CheckboxPipelineItem = {
-    name,
-    timer: null,
-    payload: {
-      addTooltip: false,
-      randomizeOptions: false,
-      setAlerts: false,
-      setPalette: false,
-      options: [],
-    },
-    type: 'Checkbox',
-  };
-  return result;
-};
-
-const fillOptionsForCheckboxes = (item: CheckboxPipelineItem, from = 1) => {
-  for (let i = from; i <= 5; i++) {
-    item.payload.options.push({
-      alert: null,
-      color: null,
-      id: 'mock-id-' + i,
-      image: null,
-      isHidden: false,
-      text: 'mock-text-' + i,
-      tooltip: null,
-      score: i * 10,
-      value: i,
-      isNoneOption: false,
-    });
-  }
-};
 
 const getEmptyAudioItem = (name: string): AudioPipelineItem => {
   const result: AudioPipelineItem = {
@@ -48,39 +15,6 @@ const getEmptyAudioItem = (name: string): AudioPipelineItem => {
     type: 'Audio',
   };
   return result;
-};
-
-const getEmptyRadioItem = (name: string): RadioPipelineItem => {
-  const result: RadioPipelineItem = {
-    name,
-    timer: null,
-    payload: {
-      addTooltip: false,
-      randomizeOptions: false,
-      setAlerts: false,
-      setPalette: false,
-      options: [],
-      autoAdvance: false,
-    },
-    type: 'Radio',
-  };
-  return result;
-};
-
-const fillOptionsForRadio = (item: RadioPipelineItem, from = 1) => {
-  for (let i = from; i <= 5; i++) {
-    item.payload.options.push({
-      alert: null,
-      color: null,
-      id: 'mock-id-' + i,
-      image: null,
-      isHidden: false,
-      text: 'mock-text-' + i,
-      tooltip: null,
-      score: i * 10,
-      value: i,
-    });
-  }
 };
 
 const getEmptySliderItem = (name: string): SliderPipelineItem => {

--- a/src/features/pass-survey/model/tests/ScoresCalculator.collectMaxScores.test.ts
+++ b/src/features/pass-survey/model/tests/ScoresCalculator.collectMaxScores.test.ts
@@ -1,49 +1,14 @@
 import {
   fillOptionsForCheckboxes,
   fillOptionsForRadio,
+  fillScoresForSlider,
+  getEmptyAudioItem,
   getEmptyCheckboxesItem,
   getEmptyRadioItem,
+  getEmptySliderItem,
 } from './testHelpers';
-import { AudioPipelineItem, PipelineItem, SliderPipelineItem } from '../../lib';
+import { PipelineItem } from '../../lib';
 import { IScoresCalculator, ScoresCalculator } from '../ScoresCalculator';
-
-const getEmptyAudioItem = (name: string): AudioPipelineItem => {
-  const result: AudioPipelineItem = {
-    name,
-    timer: null,
-    payload: {} as any,
-    type: 'Audio',
-  };
-  return result;
-};
-
-const getEmptySliderItem = (name: string): SliderPipelineItem => {
-  const result: SliderPipelineItem = {
-    name,
-    timer: null,
-    payload: {
-      isContinuousSlider: false,
-      leftImageUrl: null,
-      rightImageUrl: null,
-      leftTitle: 'left-title',
-      rightTitle: 'right-title',
-      showTickLabels: false,
-      showTickMarks: false,
-      alerts: null,
-      scores: [],
-      minValue: 2,
-      maxValue: 9,
-    },
-    type: 'Slider',
-  };
-  return result;
-};
-
-const fillOptionsForSlider = (item: SliderPipelineItem, count: number) => {
-  for (let i = 0; i < count; i++) {
-    item.payload.scores.push(i * 10);
-  }
-};
 
 describe('ScoresCalculator: test collectMaxScores', () => {
   let calculator: IScoresCalculator;
@@ -59,7 +24,7 @@ describe('ScoresCalculator: test collectMaxScores', () => {
 
     fillOptionsForCheckboxes(checkboxesItem);
     fillOptionsForRadio(radiosItem);
-    fillOptionsForSlider(sliderItem, 5);
+    fillScoresForSlider(sliderItem, 5);
 
     const selectedItems: string[] = [];
 
@@ -80,7 +45,7 @@ describe('ScoresCalculator: test collectMaxScores', () => {
 
     fillOptionsForCheckboxes(checkboxesItem);
     fillOptionsForRadio(radiosItem);
-    fillOptionsForSlider(sliderItem, 5);
+    fillScoresForSlider(sliderItem, 5);
 
     const selectedItems: string[] = [
       'checkbox-item',
@@ -105,7 +70,7 @@ describe('ScoresCalculator: test collectMaxScores', () => {
 
     fillOptionsForCheckboxes(checkboxesItem);
     fillOptionsForRadio(radiosItem);
-    fillOptionsForSlider(sliderItem, 5);
+    fillScoresForSlider(sliderItem, 5);
 
     const selectedItems: string[] = [
       'checkbox-item',
@@ -130,7 +95,7 @@ describe('ScoresCalculator: test collectMaxScores', () => {
 
     fillOptionsForCheckboxes(checkboxesItem);
     fillOptionsForRadio(radiosItem);
-    fillOptionsForSlider(sliderItem, 5);
+    fillScoresForSlider(sliderItem, 5);
 
     const selectedItems: string[] = [
       'checkbox-item',
@@ -155,7 +120,7 @@ describe('ScoresCalculator: test collectMaxScores', () => {
 
     fillOptionsForCheckboxes(checkboxesItem);
     fillOptionsForRadio(radiosItem);
-    fillOptionsForSlider(sliderItem, 5);
+    fillScoresForSlider(sliderItem, 5);
 
     const selectedItems: string[] = ['checkbox-item', 'radio-item'];
 

--- a/src/features/pass-survey/model/tests/testHelpers.ts
+++ b/src/features/pass-survey/model/tests/testHelpers.ts
@@ -1,0 +1,75 @@
+import { CheckboxPipelineItem, RadioPipelineItem } from '../../lib';
+
+export const getEmptyRadioItem = (name: string): RadioPipelineItem => {
+  const result: RadioPipelineItem = {
+    name,
+    timer: null,
+    payload: {
+      addTooltip: false,
+      randomizeOptions: false,
+      setAlerts: false,
+      setPalette: false,
+      options: [],
+      autoAdvance: false,
+    },
+    type: 'Radio',
+  };
+  return result;
+};
+
+export const fillOptionsForRadio = (
+  item: RadioPipelineItem,
+  from = 1,
+  setAlert = true,
+) => {
+  for (let i = from; i <= 5; i++) {
+    item.payload.options.push({
+      id: `mock-id-${i}`,
+      alert: setAlert ? { message: `mock-alert-${i}` } : null,
+      text: `mock-text-${i}`,
+      score: i * 10,
+      value: i,
+      color: null,
+      image: null,
+      isHidden: false,
+      tooltip: null,
+    });
+  }
+};
+
+export const getEmptyCheckboxesItem = (name: string): CheckboxPipelineItem => {
+  const result: CheckboxPipelineItem = {
+    name,
+    timer: null,
+    payload: {
+      addTooltip: false,
+      randomizeOptions: false,
+      setAlerts: false,
+      setPalette: false,
+      options: [],
+    },
+    type: 'Checkbox',
+  };
+  return result;
+};
+
+export const fillOptionsForCheckboxes = (
+  item: CheckboxPipelineItem,
+  from = 1,
+  setAlert = true,
+) => {
+  for (let i = from; i <= 5; i++) {
+    item.payload.options.push({
+      alert: setAlert ? { message: `mock-alert-${i}` } : null,
+      color: null,
+      id: 'mock-id-' + i,
+      image: null,
+      isHidden: false,
+      text: 'mock-text-' + i,
+      tooltip: null,
+      score: i * 10,
+      value: i,
+      isNoneOption: false,
+    });
+  }
+};

--- a/src/features/pass-survey/model/tests/testHelpers.ts
+++ b/src/features/pass-survey/model/tests/testHelpers.ts
@@ -1,7 +1,13 @@
-import { CheckboxPipelineItem, RadioPipelineItem } from '../../lib';
+import {
+  AudioPipelineItem,
+  CheckboxPipelineItem,
+  RadioPipelineItem,
+  SliderPipelineItem,
+} from '../../lib';
 
 export const getEmptyRadioItem = (name: string): RadioPipelineItem => {
   const result: RadioPipelineItem = {
+    id: 'mock-radio-id',
     name,
     timer: null,
     payload: {
@@ -39,6 +45,7 @@ export const fillOptionsForRadio = (
 
 export const getEmptyCheckboxesItem = (name: string): CheckboxPipelineItem => {
   const result: CheckboxPipelineItem = {
+    id: 'mock-checkbox-id',
     name,
     timer: null,
     payload: {
@@ -72,4 +79,75 @@ export const fillOptionsForCheckboxes = (
       isNoneOption: false,
     });
   }
+};
+
+export const getEmptySliderItem = (name: string): SliderPipelineItem => {
+  const result: SliderPipelineItem = {
+    id: 'mock-slider-id',
+    name,
+    timer: null,
+    payload: {
+      isContinuousSlider: false,
+      leftImageUrl: null,
+      rightImageUrl: null,
+      leftTitle: 'left-title',
+      rightTitle: 'right-title',
+      showTickLabels: false,
+      showTickMarks: false,
+      alerts: [],
+      scores: [],
+      minValue: 2,
+      maxValue: 9,
+    },
+    type: 'Slider',
+  };
+  return result;
+};
+
+export const fillScoresForSlider = (
+  item: SliderPipelineItem,
+  count: number,
+) => {
+  for (let i = 0; i < count; i++) {
+    item.payload.scores.push(i * 10);
+  }
+};
+
+export const fillAlertsForSlider = (item: SliderPipelineItem) => {
+  item.payload.alerts?.push({
+    value: 2,
+    message: 'alert-2',
+    minValue: null,
+    maxValue: null,
+  });
+  item.payload.alerts?.push({
+    value: 3,
+    message: 'alert-3',
+    minValue: null,
+    maxValue: null,
+  });
+  item.payload.alerts?.push({
+    value: 9,
+    message: 'alert-9',
+    minValue: null,
+    maxValue: null,
+  });
+
+  item.payload.alerts?.push({
+    value: NaN,
+    message: 'alert-7-8',
+    minValue: 7,
+    maxValue: 8,
+  });
+};
+
+export const getEmptyAudioItem = (name: string): AudioPipelineItem => {
+  const result: AudioPipelineItem = {
+    id: 'mock-audio-id',
+    name,
+    timer: null,
+    payload: {} as any,
+    type: 'Audio',
+  };
+  return result;
 };


### PR DESCRIPTION
### 📝 Description

🔗 [Jira Ticket M2-5363](https://mindlogger.atlassian.net/browse/M2-5363)
🔗 [Jira Ticket M2-5364](https://mindlogger.atlassian.net/browse/M2-5364)
🔗 [Jira Ticket M2-5365](https://mindlogger.atlassian.net/browse/M2-5365)

This PR adds unit tests that cover AlertsExtractor logic for not stacked item types

This PR changes:
- add three unit test modules
- add testHelpers module that contains create/populate functions
