### PR TITLE
M2-5369, M2-5370 unit tests for alerts-extractor: extract-from-item and penetration tests

### DIFF
--- a/src/features/pass-survey/model/tests/AlertsExtractor.extractFromItem.test.ts
+++ b/src/features/pass-survey/model/tests/AlertsExtractor.extractFromItem.test.ts
@@ -22,15 +22,6 @@ const mockExtractFunctions = (extractor: AlertsExtractor) => {
   extractor.extractFromStackedCheckbox = extractFromStackedCheckboxMock;
   extractor.extractFromStackedRadio = extractFromStackedRadioMock;
   extractor.extractFromStackedSlider = extractFromStackedSliderMock;
-
-  return {
-    extractFromRadioMock,
-    extractFromCheckboxMock,
-    extractFromStackedRadioMock,
-    extractFromStackedCheckboxMock,
-    extractFromSliderMock,
-    extractFromStackedSliderMock,
-  };
 };
 
 describe('AlertsExtractor: test extractFromItem', () => {
@@ -43,92 +34,73 @@ describe('AlertsExtractor: test extractFromItem', () => {
       error: jest.fn(),
       info: jest.fn(),
     } as unknown as ILogger);
+
+    mockExtractFunctions(extractor);
   });
 
   it('Should call extractFromRadio when type is Radio', () => {
-    const { extractFromRadioMock } = mockExtractFunctions(extractor);
-
     //@ts-expect-error
     extractor.extractFromItem({ type: 'Radio' } as PipelineItem, {} as Answer);
 
-    expect(extractFromRadioMock).toBeCalledTimes(1);
+    expect(extractor.extractFromRadio).toBeCalledTimes(1);
   });
 
   it('Should call extractFromCheckbox when type is Checkbox', () => {
-    const { extractFromCheckboxMock } = mockExtractFunctions(extractor);
-
     //@ts-expect-error
     extractor.extractFromItem(
       { type: 'Checkbox' } as PipelineItem,
       {} as Answer,
     );
 
-    expect(extractFromCheckboxMock).toBeCalledTimes(1);
+    expect(extractor.extractFromCheckbox).toBeCalledTimes(1);
   });
 
   it('Should call extractFromSlider when type is Slider', () => {
-    const { extractFromSliderMock } = mockExtractFunctions(extractor);
-
     //@ts-expect-error
     extractor.extractFromItem({ type: 'Slider' } as PipelineItem, {} as Answer);
 
-    expect(extractFromSliderMock).toBeCalledTimes(1);
+    expect(extractor.extractFromSlider).toBeCalledTimes(1);
   });
 
   it('Should call extractFromStackedRadio when type is StackedRadio', () => {
-    const { extractFromStackedRadioMock } = mockExtractFunctions(extractor);
-
     //@ts-expect-error
     extractor.extractFromItem(
       { type: 'StackedRadio' } as PipelineItem,
       {} as Answer,
     );
 
-    expect(extractFromStackedRadioMock).toBeCalledTimes(1);
+    expect(extractor.extractFromStackedRadio).toBeCalledTimes(1);
   });
 
   it('Should call extractFromStackedCheckbox when type is StackedCheckbox', () => {
-    const { extractFromStackedCheckboxMock } = mockExtractFunctions(extractor);
-
     //@ts-expect-error
     extractor.extractFromItem(
       { type: 'StackedCheckbox' } as PipelineItem,
       {} as Answer,
     );
 
-    expect(extractFromStackedCheckboxMock).toBeCalledTimes(1);
+    expect(extractor.extractFromStackedCheckbox).toBeCalledTimes(1);
   });
 
   it('Should call extractFromStackedSlider when type is StackedSlider', () => {
-    const { extractFromStackedSliderMock } = mockExtractFunctions(extractor);
-
     //@ts-expect-error
     extractor.extractFromItem(
       { type: 'StackedSlider' } as PipelineItem,
       {} as Answer,
     );
 
-    expect(extractFromStackedSliderMock).toBeCalledTimes(1);
+    expect(extractor.extractFromStackedSlider).toBeCalledTimes(1);
   });
 
   it('Should not call anything when type is Audio', () => {
-    const {
-      extractFromRadioMock,
-      extractFromCheckboxMock,
-      extractFromStackedRadioMock,
-      extractFromStackedCheckboxMock,
-      extractFromSliderMock,
-      extractFromStackedSliderMock,
-    } = mockExtractFunctions(extractor);
-
     //@ts-expect-error
     extractor.extractFromItem({ type: 'Audio' } as PipelineItem, {} as Answer);
 
-    expect(extractFromRadioMock).toBeCalledTimes(0);
-    expect(extractFromCheckboxMock).toBeCalledTimes(0);
-    expect(extractFromStackedRadioMock).toBeCalledTimes(0);
-    expect(extractFromStackedCheckboxMock).toBeCalledTimes(0);
-    expect(extractFromSliderMock).toBeCalledTimes(0);
-    expect(extractFromStackedSliderMock).toBeCalledTimes(0);
+    expect(extractor.extractFromRadio).toBeCalledTimes(0);
+    expect(extractor.extractFromCheckbox).toBeCalledTimes(0);
+    expect(extractor.extractFromStackedRadio).toBeCalledTimes(0);
+    expect(extractor.extractFromStackedCheckbox).toBeCalledTimes(0);
+    expect(extractor.extractFromSlider).toBeCalledTimes(0);
+    expect(extractor.extractFromStackedSlider).toBeCalledTimes(0);
   });
 });

