### PR TITLE
M2-5292 Duplicated timestamps in the drawing-response

### DIFF
--- a/patches/react-native-gesture-handler+2.14.1.patch
+++ b/patches/react-native-gesture-handler+2.14.1.patch
@@ -1,0 +1,52 @@
+diff --git a/node_modules/react-native-gesture-handler/ios/RNGestureHandlerEvents.m b/node_modules/react-native-gesture-handler/ios/RNGestureHandlerEvents.m
+index 6e04f51..c4ae2ae 100644
+--- a/node_modules/react-native-gesture-handler/ios/RNGestureHandlerEvents.m
++++ b/node_modules/react-native-gesture-handler/ios/RNGestureHandlerEvents.m
+@@ -12,6 +12,13 @@ - (instancetype)initWithData:(NSDictionary *)data;
+   return self;
+ }
+ 
+++ (uint64_t)currentTimestampInMilliseconds {
++    NSTimeInterval unixEpochTimeInSeconds = [[NSDate date] timeIntervalSince1970];
++    uint64_t unixEpochTimeInMilliseconds = (uint64_t)(unixEpochTimeInSeconds * 1000);
++
++    return unixEpochTimeInMilliseconds;
++}
++
+ + (RNGestureHandlerEventExtraData *)forPosition:(CGPoint)position withAbsolutePosition:(CGPoint)absolutePosition
+ {
+   return [[RNGestureHandlerEventExtraData alloc] initWithData:@{
+@@ -56,6 +63,8 @@ + (RNGestureHandlerEventExtraData *)forPan:(CGPoint)position
+                               withVelocity:(CGPoint)velocity
+                        withNumberOfTouches:(NSUInteger)numberOfTouches
+ {
++  uint64_t timestamp = [self currentTimestampInMilliseconds];
++
+   return [[RNGestureHandlerEventExtraData alloc] initWithData:@{
+     @"x" : @(position.x),
+     @"y" : @(position.y),
+@@ -65,7 +74,8 @@ + (RNGestureHandlerEventExtraData *)forPan:(CGPoint)position
+     @"translationY" : @(translation.y),
+     @"velocityX" : SAFE_VELOCITY(velocity.x),
+     @"velocityY" : SAFE_VELOCITY(velocity.y),
+-    @"numberOfPointers" : @(numberOfTouches)
++    @"numberOfPointers" : @(numberOfTouches),
++    @"timestamp": @(timestamp)
+   }];
+ }
+ 
+diff --git a/node_modules/react-native-gesture-handler/lib/typescript/handlers/PanGestureHandler.d.ts b/node_modules/react-native-gesture-handler/lib/typescript/handlers/PanGestureHandler.d.ts
+index 4685c5b..7f628e6 100644
+--- a/node_modules/react-native-gesture-handler/lib/typescript/handlers/PanGestureHandler.d.ts
++++ b/node_modules/react-native-gesture-handler/lib/typescript/handlers/PanGestureHandler.d.ts
+@@ -50,6 +50,10 @@ export type PanGestureHandlerEventPayload = {
+      * value is expressed in point units per second.
+      */
+     velocityY: number;
++    /**
++     * The number of milliseconds elapsed since the epoch of the pan gesture in the current moment.
++     */
++    timestamp: number;
+ };
+ interface CommonPanProperties {
+     /**

--- a/src/shared/ui/SketchCanvas/DrawingGesture.ts
+++ b/src/shared/ui/SketchCanvas/DrawingGesture.ts
@@ -104,7 +104,7 @@ function DrawingGesture(
     Gesture.Pan()
       .maxPointers(1)
       .onBegin(event => {
-        runOnJS(onTouchStart)(event, Date.now());
+        runOnJS(onTouchStart)(event, event.timestamp);
       })
       .onTouchesMove((event, manager) => {
         const touchData = event.allTouches[0];
@@ -116,9 +116,10 @@ function DrawingGesture(
           runOnJS(onTouchProgress)(finalPoint, true, time);
 
           manager.end();
-        } else {
-          runOnJS(onTouchProgress)(touchData, false, time);
         }
+      })
+      .onUpdate(event => {
+        runOnJS(onTouchProgress)(event, false, event.timestamp);
       })
       .onFinalize(() => {
         runOnJS(onTouchEnd)();


### PR DESCRIPTION
### 📝 Description

🔗 [Jira Ticket M2-5292](https://mindlogger.atlassian.net/browse/M2-5292)

The issue happens from time to time on iOS devices. It is sometimes hard to reproduce but basically, the problem is that sometimes drawing events may have the same timestamp.

This PR changes:

- the way how timestamps are created for each "move" event of Pan Responder.
- the iOS native module of React Native Gesture Handler (patch).

### 🪤 Peer Testing

Steps to reproduce:

- Add the following code to the onTouchProgress function which is located in DrawingBoard.tsx:
<img width="525" alt="image" src="https://github.com/ChildMindInstitute/mindlogger-app-refactor/assets/20073193/667c83ed-b545-4eb6-b728-0e75d4fedac0">

- Open an activity with the Drawing Item
-  Draw a spiral (or anything else) for 5 minutes (try to not interrupt the line, don’t raise a finger/stylus)
OR draw 90 lines with different speed

    **Expected outcome:** Alert window doesn't pop up.

### ✏️ Notes

After numerous trials and tests, it became evident that, owing to the asynchronous nature of JavaScript and delays in communication between Native modules and JS code, the Date timestamps generated in the app code do not align with the actual moment when the event occurred. Consequently, the decision was made to generate timestamps within the initialization method of the iOS Native Module. This way, we guarantee that a timestamp of an event doesn't intersect with the previous timestamps and is created right after the event coalescing processing is done on the React Native side.

Android implementation is out of scope as the problem has been found on the iOS side only. If there is a problem on Android in the future then a separate PR will be created.