### PR TITLE
M2-5366, M2-5367, M2-5368: unit tests for stacked items

### DIFF
--- a/src/entities/notification/model/factory/NotificationBuilder.ts
+++ b/src/entities/notification/model/factory/NotificationBuilder.ts
@@ -7,7 +7,7 @@ import {
   NotificationTriggerType,
   PeriodicityType,
 } from '@app/abstract/lib';
-import { DatesFromTo, Logger } from '@app/shared/lib';
+import { DatesFromTo, ILogger, Logger } from '@app/shared/lib';
 
 import { NotificationDaysExtractor } from './NotificationDaysExtractor';
 import { NotificationUtility } from './NotificationUtility';
@@ -45,7 +45,9 @@ class NotificationBuilder implements INotificationBuilder {
 
   private appletId: string;
 
-  constructor(inputData: NotificationBuilderInput) {
+  private logger: ILogger;
+
+  constructor(inputData: NotificationBuilderInput, logger: ILogger) {
     this.appletName = inputData.appletName;
     this.eventEntities = inputData.eventEntities;
 
@@ -54,6 +56,7 @@ class NotificationBuilder implements INotificationBuilder {
     this.notificationDaysExtractor = new NotificationDaysExtractor(
       inputData.progress,
       inputData.appletId,
+      logger,
     );
 
     this.reminderCreator = new ReminderCreator(
@@ -68,6 +71,7 @@ class NotificationBuilder implements INotificationBuilder {
     );
 
     this.appletId = inputData.appletId;
+    this.logger = logger;
   }
 
   private processEventDay(
@@ -124,7 +128,7 @@ class NotificationBuilder implements INotificationBuilder {
         );
 
         if (!triggerAt) {
-          Logger.warn(
+          this.logger.warn(
             '[NotificationBuilder.processEventDay]: triggerAt is not defined for random notification',
           );
           continue;
@@ -361,6 +365,7 @@ class NotificationBuilder implements INotificationBuilder {
 
 export const createNotificationBuilder = (
   inputData: NotificationBuilderInput,
+  logger: ILogger = Logger,
 ): INotificationBuilder => {
-  return new NotificationBuilder(inputData);
+  return new NotificationBuilder(inputData, logger);
 };

--- a/src/entities/notification/model/factory/NotificationDaysExtractor.ts
+++ b/src/entities/notification/model/factory/NotificationDaysExtractor.ts
@@ -9,7 +9,7 @@ import {
 } from 'date-fns';
 
 import { PeriodicityType, Progress } from '@app/abstract/lib';
-import { ILogger, Logger } from '@app/shared/lib';
+import { ILogger } from '@app/shared/lib';
 
 import { NotificationUtility } from './NotificationUtility';
 
@@ -18,9 +18,9 @@ export class NotificationDaysExtractor {
 
   private logger: ILogger;
 
-  constructor(progress: Progress, appletId: string) {
+  constructor(progress: Progress, appletId: string, logger: ILogger) {
     this.utility = new NotificationUtility(progress, appletId);
-    this.logger = Logger;
+    this.logger = logger;
   }
 
   private getDayFrom(

--- a/src/entities/notification/model/factory/tests/NotificationBuilder.alwaysAvailable.test.ts
+++ b/src/entities/notification/model/factory/tests/NotificationBuilder.alwaysAvailable.test.ts
@@ -41,6 +41,9 @@ const mockUtilityProps = (builder: INotificationBuilder, now: Date) => {
     });
   //@ts-ignore
   builder.reminderCreator.utility.now = new Date(now);
+
+  //@ts-ignore
+  builder.notificationDaysExtractor.utility.now = new Date(now);
 };
 
 const calculateScheduledAt = (event: ScheduleEvent, now: Date) => {

--- a/src/entities/notification/model/factory/tests/NotificationBuilder.daily.test.ts
+++ b/src/entities/notification/model/factory/tests/NotificationBuilder.daily.test.ts
@@ -42,6 +42,9 @@ const mockUtilityProps = (builder: INotificationBuilder, now: Date) => {
     });
   //@ts-ignore
   builder.reminderCreator.utility.now = new Date(now);
+
+  //@ts-ignore
+  builder.notificationDaysExtractor.utility.now = new Date(now);
 };
 
 const calculateScheduledAt = (event: ScheduleEvent, now: Date) => {

--- a/src/entities/notification/model/factory/tests/NotificationDaysExtractor.test.ts
+++ b/src/entities/notification/model/factory/tests/NotificationDaysExtractor.test.ts
@@ -9,7 +9,7 @@ import {
 
 import { PeriodicityType } from '@app/abstract/lib';
 
-import { addTime } from './testHelpers';
+import { addTime, getLoggerMock } from './testHelpers';
 import { NotificationDaysExtractor } from '../NotificationDaysExtractor';
 import { NumberOfDaysForSchedule } from '../NotificationUtility';
 
@@ -53,6 +53,8 @@ const mockUtilityProps = (extractor: NotificationDaysExtractor, now: Date) => {
   extractor.utility.now = new Date(now);
 };
 
+const loggerMock = getLoggerMock();
+
 describe('NotificationDaysExtractor tests. Extract days for regular notifications.', () => {
   let CurrentDay: Date;
 
@@ -81,7 +83,7 @@ describe('NotificationDaysExtractor tests. Extract days for regular notification
       const scheduledDay = CurrentDay;
       const now = addTime({ hours: 15, minutes: 30 }, CurrentDay);
 
-      const extractor = new NotificationDaysExtractor({}, AppletId);
+      const extractor = new NotificationDaysExtractor({}, AppletId, loggerMock);
       mockUtilityProps(extractor, now);
 
       const result = extractor.extract(
@@ -102,7 +104,7 @@ describe('NotificationDaysExtractor tests. Extract days for regular notification
       const scheduledDay = CurrentDay;
       const now = addTime({ hours: 15, minutes: 30 }, CurrentDay);
 
-      const extractor = new NotificationDaysExtractor({}, AppletId);
+      const extractor = new NotificationDaysExtractor({}, AppletId, loggerMock);
       mockUtilityProps(extractor, now);
 
       const eventDayFrom = subDays(CurrentDay, 2);
@@ -134,7 +136,7 @@ describe('NotificationDaysExtractor tests. Extract days for regular notification
       const eventDayFrom = null;
       const eventDayTo = new Date(CurrentDay);
 
-      const extractor = new NotificationDaysExtractor({}, AppletId);
+      const extractor = new NotificationDaysExtractor({}, AppletId, loggerMock);
       mockUtilityProps(extractor, now);
 
       const result = extractor.extract(
@@ -155,7 +157,7 @@ describe('NotificationDaysExtractor tests. Extract days for regular notification
       const scheduledDay = CurrentDay;
       const now = addTime({ hours: 15, minutes: 30 }, CurrentDay);
 
-      const extractor = new NotificationDaysExtractor({}, AppletId);
+      const extractor = new NotificationDaysExtractor({}, AppletId, loggerMock);
       mockUtilityProps(extractor, now);
 
       const eventDayFrom = subDays(CurrentDay, 5);
@@ -179,7 +181,7 @@ describe('NotificationDaysExtractor tests. Extract days for regular notification
       const scheduledDay = CurrentDay;
       const now = addTime({ hours: 15, minutes: 30 }, CurrentDay);
 
-      const extractor = new NotificationDaysExtractor({}, AppletId);
+      const extractor = new NotificationDaysExtractor({}, AppletId, loggerMock);
       mockUtilityProps(extractor, now);
 
       const eventDayFrom = subDays(CurrentDay, 5);
@@ -201,7 +203,7 @@ describe('NotificationDaysExtractor tests. Extract days for regular notification
       const scheduledDay = CurrentDay;
       const now = addTime({ hours: 15, minutes: 30 }, CurrentDay);
 
-      const extractor = new NotificationDaysExtractor({}, AppletId);
+      const extractor = new NotificationDaysExtractor({}, AppletId, loggerMock);
       mockUtilityProps(extractor, now);
 
       const eventDayFrom = new Date(CurrentDay);
@@ -225,7 +227,7 @@ describe('NotificationDaysExtractor tests. Extract days for regular notification
       const scheduledDay = CurrentDay;
       const now = addTime({ hours: 15, minutes: 30 }, CurrentDay);
 
-      const extractor = new NotificationDaysExtractor({}, AppletId);
+      const extractor = new NotificationDaysExtractor({}, AppletId, loggerMock);
       mockUtilityProps(extractor, now);
 
       const eventDayFrom = new Date(Tomorrow);
@@ -249,7 +251,7 @@ describe('NotificationDaysExtractor tests. Extract days for regular notification
       const scheduledDay = CurrentDay;
       const now = addTime({ hours: 15, minutes: 30 }, CurrentDay);
 
-      const extractor = new NotificationDaysExtractor({}, AppletId);
+      const extractor = new NotificationDaysExtractor({}, AppletId, loggerMock);
       mockUtilityProps(extractor, now);
 
       const eventDayFrom = new Date(Tomorrow);
@@ -277,7 +279,7 @@ describe('NotificationDaysExtractor tests. Extract days for regular notification
       const scheduledDay = CurrentDay;
       const now = addTime({ hours: 15, minutes: 30 }, CurrentDay);
 
-      const extractor = new NotificationDaysExtractor({}, AppletId);
+      const extractor = new NotificationDaysExtractor({}, AppletId, loggerMock);
       mockUtilityProps(extractor, now);
 
       const result = extractor.extract(
@@ -297,7 +299,7 @@ describe('NotificationDaysExtractor tests. Extract days for regular notification
     it("Should return 4 days: from yesterday to the day after tomorrow when event's dateFrom is currentDay - 2 days and dateTo is currentDay + 2 days", () => {
       const scheduledDay = CurrentDay;
 
-      const extractor = new NotificationDaysExtractor({}, AppletId);
+      const extractor = new NotificationDaysExtractor({}, AppletId, loggerMock);
       mockUtilityProps(extractor, CurrentDay);
 
       const eventDayFrom = subDays(CurrentDay, 2);
@@ -329,7 +331,7 @@ describe('NotificationDaysExtractor tests. Extract days for regular notification
       const eventDayFrom = null;
       const eventDayTo = new Date(CurrentDay);
 
-      const extractor = new NotificationDaysExtractor({}, AppletId);
+      const extractor = new NotificationDaysExtractor({}, AppletId, loggerMock);
       mockUtilityProps(extractor, now);
 
       const result = extractor.extract(
@@ -350,7 +352,7 @@ describe('NotificationDaysExtractor tests. Extract days for regular notification
       const scheduledDay = CurrentDay;
       const now = addTime({ hours: 15, minutes: 30 }, CurrentDay);
 
-      const extractor = new NotificationDaysExtractor({}, AppletId);
+      const extractor = new NotificationDaysExtractor({}, AppletId, loggerMock);
       mockUtilityProps(extractor, now);
 
       const eventDayFrom = subDays(CurrentDay, 5);
@@ -374,7 +376,7 @@ describe('NotificationDaysExtractor tests. Extract days for regular notification
       const scheduledDay = CurrentDay;
       const now = addTime({ hours: 15, minutes: 30 }, CurrentDay);
 
-      const extractor = new NotificationDaysExtractor({}, AppletId);
+      const extractor = new NotificationDaysExtractor({}, AppletId, loggerMock);
       mockUtilityProps(extractor, now);
 
       const eventDayFrom = subDays(CurrentDay, 5);
@@ -396,7 +398,7 @@ describe('NotificationDaysExtractor tests. Extract days for regular notification
       const scheduledDay = CurrentDay;
       const now = addTime({ hours: 15, minutes: 30 }, CurrentDay);
 
-      const extractor = new NotificationDaysExtractor({}, AppletId);
+      const extractor = new NotificationDaysExtractor({}, AppletId, loggerMock);
       mockUtilityProps(extractor, now);
 
       const eventDayFrom = new Date(CurrentDay);
@@ -420,7 +422,7 @@ describe('NotificationDaysExtractor tests. Extract days for regular notification
       const scheduledDay = CurrentDay;
       const now = addTime({ hours: 15, minutes: 30 }, CurrentDay);
 
-      const extractor = new NotificationDaysExtractor({}, AppletId);
+      const extractor = new NotificationDaysExtractor({}, AppletId, loggerMock);
       mockUtilityProps(extractor, now);
 
       const eventDayFrom = new Date(Tomorrow);
@@ -444,7 +446,7 @@ describe('NotificationDaysExtractor tests. Extract days for regular notification
       const scheduledDay = CurrentDay;
       const now = addTime({ hours: 15, minutes: 30 }, CurrentDay);
 
-      const extractor = new NotificationDaysExtractor({}, AppletId);
+      const extractor = new NotificationDaysExtractor({}, AppletId, loggerMock);
       mockUtilityProps(extractor, now);
 
       const eventDayFrom = new Date(Tomorrow);
@@ -472,7 +474,7 @@ describe('NotificationDaysExtractor tests. Extract days for regular notification
       const scheduledDay = subDays(CurrentDay, 3);
       const now = addTime({ hours: 15, minutes: 30 }, CurrentDay);
 
-      const extractor = new NotificationDaysExtractor({}, AppletId);
+      const extractor = new NotificationDaysExtractor({}, AppletId, loggerMock);
       mockUtilityProps(extractor, now);
 
       const result = extractor.extract(
@@ -497,7 +499,7 @@ describe('NotificationDaysExtractor tests. Extract days for regular notification
       const scheduledDay = subDays(CurrentDay, 3);
       const now = addTime({ hours: 15, minutes: 30 }, CurrentDay);
 
-      const extractor = new NotificationDaysExtractor({}, AppletId);
+      const extractor = new NotificationDaysExtractor({}, AppletId, loggerMock);
       mockUtilityProps(extractor, now);
 
       const eventDayFrom = subDays(CurrentDay, 2);
@@ -521,7 +523,7 @@ describe('NotificationDaysExtractor tests. Extract days for regular notification
       const scheduledDay = subDays(CurrentDay, 3);
       const now = addTime({ hours: 15, minutes: 30 }, CurrentDay);
 
-      const extractor = new NotificationDaysExtractor({}, AppletId);
+      const extractor = new NotificationDaysExtractor({}, AppletId, loggerMock);
       mockUtilityProps(extractor, now);
 
       const eventDayFrom = subDays(CurrentDay, 2);
@@ -545,7 +547,7 @@ describe('NotificationDaysExtractor tests. Extract days for regular notification
       const scheduledDay = subDays(CurrentDay, 3);
       const now = addTime({ hours: 15, minutes: 30 }, CurrentDay);
 
-      const extractor = new NotificationDaysExtractor({}, AppletId);
+      const extractor = new NotificationDaysExtractor({}, AppletId, loggerMock);
       mockUtilityProps(extractor, now);
 
       const eventDayFrom = null;
@@ -569,7 +571,7 @@ describe('NotificationDaysExtractor tests. Extract days for regular notification
       const scheduledDay = subDays(CurrentDay, 3);
       const now = addTime({ hours: 15, minutes: 30 }, CurrentDay);
 
-      const extractor = new NotificationDaysExtractor({}, AppletId);
+      const extractor = new NotificationDaysExtractor({}, AppletId, loggerMock);
       mockUtilityProps(extractor, now);
 
       const eventDayFrom = addDays(CurrentDay, 1);
@@ -595,7 +597,7 @@ describe('NotificationDaysExtractor tests. Extract days for regular notification
       const scheduledDay = CurrentDay;
       const now = addTime({ hours: 15, minutes: 30 }, CurrentDay);
 
-      const extractor = new NotificationDaysExtractor({}, AppletId);
+      const extractor = new NotificationDaysExtractor({}, AppletId, loggerMock);
       mockUtilityProps(extractor, now);
 
       const result = extractor.extract(
@@ -619,7 +621,7 @@ describe('NotificationDaysExtractor tests. Extract days for regular notification
       const scheduledDay = CurrentDay;
       const now = addTime({ hours: 15, minutes: 30 }, CurrentDay);
 
-      const extractor = new NotificationDaysExtractor({}, AppletId);
+      const extractor = new NotificationDaysExtractor({}, AppletId, loggerMock);
       mockUtilityProps(extractor, now);
 
       const eventDayFrom = subDays(CurrentDay, 2);
@@ -646,7 +648,7 @@ describe('NotificationDaysExtractor tests. Extract days for regular notification
       const eventDayFrom = null;
       const eventDayTo = new Date(CurrentDay);
 
-      const extractor = new NotificationDaysExtractor({}, AppletId);
+      const extractor = new NotificationDaysExtractor({}, AppletId, loggerMock);
       mockUtilityProps(extractor, now);
 
       const result = extractor.extract(
@@ -667,7 +669,7 @@ describe('NotificationDaysExtractor tests. Extract days for regular notification
       const scheduledDay = CurrentDay;
       const now = addTime({ hours: 15, minutes: 30 }, CurrentDay);
 
-      const extractor = new NotificationDaysExtractor({}, AppletId);
+      const extractor = new NotificationDaysExtractor({}, AppletId, loggerMock);
       mockUtilityProps(extractor, now);
 
       const eventDayFrom = subDays(CurrentDay, 5);
@@ -689,7 +691,7 @@ describe('NotificationDaysExtractor tests. Extract days for regular notification
       const scheduledDay = CurrentDay;
       const now = addTime({ hours: 15, minutes: 30 }, CurrentDay);
 
-      const extractor = new NotificationDaysExtractor({}, AppletId);
+      const extractor = new NotificationDaysExtractor({}, AppletId, loggerMock);
       mockUtilityProps(extractor, now);
 
       const eventDayFrom = new Date(CurrentDay);
@@ -713,7 +715,7 @@ describe('NotificationDaysExtractor tests. Extract days for regular notification
       const scheduledDay = CurrentDay;
       const now = addTime({ hours: 15, minutes: 30 }, CurrentDay);
 
-      const extractor = new NotificationDaysExtractor({}, AppletId);
+      const extractor = new NotificationDaysExtractor({}, AppletId, loggerMock);
       mockUtilityProps(extractor, now);
 
       const eventDayFrom = new Date(Tomorrow);
@@ -737,7 +739,7 @@ describe('NotificationDaysExtractor tests. Extract days for regular notification
       const scheduledDay = CurrentDay;
       const now = addTime({ hours: 15, minutes: 30 }, CurrentDay);
 
-      const extractor = new NotificationDaysExtractor({}, AppletId);
+      const extractor = new NotificationDaysExtractor({}, AppletId, loggerMock);
       mockUtilityProps(extractor, now);
 
       const eventDayFrom = addDays(CurrentDay, 3);
@@ -762,7 +764,7 @@ describe('NotificationDaysExtractor tests. Extract days for regular notification
       const scheduledDay = CurrentDay;
       const now = addTime({ hours: 15, minutes: 30 }, CurrentDay);
 
-      const extractor = new NotificationDaysExtractor({}, AppletId);
+      const extractor = new NotificationDaysExtractor({}, AppletId, loggerMock);
       mockUtilityProps(extractor, now);
 
       const eventDayFrom = new Date(Tomorrow);
@@ -791,7 +793,7 @@ describe('NotificationDaysExtractor tests. Extract days for regular notification
       const scheduledDay = subDays(CurrentDay, 35);
       const now = addTime({ hours: 15, minutes: 30 }, CurrentDay);
 
-      const extractor = new NotificationDaysExtractor({}, AppletId);
+      const extractor = new NotificationDaysExtractor({}, AppletId, loggerMock);
       mockUtilityProps(extractor, now);
 
       const result = extractor.extract(
@@ -812,7 +814,7 @@ describe('NotificationDaysExtractor tests. Extract days for regular notification
       const scheduledDay = subDays(CurrentDay, 25);
       const now = addTime({ hours: 15, minutes: 30 }, CurrentDay);
 
-      const extractor = new NotificationDaysExtractor({}, AppletId);
+      const extractor = new NotificationDaysExtractor({}, AppletId, loggerMock);
       mockUtilityProps(extractor, now);
 
       const result = extractor.extract(
@@ -833,7 +835,7 @@ describe('NotificationDaysExtractor tests. Extract days for regular notification
       const scheduledDay = CurrentDay;
       const now = addTime({ hours: 15, minutes: 30 }, CurrentDay);
 
-      const extractor = new NotificationDaysExtractor({}, AppletId);
+      const extractor = new NotificationDaysExtractor({}, AppletId, loggerMock);
       mockUtilityProps(extractor, now);
 
       const result = extractor.extract(
@@ -854,7 +856,7 @@ describe('NotificationDaysExtractor tests. Extract days for regular notification
       const scheduledDay = addDays(CurrentDay, 10);
       const now = addTime({ hours: 15, minutes: 30 }, CurrentDay);
 
-      const extractor = new NotificationDaysExtractor({}, AppletId);
+      const extractor = new NotificationDaysExtractor({}, AppletId, loggerMock);
       mockUtilityProps(extractor, now);
 
       const result = extractor.extract(
@@ -875,7 +877,7 @@ describe('NotificationDaysExtractor tests. Extract days for regular notification
       const scheduledDay = addDays(CurrentDay, 20);
       const now = addTime({ hours: 15, minutes: 30 }, CurrentDay);
 
-      const extractor = new NotificationDaysExtractor({}, AppletId);
+      const extractor = new NotificationDaysExtractor({}, AppletId, loggerMock);
       mockUtilityProps(extractor, now);
 
       const result = extractor.extract(
@@ -894,7 +896,7 @@ describe('NotificationDaysExtractor tests. Extract days for regular notification
       const scheduledDay = subDays(CurrentDay, 25);
       const now = addTime({ hours: 15, minutes: 30 }, CurrentDay);
 
-      const extractor = new NotificationDaysExtractor({}, AppletId);
+      const extractor = new NotificationDaysExtractor({}, AppletId, loggerMock);
       mockUtilityProps(extractor, now);
 
       const startDate = subDays(CurrentDay, 15);
@@ -917,7 +919,7 @@ describe('NotificationDaysExtractor tests. Extract days for regular notification
       const scheduledDay = subDays(CurrentDay, 25);
       const now = addTime({ hours: 15, minutes: 30 }, CurrentDay);
 
-      const extractor = new NotificationDaysExtractor({}, AppletId);
+      const extractor = new NotificationDaysExtractor({}, AppletId, loggerMock);
       mockUtilityProps(extractor, now);
 
       const endDate = new Date(CurrentDay);
@@ -962,7 +964,7 @@ describe('NotificationDaysExtractor tests. Extract days for reminder notificatio
       const scheduledDay = CurrentDay;
       const now = addTime({ hours: 15, minutes: 30 }, CurrentDay);
 
-      const extractor = new NotificationDaysExtractor({}, AppletId);
+      const extractor = new NotificationDaysExtractor({}, AppletId, loggerMock);
       mockUtilityProps(extractor, now);
 
       const result = extractor.extractForReminders(
@@ -982,7 +984,7 @@ describe('NotificationDaysExtractor tests. Extract days for reminder notificatio
       const scheduledDay = CurrentDay;
       const now = addTime({ hours: 15, minutes: 30 }, CurrentDay);
 
-      const extractor = new NotificationDaysExtractor({}, AppletId);
+      const extractor = new NotificationDaysExtractor({}, AppletId, loggerMock);
       mockUtilityProps(extractor, now);
 
       const eventDayFrom = subDays(CurrentDay, 2);
@@ -1014,7 +1016,7 @@ describe('NotificationDaysExtractor tests. Extract days for reminder notificatio
       const eventDayFrom = null;
       const eventDayTo = new Date(CurrentDay);
 
-      const extractor = new NotificationDaysExtractor({}, AppletId);
+      const extractor = new NotificationDaysExtractor({}, AppletId, loggerMock);
       mockUtilityProps(extractor, now);
 
       const result = extractor.extractForReminders(
@@ -1034,7 +1036,7 @@ describe('NotificationDaysExtractor tests. Extract days for reminder notificatio
       const scheduledDay = CurrentDay;
       const now = addTime({ hours: 15, minutes: 30 }, CurrentDay);
 
-      const extractor = new NotificationDaysExtractor({}, AppletId);
+      const extractor = new NotificationDaysExtractor({}, AppletId, loggerMock);
       mockUtilityProps(extractor, now);
 
       const eventDayFrom = subDays(CurrentDay, 5);
@@ -1057,7 +1059,7 @@ describe('NotificationDaysExtractor tests. Extract days for reminder notificatio
       const scheduledDay = CurrentDay;
       const now = addTime({ hours: 15, minutes: 30 }, CurrentDay);
 
-      const extractor = new NotificationDaysExtractor({}, AppletId);
+      const extractor = new NotificationDaysExtractor({}, AppletId, loggerMock);
       mockUtilityProps(extractor, now);
 
       const eventDayFrom = new Date(CurrentDay);
@@ -1080,7 +1082,7 @@ describe('NotificationDaysExtractor tests. Extract days for reminder notificatio
       const scheduledDay = CurrentDay;
       const now = addTime({ hours: 15, minutes: 30 }, CurrentDay);
 
-      const extractor = new NotificationDaysExtractor({}, AppletId);
+      const extractor = new NotificationDaysExtractor({}, AppletId, loggerMock);
       mockUtilityProps(extractor, now);
 
       const eventDayFrom = new Date(Tomorrow);
@@ -1103,7 +1105,7 @@ describe('NotificationDaysExtractor tests. Extract days for reminder notificatio
       const scheduledDay = CurrentDay;
       const now = addTime({ hours: 15, minutes: 30 }, CurrentDay);
 
-      const extractor = new NotificationDaysExtractor({}, AppletId);
+      const extractor = new NotificationDaysExtractor({}, AppletId, loggerMock);
       mockUtilityProps(extractor, now);
 
       const eventDayFrom = new Date(Tomorrow);
@@ -1130,7 +1132,7 @@ describe('NotificationDaysExtractor tests. Extract days for reminder notificatio
       const scheduledDay = CurrentDay;
       const now = addTime({ hours: 15, minutes: 30 }, CurrentDay);
 
-      const extractor = new NotificationDaysExtractor({}, AppletId);
+      const extractor = new NotificationDaysExtractor({}, AppletId, loggerMock);
       mockUtilityProps(extractor, now);
 
       const result = extractor.extractForReminders(
@@ -1150,7 +1152,7 @@ describe('NotificationDaysExtractor tests. Extract days for reminder notificatio
       const scheduledDay = CurrentDay;
       const now = addTime({ hours: 15, minutes: 30 }, CurrentDay);
 
-      const extractor = new NotificationDaysExtractor({}, AppletId);
+      const extractor = new NotificationDaysExtractor({}, AppletId, loggerMock);
       mockUtilityProps(extractor, now);
 
       const eventDayFrom = subDays(CurrentDay, 2);
@@ -1182,7 +1184,7 @@ describe('NotificationDaysExtractor tests. Extract days for reminder notificatio
       const eventDayFrom = null;
       const eventDayTo = new Date(CurrentDay);
 
-      const extractor = new NotificationDaysExtractor({}, AppletId);
+      const extractor = new NotificationDaysExtractor({}, AppletId, loggerMock);
       mockUtilityProps(extractor, now);
 
       const result = extractor.extractForReminders(
@@ -1202,7 +1204,7 @@ describe('NotificationDaysExtractor tests. Extract days for reminder notificatio
       const scheduledDay = CurrentDay;
       const now = addTime({ hours: 15, minutes: 30 }, CurrentDay);
 
-      const extractor = new NotificationDaysExtractor({}, AppletId);
+      const extractor = new NotificationDaysExtractor({}, AppletId, loggerMock);
       mockUtilityProps(extractor, now);
 
       const eventDayFrom = subDays(CurrentDay, 5);
@@ -1225,7 +1227,7 @@ describe('NotificationDaysExtractor tests. Extract days for reminder notificatio
       const scheduledDay = CurrentDay;
       const now = addTime({ hours: 15, minutes: 30 }, CurrentDay);
 
-      const extractor = new NotificationDaysExtractor({}, AppletId);
+      const extractor = new NotificationDaysExtractor({}, AppletId, loggerMock);
       mockUtilityProps(extractor, now);
 
       const eventDayFrom = new Date(CurrentDay);
@@ -1248,7 +1250,7 @@ describe('NotificationDaysExtractor tests. Extract days for reminder notificatio
       const scheduledDay = CurrentDay;
       const now = addTime({ hours: 15, minutes: 30 }, CurrentDay);
 
-      const extractor = new NotificationDaysExtractor({}, AppletId);
+      const extractor = new NotificationDaysExtractor({}, AppletId, loggerMock);
       mockUtilityProps(extractor, now);
 
       const eventDayFrom = new Date(Tomorrow);
@@ -1271,7 +1273,7 @@ describe('NotificationDaysExtractor tests. Extract days for reminder notificatio
       const scheduledDay = CurrentDay;
       const now = addTime({ hours: 15, minutes: 30 }, CurrentDay);
 
-      const extractor = new NotificationDaysExtractor({}, AppletId);
+      const extractor = new NotificationDaysExtractor({}, AppletId, loggerMock);
       mockUtilityProps(extractor, now);
 
       const eventDayFrom = new Date(Tomorrow);
@@ -1298,7 +1300,7 @@ describe('NotificationDaysExtractor tests. Extract days for reminder notificatio
       const scheduledDay = subDays(CurrentDay, 3);
       const now = addTime({ hours: 15, minutes: 30 }, CurrentDay);
 
-      const extractor = new NotificationDaysExtractor({}, AppletId);
+      const extractor = new NotificationDaysExtractor({}, AppletId, loggerMock);
       mockUtilityProps(extractor, now);
 
       const result = extractor.extractForReminders(
@@ -1326,7 +1328,7 @@ describe('NotificationDaysExtractor tests. Extract days for reminder notificatio
       const scheduledDay = subDays(CurrentDay, 3);
       const now = addTime({ hours: 15, minutes: 30 }, CurrentDay);
 
-      const extractor = new NotificationDaysExtractor({}, AppletId);
+      const extractor = new NotificationDaysExtractor({}, AppletId, loggerMock);
       mockUtilityProps(extractor, now);
 
       const eventDayFrom = subDays(CurrentDay, 2);
@@ -1349,7 +1351,7 @@ describe('NotificationDaysExtractor tests. Extract days for reminder notificatio
       const scheduledDay = subDays(CurrentDay, 3);
       const now = addTime({ hours: 15, minutes: 30 }, CurrentDay);
 
-      const extractor = new NotificationDaysExtractor({}, AppletId);
+      const extractor = new NotificationDaysExtractor({}, AppletId, loggerMock);
       mockUtilityProps(extractor, now);
 
       const eventDayFrom = subDays(CurrentDay, 2);
@@ -1372,7 +1374,7 @@ describe('NotificationDaysExtractor tests. Extract days for reminder notificatio
       const scheduledDay = subDays(CurrentDay, 3);
       const now = addTime({ hours: 15, minutes: 30 }, CurrentDay);
 
-      const extractor = new NotificationDaysExtractor({}, AppletId);
+      const extractor = new NotificationDaysExtractor({}, AppletId, loggerMock);
       mockUtilityProps(extractor, now);
 
       const eventDayFrom = null;
@@ -1402,7 +1404,7 @@ describe('NotificationDaysExtractor tests. Extract days for reminder notificatio
       const scheduledDay = subDays(CurrentDay, 3);
       const now = addTime({ hours: 15, minutes: 30 }, CurrentDay);
 
-      const extractor = new NotificationDaysExtractor({}, AppletId);
+      const extractor = new NotificationDaysExtractor({}, AppletId, loggerMock);
       mockUtilityProps(extractor, now);
 
       const eventDayFrom = addDays(CurrentDay, 1);
@@ -1427,7 +1429,7 @@ describe('NotificationDaysExtractor tests. Extract days for reminder notificatio
       const scheduledDay = subDays(CurrentDay, 35);
       const now = addTime({ hours: 15, minutes: 30 }, CurrentDay);
 
-      const extractor = new NotificationDaysExtractor({}, AppletId);
+      const extractor = new NotificationDaysExtractor({}, AppletId, loggerMock);
       mockUtilityProps(extractor, now);
 
       const result = extractor.extractForReminders(
@@ -1452,7 +1454,7 @@ describe('NotificationDaysExtractor tests. Extract days for reminder notificatio
       const scheduledDay = subDays(CurrentDay, 25);
       const now = addTime({ hours: 15, minutes: 30 }, CurrentDay);
 
-      const extractor = new NotificationDaysExtractor({}, AppletId);
+      const extractor = new NotificationDaysExtractor({}, AppletId, loggerMock);
       mockUtilityProps(extractor, now);
 
       const result = extractor.extractForReminders(
@@ -1477,7 +1479,7 @@ describe('NotificationDaysExtractor tests. Extract days for reminder notificatio
       const scheduledDay = CurrentDay;
       const now = addTime({ hours: 15, minutes: 30 }, CurrentDay);
 
-      const extractor = new NotificationDaysExtractor({}, AppletId);
+      const extractor = new NotificationDaysExtractor({}, AppletId, loggerMock);
       mockUtilityProps(extractor, now);
 
       const result = extractor.extractForReminders(
@@ -1501,7 +1503,7 @@ describe('NotificationDaysExtractor tests. Extract days for reminder notificatio
       const scheduledDay = addDays(CurrentDay, 10);
       const now = addTime({ hours: 15, minutes: 30 }, CurrentDay);
 
-      const extractor = new NotificationDaysExtractor({}, AppletId);
+      const extractor = new NotificationDaysExtractor({}, AppletId, loggerMock);
       mockUtilityProps(extractor, now);
 
       const result = extractor.extractForReminders(
@@ -1525,7 +1527,7 @@ describe('NotificationDaysExtractor tests. Extract days for reminder notificatio
       const scheduledDay = addDays(CurrentDay, 20);
       const now = addTime({ hours: 15, minutes: 30 }, CurrentDay);
 
-      const extractor = new NotificationDaysExtractor({}, AppletId);
+      const extractor = new NotificationDaysExtractor({}, AppletId, loggerMock);
       mockUtilityProps(extractor, now);
 
       const result = extractor.extractForReminders(
@@ -1545,7 +1547,7 @@ describe('NotificationDaysExtractor tests. Extract days for reminder notificatio
       const scheduledDay = subDays(CurrentDay, 25);
       const now = addTime({ hours: 15, minutes: 30 }, CurrentDay);
 
-      const extractor = new NotificationDaysExtractor({}, AppletId);
+      const extractor = new NotificationDaysExtractor({}, AppletId, loggerMock);
       mockUtilityProps(extractor, now);
 
       const startDate = subDays(CurrentDay, 15);
@@ -1567,7 +1569,7 @@ describe('NotificationDaysExtractor tests. Extract days for reminder notificatio
       const scheduledDay = subDays(CurrentDay, 25);
       const now = addTime({ hours: 15, minutes: 30 }, CurrentDay);
 
-      const extractor = new NotificationDaysExtractor({}, AppletId);
+      const extractor = new NotificationDaysExtractor({}, AppletId, loggerMock);
       mockUtilityProps(extractor, now);
 
       const endDate = new Date(CurrentDay);

--- a/src/entities/notification/model/factory/tests/testHelpers.ts
+++ b/src/entities/notification/model/factory/tests/testHelpers.ts
@@ -12,7 +12,7 @@ import {
   NotificationType,
   ScheduleEvent,
 } from '@app/entities/notification/lib';
-import { HourMinute } from '@app/shared/lib';
+import { HourMinute, ILogger } from '@app/shared/lib';
 
 import { createNotificationBuilder } from '../NotificationBuilder';
 
@@ -100,4 +100,13 @@ export const addTime = (time: HourMinute, date: Date): Date => {
   result.setHours(time.hours);
   result.setMinutes(time.minutes);
   return result;
+};
+
+export const getLoggerMock = (): ILogger => {
+  return {
+    log: jest.fn(),
+    warn: jest.fn(),
+    error: jest.fn(),
+    info: jest.fn(),
+  } as unknown as ILogger;
 };

--- a/src/features/pass-survey/model/AlertsExtractor.ts
+++ b/src/features/pass-survey/model/AlertsExtractor.ts
@@ -152,13 +152,12 @@ export class AlertsExtractor {
     const alerts: AnswerAlerts = [];
 
     stackedCheckboxItem.payload.dataMatrix.forEach((row, rowIndex) => {
-      if (stackedCheckboxAnswer[rowIndex]?.length) {
+      const columnAnswers = stackedCheckboxAnswer[rowIndex];
+
+      if (columnAnswers?.length) {
         row.options.forEach(option => {
-          stackedCheckboxAnswer[rowIndex].forEach(itemAnswer => {
-            if (
-              stackedCheckboxAnswer[rowIndex] &&
-              itemAnswer.id === option.optionId!
-            ) {
+          columnAnswers.forEach(cellAnswer => {
+            if (cellAnswer.id === option.optionId!) {
               option.alert &&
                 alerts.push({
                   activityItemId: stackedCheckboxItem.id!,

--- a/src/features/pass-survey/model/tests/AlertsExtractor.extractFromStackedCheckbox.test.ts
+++ b/src/features/pass-survey/model/tests/AlertsExtractor.extractFromStackedCheckbox.test.ts
@@ -1,0 +1,101 @@
+import { ILogger } from '@app/shared/lib';
+
+import {
+  getStackedCheckboxItem,
+  getStackedCheckboxResponse,
+} from './testHelpers';
+import { AnswerAlerts, StackedCheckboxResponse } from '../../lib';
+import { AlertsExtractor } from '../AlertsExtractor';
+
+jest.mock('@app/shared/lib/constants', () => ({
+  ...jest.requireActual('@app/shared/lib/constants'),
+  STORE_ENCRYPTION_KEY: '12345',
+}));
+
+describe('AlertsExtractor: test extractFromStackedRadio', () => {
+  let extractor: AlertsExtractor;
+
+  beforeEach(() => {
+    extractor = new AlertsExtractor({
+      log: jest.fn(),
+      warn: jest.fn(),
+      error: jest.fn(),
+      info: jest.fn(),
+    } as unknown as ILogger);
+  });
+
+  it('Should return three alerts from the four selected cells in different rows', () => {
+    const checkboxesItem = getStackedCheckboxItem();
+
+    const checkboxesAnswer: StackedCheckboxResponse =
+      getStackedCheckboxResponse('1-partially-selected');
+
+    const result: AnswerAlerts = extractor.extractFromStackedCheckbox(
+      checkboxesItem,
+      {
+        answer: checkboxesAnswer,
+      },
+    );
+
+    const expected: AnswerAlerts = [
+      { activityItemId: 'item-stacked-checkbox', message: 'mock-alert-r1-o1' },
+      { activityItemId: 'item-stacked-checkbox', message: 'mock-alert-r1-o2' },
+      { activityItemId: 'item-stacked-checkbox', message: 'mock-alert-r2-o2' },
+    ];
+
+    expect(result).toEqual(expected);
+  });
+
+  it('Should return all five alerts from the all six selected cells in different rows', () => {
+    const checkboxesItem = getStackedCheckboxItem();
+
+    const checkboxesAnswer: StackedCheckboxResponse =
+      getStackedCheckboxResponse('2-all-selected');
+
+    const result: AnswerAlerts = extractor.extractFromStackedCheckbox(
+      checkboxesItem,
+      {
+        answer: checkboxesAnswer,
+      },
+    );
+
+    const expected: AnswerAlerts = [
+      { activityItemId: 'item-stacked-checkbox', message: 'mock-alert-r1-o1' },
+      { activityItemId: 'item-stacked-checkbox', message: 'mock-alert-r1-o2' },
+      { activityItemId: 'item-stacked-checkbox', message: 'mock-alert-r1-o3' },
+      { activityItemId: 'item-stacked-checkbox', message: 'mock-alert-r2-o1' },
+      { activityItemId: 'item-stacked-checkbox', message: 'mock-alert-r2-o2' },
+    ];
+
+    expect(result).toEqual(expected);
+  });
+
+  it('Should return empty alerts array when nothing selected', () => {
+    const checkboxesItem = getStackedCheckboxItem();
+
+    const checkboxesAnswer: StackedCheckboxResponse =
+      getStackedCheckboxResponse('3-no-selection');
+
+    const result: AnswerAlerts = extractor.extractFromStackedCheckbox(
+      checkboxesItem,
+      {
+        answer: checkboxesAnswer,
+      },
+    );
+
+    expect(result).toEqual([]);
+  });
+
+  it('Should return empty alerts array when answer sub-object is undefined', () => {
+    const checkboxesItem = getStackedCheckboxItem();
+
+    const result: AnswerAlerts = extractor.extractFromStackedCheckbox(
+      checkboxesItem,
+      {
+        answer: undefined,
+      },
+    );
+
+    expect(result).toEqual([]);
+  });
+});

--- a/src/features/pass-survey/model/tests/AlertsExtractor.extractFromStackedCheckbox.test.ts
+++ b/src/features/pass-survey/model/tests/AlertsExtractor.extractFromStackedCheckbox.test.ts
@@ -12,7 +12,7 @@ jest.mock('@app/shared/lib/constants', () => ({
   STORE_ENCRYPTION_KEY: '12345',
 }));
 
-describe('AlertsExtractor: test extractFromStackedRadio', () => {
+describe('AlertsExtractor: test extractFromStackedCheckbox', () => {
   let extractor: AlertsExtractor;
 
   beforeEach(() => {

--- a/src/features/pass-survey/model/tests/AlertsExtractor.extractFromStackedRadio.test.ts
+++ b/src/features/pass-survey/model/tests/AlertsExtractor.extractFromStackedRadio.test.ts
@@ -21,10 +21,11 @@ describe('AlertsExtractor: test extractFromStackedRadio', () => {
     } as unknown as ILogger);
   });
 
-  it('Should return two alerts from the two selected cells in the different rows', () => {
+  it('Should return two alerts from the two selected cells in different rows', () => {
     const radiosItem = getStackedRadioItem();
 
-    const radioAnswer: StackedRadioResponse = getStackedRadioResponse('1');
+    const radioAnswer: StackedRadioResponse =
+      getStackedRadioResponse('1-no-empty-alerts');
 
     const result: AnswerAlerts = extractor.extractFromStackedRadio(radiosItem, {
       answer: radioAnswer,
@@ -38,10 +39,11 @@ describe('AlertsExtractor: test extractFromStackedRadio', () => {
     expect(result).toEqual(expected);
   });
 
-  it('Should return a single alert from the two selected cells in the different rows', () => {
+  it('Should return a single alert from the two selected cells in different rows', () => {
     const radiosItem = getStackedRadioItem();
 
-    const radioAnswer: StackedRadioResponse = getStackedRadioResponse('2');
+    const radioAnswer: StackedRadioResponse =
+      getStackedRadioResponse('2-is-empty-alert');
 
     const result: AnswerAlerts = extractor.extractFromStackedRadio(radiosItem, {
       answer: radioAnswer,

--- a/src/features/pass-survey/model/tests/AlertsExtractor.extractFromStackedRadio.test.ts
+++ b/src/features/pass-survey/model/tests/AlertsExtractor.extractFromStackedRadio.test.ts
@@ -1,0 +1,56 @@
+import { ILogger } from '@app/shared/lib';
+
+import { getStackedRadioItem, getStackedRadioResponse } from './testHelpers';
+import { AnswerAlerts, StackedRadioResponse } from '../../lib';
+import { AlertsExtractor } from '../AlertsExtractor';
+
+jest.mock('@app/shared/lib/constants', () => ({
+  ...jest.requireActual('@app/shared/lib/constants'),
+  STORE_ENCRYPTION_KEY: '12345',
+}));
+
+describe('AlertsExtractor: test extractFromStackedRadio', () => {
+  let extractor: AlertsExtractor;
+
+  beforeEach(() => {
+    extractor = new AlertsExtractor({
+      log: jest.fn(),
+      warn: jest.fn(),
+      error: jest.fn(),
+      info: jest.fn(),
+    } as unknown as ILogger);
+  });
+
+  it('Should return two alerts from the two selected cells in the different rows', () => {
+    const radiosItem = getStackedRadioItem();
+
+    const radioAnswer: StackedRadioResponse = getStackedRadioResponse('1');
+
+    const result: AnswerAlerts = extractor.extractFromStackedRadio(radiosItem, {
+      answer: radioAnswer,
+    });
+
+    const expected: AnswerAlerts = [
+      { activityItemId: 'item-stacked-radio', message: 'mock-alert-r1-o1' },
+      { activityItemId: 'item-stacked-radio', message: 'mock-alert-r2-o2' },
+    ];
+
+    expect(result).toEqual(expected);
+  });
+
+  it('Should return a single alert from the two selected cells in the different rows', () => {
+    const radiosItem = getStackedRadioItem();
+
+    const radioAnswer: StackedRadioResponse = getStackedRadioResponse('2');
+
+    const result: AnswerAlerts = extractor.extractFromStackedRadio(radiosItem, {
+      answer: radioAnswer,
+    });
+
+    const expected: AnswerAlerts = [
+      { activityItemId: 'item-stacked-radio', message: 'mock-alert-r1-o1' },
+    ];
+
+    expect(result).toEqual(expected);
+  });
+});

--- a/src/features/pass-survey/model/tests/AlertsExtractor.extractFromStackedSlider.test.ts
+++ b/src/features/pass-survey/model/tests/AlertsExtractor.extractFromStackedSlider.test.ts
@@ -1,0 +1,110 @@
+import { ILogger } from '@app/shared/lib';
+
+import { getStackedSliderItem } from './testHelpers';
+import { AnswerAlerts, StackedSliderResponse } from '../../lib';
+import { AlertsExtractor } from '../AlertsExtractor';
+
+jest.mock('@app/shared/lib/constants', () => ({
+  ...jest.requireActual('@app/shared/lib/constants'),
+  STORE_ENCRYPTION_KEY: '12345',
+}));
+
+describe('AlertsExtractor: test extractFromStackedSlider', () => {
+  let extractor: AlertsExtractor;
+
+  beforeEach(() => {
+    extractor = new AlertsExtractor({
+      log: jest.fn(),
+      warn: jest.fn(),
+      error: jest.fn(),
+      info: jest.fn(),
+    } as unknown as ILogger);
+  });
+
+  const tests = [
+    {
+      firstValue: 5,
+      secondValue: 3,
+      firstAlert: 'mock-row1-5-alert',
+      secondAlert: 'mock-row2-3-alert',
+    },
+    {
+      firstValue: 2,
+      secondValue: 1,
+      firstAlert: 'mock-row1-2-alert',
+      secondAlert: undefined,
+    },
+    {
+      firstValue: 9,
+      secondValue: 5,
+      firstAlert: 'mock-row1-9-alert',
+      secondAlert: undefined,
+    },
+  ];
+
+  tests.forEach(({ firstValue, secondValue, firstAlert, secondAlert }) => {
+    const secondAlertSubstring =
+      secondAlert !== undefined ? ', ' + secondAlert : '';
+
+    it(`Should return alerts '${firstAlert}'${secondAlertSubstring} when values are ${firstValue} and ${secondValue} on the 1st and 2nd slider correspondingly`, () => {
+      const slidersItem = getStackedSliderItem();
+
+      const sliderAnswers: StackedSliderResponse = [firstValue, secondValue];
+
+      const result: AnswerAlerts = extractor.extractFromStackedSlider(
+        slidersItem,
+        {
+          answer: sliderAnswers,
+        },
+      );
+
+      const expected: AnswerAlerts = [
+        {
+          activityItemId: 'mock-stacked-slider-id',
+          message: firstAlert,
+        },
+      ];
+
+      if (secondAlert !== undefined) {
+        expected.push({
+          activityItemId: 'mock-stacked-slider-id',
+          message: secondAlert,
+        });
+      }
+
+      expect(result).toEqual(expected);
+    });
+  });
+
+  it('Should return empty alerts array when values are 3 and 4 on the 1st and 2nd slider correspondingly and there is no any set alert', () => {
+    const slidersItem = getStackedSliderItem();
+
+    const sliderAnswers: StackedSliderResponse = [3, 4];
+
+    const result: AnswerAlerts = extractor.extractFromStackedSlider(
+      slidersItem,
+      {
+        answer: sliderAnswers,
+      },
+    );
+
+    expect(result).toEqual([]);
+  });
+
+  it('Should return empty alerts array when values are 1 and 2 on the 1st and 2nd slider correspondingly and alerts set to null in the both rows', () => {
+    const slidersItem = getStackedSliderItem();
+    slidersItem.payload.rows[0].alerts = null;
+    slidersItem.payload.rows[1].alerts = null;
+
+    const sliderAnswers: StackedSliderResponse = [1, 2];
+
+    const result: AnswerAlerts = extractor.extractFromStackedSlider(
+      slidersItem,
+      {
+        answer: sliderAnswers,
+      },
+    );
+
+    expect(result).toEqual([]);
+  });
+});

--- a/src/features/pass-survey/model/tests/testHelpers.ts
+++ b/src/features/pass-survey/model/tests/testHelpers.ts
@@ -7,6 +7,7 @@ import {
   StackedCheckboxResponse,
   StackedRadioPipelineItem,
   StackedRadioResponse,
+  StackedSliderPipelineItem,
 } from '../../lib';
 
 export const getEmptyRadioItem = (name: string): RadioPipelineItem => {
@@ -332,5 +333,65 @@ export const getStackedCheckboxResponse = (
   if (test === '3-no-selection') {
   }
 
+  return result;
+};
+
+export const getStackedSliderItem = (): StackedSliderPipelineItem => {
+  const result: StackedSliderPipelineItem = {
+    id: 'mock-stacked-slider-id',
+    name: 'mock-stacked-slider-name',
+    timer: null,
+    payload: {
+      addScores: false,
+      setAlerts: true,
+      rows: [
+        {
+          id: 'mock-row1-id',
+          label: 'mock-row1-label',
+          leftImageUrl: null,
+          rightImageUrl: null,
+          leftTitle: 'left-title',
+          rightTitle: 'right-title',
+          alerts: [
+            {
+              message: 'mock-row1-2-alert',
+              value: 2,
+            },
+            {
+              message: 'mock-row1-5-alert',
+              value: 5,
+            },
+            {
+              message: 'mock-row1-6-alert',
+              value: 6,
+            },
+            {
+              message: 'mock-row1-9-alert',
+              value: 9,
+            },
+          ],
+          minValue: 2,
+          maxValue: 9,
+        },
+        {
+          id: 'mock-row1-id',
+          label: 'mock-row1-label',
+          leftImageUrl: null,
+          rightImageUrl: null,
+          leftTitle: 'left-title',
+          rightTitle: 'right-title',
+          alerts: [
+            {
+              message: 'mock-row2-3-alert',
+              value: 3,
+            },
+          ],
+          minValue: 1,
+          maxValue: 5,
+        },
+      ],
+    },
+    type: 'StackedSlider',
+  };
   return result;
 };

--- a/src/features/pass-survey/model/tests/testHelpers.ts
+++ b/src/features/pass-survey/model/tests/testHelpers.ts
@@ -3,6 +3,8 @@ import {
   CheckboxPipelineItem,
   RadioPipelineItem,
   SliderPipelineItem,
+  StackedCheckboxPipelineItem,
+  StackedCheckboxResponse,
   StackedRadioPipelineItem,
   StackedRadioResponse,
 } from '../../lib';
@@ -163,8 +165,8 @@ export const getStackedRadioItem = () => {
       addScores: false,
       setAlerts: true,
       addTooltip: false,
-      options: [], // no need for alerts test
-      rows: [], // - / -
+      options: [],
+      rows: [],
       randomizeOptions: false,
       dataMatrix: [
         {
@@ -213,10 +215,12 @@ export const getStackedRadioItem = () => {
   return result;
 };
 
-export const getStackedRadioResponse = (test: '1' | '2') => {
+export const getStackedRadioResponse = (
+  test: '1-no-empty-alerts' | '2-is-empty-alert',
+) => {
   const result: StackedRadioResponse = [];
 
-  if (test === '1') {
+  if (test === '1-no-empty-alerts') {
     result.push({ id: 'mock-opt-id-1', rowId: 'mock-row-id-1', tooltip: null });
     result.push({
       id: 'mock-opt-id-20',
@@ -225,13 +229,107 @@ export const getStackedRadioResponse = (test: '1' | '2') => {
     });
   }
 
-  if (test === '2') {
+  if (test === '2-is-empty-alert') {
     result.push({ id: 'mock-opt-id-1', rowId: 'mock-row-id-1', tooltip: null });
     result.push({
       id: 'mock-opt-id-30',
       rowId: 'mock-row-id-2',
       tooltip: null,
     });
+  }
+
+  return result;
+};
+
+export const getStackedCheckboxItem = () => {
+  const result: StackedCheckboxPipelineItem = {
+    timer: null,
+    type: 'StackedCheckbox',
+    id: 'item-stacked-checkbox',
+    payload: {
+      addScores: false,
+      setAlerts: true,
+      addTooltip: false,
+      options: [],
+      rows: [],
+      randomizeOptions: false,
+      dataMatrix: [
+        {
+          rowId: 'mock-row-id-1',
+          options: [
+            {
+              alert: { message: 'mock-alert-r1-o1' },
+              optionId: 'mock-opt-id-1',
+              score: 0,
+            },
+            {
+              alert: { message: 'mock-alert-r1-o2' },
+              optionId: 'mock-opt-id-2',
+              score: 0,
+            },
+            {
+              alert: { message: 'mock-alert-r1-o3' },
+              optionId: 'mock-opt-id-3',
+              score: 0,
+            },
+          ],
+        },
+        {
+          rowId: 'mock-row-id-2',
+          options: [
+            {
+              alert: { message: 'mock-alert-r2-o1' },
+              optionId: 'mock-opt-id-10',
+              score: 0,
+            },
+            {
+              alert: { message: 'mock-alert-r2-o2' },
+              optionId: 'mock-opt-id-20',
+              score: 0,
+            },
+            {
+              alert: null,
+              optionId: 'mock-opt-id-30',
+              score: 0,
+            },
+          ],
+        },
+      ],
+    },
+  };
+  return result;
+};
+
+export const getStackedCheckboxResponse = (
+  test: '1-partially-selected' | '2-all-selected' | '3-no-selection',
+) => {
+  const result: StackedCheckboxResponse = [];
+
+  if (test === '1-partially-selected') {
+    result.push([
+      { id: 'mock-opt-id-1', tooltip: null },
+      { id: 'mock-opt-id-2', tooltip: null },
+    ]);
+    result.push([
+      { id: 'mock-opt-id-20', tooltip: null },
+      { id: 'mock-opt-id-30', tooltip: null },
+    ]);
+  }
+
+  if (test === '2-all-selected') {
+    result.push([
+      { id: 'mock-opt-id-1', tooltip: null },
+      { id: 'mock-opt-id-2', tooltip: null },
+      { id: 'mock-opt-id-3', tooltip: null },
+    ]);
+    result.push([
+      { id: 'mock-opt-id-10', tooltip: null },
+      { id: 'mock-opt-id-20', tooltip: null },
+      { id: 'mock-opt-id-30', tooltip: null },
+    ]);
+  }
+
+  if (test === '3-no-selection') {
   }
 
   return result;

--- a/src/features/pass-survey/model/tests/testHelpers.ts
+++ b/src/features/pass-survey/model/tests/testHelpers.ts
@@ -3,6 +3,8 @@ import {
   CheckboxPipelineItem,
   RadioPipelineItem,
   SliderPipelineItem,
+  StackedRadioPipelineItem,
+  StackedRadioResponse,
 } from '../../lib';
 
 export const getEmptyRadioItem = (name: string): RadioPipelineItem => {
@@ -149,5 +151,88 @@ export const getEmptyAudioItem = (name: string): AudioPipelineItem => {
     payload: {} as any,
     type: 'Audio',
   };
+  return result;
+};
+
+export const getStackedRadioItem = () => {
+  const result: StackedRadioPipelineItem = {
+    timer: null,
+    type: 'StackedRadio',
+    id: 'item-stacked-radio',
+    payload: {
+      addScores: false,
+      setAlerts: true,
+      addTooltip: false,
+      options: [], // no need for alerts test
+      rows: [], // - / -
+      randomizeOptions: false,
+      dataMatrix: [
+        {
+          rowId: 'mock-row-id-1',
+          options: [
+            {
+              alert: { message: 'mock-alert-r1-o1' },
+              optionId: 'mock-opt-id-1',
+              score: 0,
+            },
+            {
+              alert: { message: 'mock-alert-r1-o2' },
+              optionId: 'mock-opt-id-2',
+              score: 0,
+            },
+            {
+              alert: { message: 'mock-alert-r1-o3' },
+              optionId: 'mock-opt-id-3',
+              score: 0,
+            },
+          ],
+        },
+        {
+          rowId: 'mock-row-id-2',
+          options: [
+            {
+              alert: { message: 'mock-alert-r2-o1' },
+              optionId: 'mock-opt-id-10',
+              score: 0,
+            },
+            {
+              alert: { message: 'mock-alert-r2-o2' },
+              optionId: 'mock-opt-id-20',
+              score: 0,
+            },
+            {
+              alert: null,
+              optionId: 'mock-opt-id-30',
+              score: 0,
+            },
+          ],
+        },
+      ],
+    },
+  };
+  return result;
+};
+
+export const getStackedRadioResponse = (test: '1' | '2') => {
+  const result: StackedRadioResponse = [];
+
+  if (test === '1') {
+    result.push({ id: 'mock-opt-id-1', rowId: 'mock-row-id-1', tooltip: null });
+    result.push({
+      id: 'mock-opt-id-20',
+      rowId: 'mock-row-id-2',
+      tooltip: null,
+    });
+  }
+
+  if (test === '2') {
+    result.push({ id: 'mock-opt-id-1', rowId: 'mock-row-id-1', tooltip: null });
+    result.push({
+      id: 'mock-opt-id-30',
+      rowId: 'mock-row-id-2',
+      tooltip: null,
+    });
+  }
+
   return result;
 };


### PR DESCRIPTION
### 📝 Description

🔗 [Jira Ticket M2-5366](https://mindlogger.atlassian.net/browse/M2-5366)
🔗 [Jira Ticket M2-5367](https://mindlogger.atlassian.net/browse/M2-5367)
🔗 [Jira Ticket M2-5368](https://mindlogger.atlassian.net/browse/M2-5368)

This PR adds unit tests that cover AlertsExtractor logic for stacked item types

Changes include:

- Added unit tests for AlertsExtractor module: extractFromStackedSlider function
- Added unit tests for AlertsExtractor module: extractFromStackedCheckbox function
- Added unit tests for AlertsExtractor module: extractFromStackedRadio function
- Slightly improved code for the extractFromStackedCheckbox
- Added fixes for notification-related unit-tests (missed mock)