--- a/src/features/pass-survey/model/tests/AlertsExtractor.extractFromItem.test.ts
+++ b/src/features/pass-survey/model/tests/AlertsExtractor.extractFromItem.test.ts
@@ -1,0 +1,134 @@
+import { ILogger } from '@app/shared/lib';
+
+import { Answer, PipelineItem } from '../../lib';
+import { AlertsExtractor } from '../AlertsExtractor';
+
+jest.mock('@app/shared/lib/constants', () => ({
+  ...jest.requireActual('@app/shared/lib/constants'),
+  STORE_ENCRYPTION_KEY: '12345',
+}));
+
+const mockExtractFunctions = (extractor: AlertsExtractor) => {
+  const extractFromRadioMock = jest.fn();
+  const extractFromCheckboxMock = jest.fn();
+  const extractFromStackedRadioMock = jest.fn();
+  const extractFromStackedCheckboxMock = jest.fn();
+  const extractFromSliderMock = jest.fn();
+  const extractFromStackedSliderMock = jest.fn();
+
+  extractor.extractFromCheckbox = extractFromCheckboxMock;
+  extractor.extractFromRadio = extractFromRadioMock;
+  extractor.extractFromSlider = extractFromSliderMock;
+  extractor.extractFromStackedCheckbox = extractFromStackedCheckboxMock;
+  extractor.extractFromStackedRadio = extractFromStackedRadioMock;
+  extractor.extractFromStackedSlider = extractFromStackedSliderMock;
+
+  return {
+    extractFromRadioMock,
+    extractFromCheckboxMock,
+    extractFromStackedRadioMock,
+    extractFromStackedCheckboxMock,
+    extractFromSliderMock,
+    extractFromStackedSliderMock,
+  };
+};
+
+describe('AlertsExtractor: test extractFromItem', () => {
+  let extractor: AlertsExtractor;
+
+  beforeEach(() => {
+    extractor = new AlertsExtractor({
+      log: jest.fn(),
+      warn: jest.fn(),
+      error: jest.fn(),
+      info: jest.fn(),
+    } as unknown as ILogger);
+  });
+
+  it('Should call extractFromRadio when type is Radio', () => {
+    const { extractFromRadioMock } = mockExtractFunctions(extractor);
+
+    //@ts-expect-error
+    extractor.extractFromItem({ type: 'Radio' } as PipelineItem, {} as Answer);
+
+    expect(extractFromRadioMock).toBeCalledTimes(1);
+  });
+
+  it('Should call extractFromCheckbox when type is Checkbox', () => {
+    const { extractFromCheckboxMock } = mockExtractFunctions(extractor);
+
+    //@ts-expect-error
+    extractor.extractFromItem(
+      { type: 'Checkbox' } as PipelineItem,
+      {} as Answer,
+    );
+
+    expect(extractFromCheckboxMock).toBeCalledTimes(1);
+  });
+
+  it('Should call extractFromSlider when type is Slider', () => {
+    const { extractFromSliderMock } = mockExtractFunctions(extractor);
+
+    //@ts-expect-error
+    extractor.extractFromItem({ type: 'Slider' } as PipelineItem, {} as Answer);
+
+    expect(extractFromSliderMock).toBeCalledTimes(1);
+  });
+
+  it('Should call extractFromStackedRadio when type is StackedRadio', () => {
+    const { extractFromStackedRadioMock } = mockExtractFunctions(extractor);
+
+    //@ts-expect-error
+    extractor.extractFromItem(
+      { type: 'StackedRadio' } as PipelineItem,
+      {} as Answer,
+    );
+
+    expect(extractFromStackedRadioMock).toBeCalledTimes(1);
+  });
+
+  it('Should call extractFromStackedCheckbox when type is StackedCheckbox', () => {
+    const { extractFromStackedCheckboxMock } = mockExtractFunctions(extractor);
+
+    //@ts-expect-error
+    extractor.extractFromItem(
+      { type: 'StackedCheckbox' } as PipelineItem,
+      {} as Answer,
+    );
+
+    expect(extractFromStackedCheckboxMock).toBeCalledTimes(1);
+  });
+
+  it('Should call extractFromStackedSlider when type is StackedSlider', () => {
+    const { extractFromStackedSliderMock } = mockExtractFunctions(extractor);
+
+    //@ts-expect-error
+    extractor.extractFromItem(
+      { type: 'StackedSlider' } as PipelineItem,
+      {} as Answer,
+    );
+
+    expect(extractFromStackedSliderMock).toBeCalledTimes(1);
+  });
+
+  it('Should not call anything when type is Audio', () => {
+    const {
+      extractFromRadioMock,
+      extractFromCheckboxMock,
+      extractFromStackedRadioMock,
+      extractFromStackedCheckboxMock,
+      extractFromSliderMock,
+      extractFromStackedSliderMock,
+    } = mockExtractFunctions(extractor);
+
+    //@ts-expect-error
+    extractor.extractFromItem({ type: 'Audio' } as PipelineItem, {} as Answer);
+
+    expect(extractFromRadioMock).toBeCalledTimes(0);
+    expect(extractFromCheckboxMock).toBeCalledTimes(0);
+    expect(extractFromStackedRadioMock).toBeCalledTimes(0);
+    expect(extractFromStackedCheckboxMock).toBeCalledTimes(0);
+    expect(extractFromSliderMock).toBeCalledTimes(0);
+    expect(extractFromStackedSliderMock).toBeCalledTimes(0);
+  });
+});

