### PR TITLE
M2-4278: [Mobile App] send application logs to server before logging …

### DIFF
--- a/src/features/logout/model/hooks.ts
+++ b/src/features/logout/model/hooks.ts
@@ -26,12 +26,18 @@ export function useLogout() {
   const { closeConnection: closeActiveTCPConnection } = useTCPSocket();
 
   const processLogout = async () => {
+    Logger.info('[useLogout.processLogout]: Processing logout');
+
+    await Logger.send();
+
     try {
       IdentityService.logout({
         deviceId: SystemRecord.getDeviceId()!,
       });
     } catch (error) {
-      Logger.error(`Logout operation failed: ${error}`);
+      console.warn(
+        `[useLogout.processLogout]: Logout operation failed: ${error}`,
+      );
     }
 
     AnalyticsService.logout();


### PR DESCRIPTION
### 📝 Description

🔗 [Jira Ticket M2-4278](https://mindlogger.atlassian.net/browse/M2-4278)

Changes include:

- Added sending logs before log-out
- Considered repeat if mutex is busy
