### PR TITLE
M2-5243: Duplicated lines produced by the Drawing Items

### DIFF
--- a/src/shared/ui/SketchCanvas/DrawingGesture.ts
+++ b/src/shared/ui/SketchCanvas/DrawingGesture.ts
@@ -127,7 +127,7 @@ function DrawingGesture(
 
         runOnJS(onTouchProgress)(event, false, time);
       })
-      .onFinalize(() => {
+      .onEnd(() => {
         runOnJS(onTouchEnd)();
       });
 


### PR DESCRIPTION
### 📝 Description

🔗 [Jira Ticket M2-5243](https://mindlogger.atlassian.net/browse/M2-5243)

Changes include:

- Method that calls the function that indicates the end of the gesture.

### ✏️ Notes

The previously used `onFinalize` function is called when the second (and further) touch is lifted even though maxPointers(1) is defined. That is because the React Native Gesture Handler internally dismisses the touch by calling the `fail()` function in the result of which `onFinalize` is called.