--- a/src/features/pass-survey/model/tests/AlertsExtractor.extractFromSlider.test.ts
+++ b/src/features/pass-survey/model/tests/AlertsExtractor.extractFromSlider.test.ts
@@ -35,7 +35,7 @@ describe('AlertsExtractor: test extractFromSlider', () => {
     const expected: AnswerAlerts = [
       {
         activityItemId: 'mock-slider-id',
-        message: 'alert-2',
+        message: 'mock-alert-2',
       },
     ];
 
@@ -56,7 +56,7 @@ describe('AlertsExtractor: test extractFromSlider', () => {
     const expected: AnswerAlerts = [
       {
         activityItemId: 'mock-slider-id',
-        message: 'alert-9',
+        message: 'mock-alert-9',
       },
     ];
 
@@ -77,7 +77,7 @@ describe('AlertsExtractor: test extractFromSlider', () => {
     const expected: AnswerAlerts = [
       {
         activityItemId: 'mock-slider-id',
-        message: 'alert-3',
+        message: 'mock-alert-3',
       },
     ];
 
@@ -147,7 +147,7 @@ describe('AlertsExtractor: test extractFromSlider', () => {
     const expected: AnswerAlerts = [
       {
         activityItemId: 'mock-slider-id',
-        message: 'alert-7-8',
+        message: 'mock-alert-7-8',
       },
     ];
 

--- a/src/features/pass-survey/model/tests/AlertsExtractor.extractFromStackedCheckbox.test.ts
+++ b/src/features/pass-survey/model/tests/AlertsExtractor.extractFromStackedCheckbox.test.ts
@@ -38,9 +38,18 @@ describe('AlertsExtractor: test extractFromStackedCheckbox', () => {
     );
 
     const expected: AnswerAlerts = [
-      { activityItemId: 'item-stacked-checkbox', message: 'mock-alert-r1-o1' },
-      { activityItemId: 'item-stacked-checkbox', message: 'mock-alert-r1-o2' },
-      { activityItemId: 'item-stacked-checkbox', message: 'mock-alert-r2-o2' },
+      {
+        activityItemId: 'mock-item-stacked-checkbox-id',
+        message: 'mock-alert-r1-o1',
+      },
+      {
+        activityItemId: 'mock-item-stacked-checkbox-id',
+        message: 'mock-alert-r1-o2',
+      },
+      {
+        activityItemId: 'mock-item-stacked-checkbox-id',
+        message: 'mock-alert-r2-o2',
+      },
     ];
 
     expect(result).toEqual(expected);
@@ -60,11 +69,26 @@ describe('AlertsExtractor: test extractFromStackedCheckbox', () => {
     );
 
     const expected: AnswerAlerts = [
-      { activityItemId: 'item-stacked-checkbox', message: 'mock-alert-r1-o1' },
-      { activityItemId: 'item-stacked-checkbox', message: 'mock-alert-r1-o2' },
-      { activityItemId: 'item-stacked-checkbox', message: 'mock-alert-r1-o3' },
-      { activityItemId: 'item-stacked-checkbox', message: 'mock-alert-r2-o1' },
-      { activityItemId: 'item-stacked-checkbox', message: 'mock-alert-r2-o2' },
+      {
+        activityItemId: 'mock-item-stacked-checkbox-id',
+        message: 'mock-alert-r1-o1',
+      },
+      {
+        activityItemId: 'mock-item-stacked-checkbox-id',
+        message: 'mock-alert-r1-o2',
+      },
+      {
+        activityItemId: 'mock-item-stacked-checkbox-id',
+        message: 'mock-alert-r1-o3',
+      },
+      {
+        activityItemId: 'mock-item-stacked-checkbox-id',
+        message: 'mock-alert-r2-o1',
+      },
+      {
+        activityItemId: 'mock-item-stacked-checkbox-id',
+        message: 'mock-alert-r2-o2',
+      },
     ];
 
     expect(result).toEqual(expected);

--- a/src/features/pass-survey/model/tests/AlertsExtractor.extractFromStackedRadio.test.ts
+++ b/src/features/pass-survey/model/tests/AlertsExtractor.extractFromStackedRadio.test.ts
@@ -32,8 +32,14 @@ describe('AlertsExtractor: test extractFromStackedRadio', () => {
     });
 
     const expected: AnswerAlerts = [
-      { activityItemId: 'item-stacked-radio', message: 'mock-alert-r1-o1' },
-      { activityItemId: 'item-stacked-radio', message: 'mock-alert-r2-o2' },
+      {
+        activityItemId: 'mock-item-stacked-radio-id',
+        message: 'mock-alert-r1-o1',
+      },
+      {
+        activityItemId: 'mock-item-stacked-radio-id',
+        message: 'mock-alert-r2-o2',
+      },
     ];
 
     expect(result).toEqual(expected);
@@ -50,7 +56,10 @@ describe('AlertsExtractor: test extractFromStackedRadio', () => {
     });
 
     const expected: AnswerAlerts = [
-      { activityItemId: 'item-stacked-radio', message: 'mock-alert-r1-o1' },
+      {
+        activityItemId: 'mock-item-stacked-radio-id',
+        message: 'mock-alert-r1-o1',
+      },
     ];
 
     expect(result).toEqual(expected);

--- a/src/features/pass-survey/model/tests/AlertsExtractor.test.ts
+++ b/src/features/pass-survey/model/tests/AlertsExtractor.test.ts
@@ -1,0 +1,143 @@
+import { ILogger } from '@app/shared/lib';
+import { Item } from '@app/shared/ui';
+
+import {
+  fillAlertsForSlider,
+  fillOptionsForCheckboxes,
+  fillOptionsForRadio,
+  getEmptyCheckboxesItem,
+  getEmptyRadioItem,
+  getEmptySliderItem,
+  getStackedCheckboxItem,
+  getStackedCheckboxResponse,
+  getStackedRadioItem,
+  getStackedRadioResponse,
+  getStackedSliderItem,
+} from './testHelpers';
+import {
+  AnswerAlerts,
+  Answers,
+  PipelineItem,
+  RadioResponse,
+  SliderResponse,
+  StackedCheckboxResponse,
+  StackedRadioResponse,
+  StackedSliderResponse,
+} from '../../lib';
+import { AlertsExtractor } from '../AlertsExtractor';
+
+jest.mock('@app/shared/lib/constants', () => ({
+  ...jest.requireActual('@app/shared/lib/constants'),
+  STORE_ENCRYPTION_KEY: '12345',
+}));
+
+describe('AlertsExtractor: penetration tests', () => {
+  let extractor: AlertsExtractor = new AlertsExtractor({
+    log: jest.fn(),
+    warn: jest.fn(),
+    error: jest.fn(),
+    info: jest.fn(),
+  } as unknown as ILogger);
+
+  it('Should return alerts for all 6 activity items', () => {
+    const radiosItem = getEmptyRadioItem('item-radio');
+    fillOptionsForRadio(radiosItem, 0);
+    const radioAnswer: RadioResponse = radiosItem.payload.options[2];
+
+    const checkboxesItem = getEmptyCheckboxesItem('item-checkboxes');
+    fillOptionsForCheckboxes(checkboxesItem, 0);
+
+    const checkboxesAnswer: Item[] = [
+      checkboxesItem.payload.options[1],
+      checkboxesItem.payload.options[2],
+    ];
+
+    const sliderItem = getEmptySliderItem('item-slider');
+    fillAlertsForSlider(sliderItem);
+    const sliderAnswer: SliderResponse = 2;
+
+    const stackedRadiosItem = getStackedRadioItem();
+    const stackedRadioAnswer: StackedRadioResponse =
+      getStackedRadioResponse('1-no-empty-alerts');
+
+    const stackedCheckboxesItem = getStackedCheckboxItem();
+    const stackedCheckboxesAnswer: StackedCheckboxResponse =
+      getStackedCheckboxResponse('1-partially-selected');
+
+    const stackedSlidersItem = getStackedSliderItem();
+    const stackedSliderAnswers: StackedSliderResponse = [5, 3];
+
+    const answers: Answers = {
+      0: { answer: radioAnswer },
+      1: { answer: checkboxesAnswer },
+      2: { answer: sliderAnswer },
+      3: { answer: stackedRadioAnswer },
+      4: { answer: stackedCheckboxesAnswer },
+      5: { answer: stackedSliderAnswers },
+    };
+
+    const pipelineItems: PipelineItem[] = [
+      radiosItem,
+      checkboxesItem,
+      sliderItem,
+      stackedRadiosItem,
+      stackedCheckboxesItem,
+      stackedSlidersItem,
+    ];
+
+    const alerts = extractor.extractForSummary(
+      pipelineItems,
+      answers,
+      'mock-activity-name',
+    );
+
+    const expected: AnswerAlerts = [
+      {
+        activityItemId: 'mock-radio-id',
+        message: 'mock-alert-2',
+      },
+      {
+        activityItemId: 'mock-checkbox-id',
+        message: 'mock-alert-1',
+      },
+      {
+        activityItemId: 'mock-checkbox-id',
+        message: 'mock-alert-2',
+      },
+      {
+        activityItemId: 'mock-slider-id',
+        message: 'mock-alert-2',
+      },
+      {
+        activityItemId: 'mock-item-stacked-radio-id',
+        message: 'mock-alert-r1-o1',
+      },
+      {
+        activityItemId: 'mock-item-stacked-radio-id',
+        message: 'mock-alert-r2-o2',
+      },
+      {
+        activityItemId: 'mock-item-stacked-checkbox-id',
+        message: 'mock-alert-r1-o1',
+      },
+      {
+        activityItemId: 'mock-item-stacked-checkbox-id',
+        message: 'mock-alert-r1-o2',
+      },
+      {
+        activityItemId: 'mock-item-stacked-checkbox-id',
+        message: 'mock-alert-r2-o2',
+      },
+      {
+        activityItemId: 'mock-stacked-slider-id',
+        message: 'mock-row1-5-alert',
+      },
+      {
+        activityItemId: 'mock-stacked-slider-id',
+        message: 'mock-row2-3-alert',
+      },
+    ];
+
+    expect(alerts).toEqual(expected);
+  });
+});

--- a/src/features/pass-survey/model/tests/testHelpers.ts
+++ b/src/features/pass-survey/model/tests/testHelpers.ts
@@ -121,26 +121,26 @@ export const fillScoresForSlider = (
 export const fillAlertsForSlider = (item: SliderPipelineItem) => {
   item.payload.alerts?.push({
     value: 2,
-    message: 'alert-2',
+    message: 'mock-alert-2',
     minValue: null,
     maxValue: null,
   });
   item.payload.alerts?.push({
     value: 3,
-    message: 'alert-3',
+    message: 'mock-alert-3',
     minValue: null,
     maxValue: null,
   });
   item.payload.alerts?.push({
     value: 9,
-    message: 'alert-9',
+    message: 'mock-alert-9',
     minValue: null,
     maxValue: null,
   });
 
   item.payload.alerts?.push({
     value: NaN,
-    message: 'alert-7-8',
+    message: 'mock-alert-7-8',
     minValue: 7,
     maxValue: 8,
   });
@@ -161,7 +161,7 @@ export const getStackedRadioItem = () => {
   const result: StackedRadioPipelineItem = {
     timer: null,
     type: 'StackedRadio',
-    id: 'item-stacked-radio',
+    id: 'mock-item-stacked-radio-id',
     payload: {
       addScores: false,
       setAlerts: true,
@@ -246,7 +246,7 @@ export const getStackedCheckboxItem = () => {
   const result: StackedCheckboxPipelineItem = {
     timer: null,
     type: 'StackedCheckbox',
-    id: 'item-stacked-checkbox',
+    id: 'mock-item-stacked-checkbox-id',
     payload: {
       addScores: false,
       setAlerts: true,


### PR DESCRIPTION
### 📝 Description

🔗 [Jira Ticket M2-5369](https://mindlogger.atlassian.net/browse/M2-5369)
🔗 [Jira Ticket M2-5370](https://mindlogger.atlassian.net/browse/M2-5370)

Changes include:

- Unit tests for AlertsExtractor -> extractFromItem function
- Unit tests for AlertsExtractor, penetration
- Unit tests minor improvements
