### PR TITLE
fix(M2-5814): Adding only nextNodeLabel for abTrails streamEvent , when user has drawn correct point

### DIFF
--- a/src/features/pass-survey/model/streamEventMapper.ts
+++ b/src/features/pass-survey/model/streamEventMapper.ts
@@ -12,12 +12,16 @@ import {
 const mapABTestStreamEventToDto = (
   streamEvent: AbTestStreamEvent,
 ): AbTestStreamEventDto => {
-  let actualPath = '-1';
+  let actualPath = '?';
+
   if (streamEvent.wrongPointLabel) {
     actualPath = streamEvent.wrongPointLabel;
   }
   if (streamEvent.error === AbTestStreamEventErrorType.OverCorrectPoint) {
     actualPath = streamEvent.nextNodeLabel;
+  }
+  if (streamEvent.error === AbTestStreamEventErrorType.OverUndefinedPoint) {
+    actualPath = '-1';
   }
 
   const dto = {


### PR DESCRIPTION
### 📝 Description

🔗 [Jira Ticket M2-5814](https://mindlogger.atlassian.net/browse/M2-5814)

Changes include:

- Adding only nextNodeLabel for abTrails streamEvent , when user has drawn correct point

### ✏️ Notes

We were sending [currentNodeLabel] ~ [nextNodeLabel].