### PR TITLE
M2-5912: Added action to clean up certain parts of state

### DIFF
--- a/src/entities/applet/model/slice.ts
+++ b/src/entities/applet/model/slice.ts
@@ -10,6 +10,7 @@ import {
   IStoreProgressPayload,
   CompletedEventEntities,
 } from '@app/abstract/lib';
+import { cleanUpAction } from '@app/shared/lib';
 
 type InProgressActivity = {
   appletId: string;
@@ -153,6 +154,10 @@ const slice = createSlice({
       state.inProgress[appletId][entityId][eventId].endAt = endAt;
     },
   },
+  extraReducers: builder =>
+    builder.addCase(cleanUpAction, () => {
+      return initialState;
+    }),
 });
 
 const { actions, reducer } = slice;

--- a/src/entities/streaming/model/slice.ts
+++ b/src/entities/streaming/model/slice.ts
@@ -1,5 +1,7 @@
 import { createSlice, PayloadAction } from '@reduxjs/toolkit';
 
+import { cleanUpAction } from '@app/shared/lib';
+
 const DEFAULT_HOST = '';
 const DEFAULT_PORT = '';
 
@@ -32,6 +34,10 @@ const streamingSlice = createSlice({
       return initialState;
     },
   },
+  extraReducers: builder =>
+    builder.addCase(cleanUpAction, () => {
+      return initialState;
+    }),
 });
 
 export const actions = {

--- a/src/features/login/ui/LoginForm.tsx
+++ b/src/features/login/ui/LoginForm.tsx
@@ -11,6 +11,7 @@ import { UserInfoRecord, UserPrivateKeyRecord } from '@entities/identity/lib';
 import { SessionModel } from '@entities/session';
 import {
   AnalyticsService,
+  cleanUpAction,
   executeIfOnline,
   MixEvents,
   useAppDispatch,
@@ -55,6 +56,7 @@ const LoginForm: FC<Props> = props => {
 
       if (userParams.userId !== userId) {
         await cleanupData();
+        dispatch(cleanUpAction());
       }
 
       const userPrivateKey = encryption.getPrivateKey(userParams);

--- a/src/shared/lib/index.ts
+++ b/src/shared/lib/index.ts
@@ -17,3 +17,4 @@ export * from './encryption';
 export * from './tcp';
 export * from './records';
 export * from './analytics';
+export * from './redux-state';

--- a/src/shared/lib/redux-state/actions.ts
+++ b/src/shared/lib/redux-state/actions.ts
@@ -1,0 +1,3 @@
+import { createAction } from '@reduxjs/toolkit';
+
+export const cleanUpAction = createAction('CLEAN_UP');

--- a/src/shared/lib/redux-state/index.ts
+++ b/src/shared/lib/redux-state/index.ts
@@ -1,0 +1,1 @@
+export * from './actions';


### PR DESCRIPTION
### 📝 Description

🔗 [Jira Ticket M2-5912](https://mindlogger.atlassian.net/browse/M2-5912)

Changes include:

- Common redux action that is used to clean up certain parts of state
- Usage of the action in the `applets` reducer
- Usage of the action in the `streaming` reducer

### ✏️ Notes
No need to clean up the whole global state on logout/login. The best practice is to use a common action that can be used through the '.extraReducer' function on slices: https://redux-toolkit.js.org/api/createSlice#extrareducers