### PR TITLE
M2-5899: Added X-Timezone header

### DIFF
--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -536,6 +536,8 @@ PODS:
     - React
   - RNGestureHandler (2.14.1):
     - React-Core
+  - RNLocalize (3.0.6):
+    - React-Core
   - RNNotifee (7.8.0):
     - React-Core
     - RNNotifee/NotifeeCore (= 7.8.0)
@@ -674,6 +676,7 @@ DEPENDENCIES:
   - "RNFBMessaging (from `../node_modules/@react-native-firebase/messaging`)"
   - RNFileLogger (from `../node_modules/react-native-file-logger`)
   - RNGestureHandler (from `../node_modules/react-native-gesture-handler`)
+  - RNLocalize (from `../node_modules/react-native-localize`)
   - "RNNotifee (from `../node_modules/@notifee/react-native`)"
   - RNPermissions (from `../node_modules/react-native-permissions`)
   - RNReanimated (from `../node_modules/react-native-reanimated`)
@@ -834,6 +837,8 @@ EXTERNAL SOURCES:
     :path: "../node_modules/react-native-file-logger"
   RNGestureHandler:
     :path: "../node_modules/react-native-gesture-handler"
+  RNLocalize:
+    :path: "../node_modules/react-native-localize"
   RNNotifee:
     :path: "../node_modules/@notifee/react-native"
   RNPermissions:
@@ -938,6 +943,7 @@ SPEC CHECKSUMS:
   RNFBMessaging: 3aca7a5b3b1f79a9ee75026662ea57693436a338
   RNFileLogger: 9eaf7a6ea709eaaffe646cc485b98ae1dbf1e9f0
   RNGestureHandler: e98441928705d9d1184b599d7c1c6df2dd4f7724
+  RNLocalize: 4222a3756cdbe2dc9a5bdf445765a4d2572107cb
   RNNotifee: f3c01b391dd8e98e67f539f9a35a9cbcd3bae744
   RNPermissions: 4f5e03e3272fdc6fcee6e571dfdcbad128aadffe
   RNReanimated: c5a0074efffd21f4af324e86b19468758fe39fa2

--- a/jest.setup.js
+++ b/jest.setup.js
@@ -177,3 +177,27 @@ jest.mock('react-native-device-info', () => mockRNDeviceInfo);
 jest.mock('react-native-gesture-handler', () =>
   jest.mock('react-native-gesture-handler'),
 );
+
+jest.mock('react-native-localize', () => require('react-native-localize/mock'));
+
+/*
+ * Turbo modules mocks.
+ */
+
+jest.mock('react-native/Libraries/TurboModule/TurboModuleRegistry', () => {
+  const turboModuleRegistry = jest.requireActual(
+    'react-native/Libraries/TurboModule/TurboModuleRegistry',
+  );
+  return {
+    ...turboModuleRegistry,
+    getEnforcing: name => {
+      // List of TurboModules libraries to mock.
+      const modulesToMock = ['RNLocalize'];
+
+      if (modulesToMock.includes(name)) {
+        return null;
+      }
+      return turboModuleRegistry.getEnforcing(name);
+    },
+  };
+});

--- a/package.json
+++ b/package.json
@@ -89,6 +89,7 @@
     "react-native-get-random-values": "^1.8.0",
     "react-native-image-picker": "^7.0.3",
     "react-native-keyboard-aware-scroll-view": "^0.9.5",
+    "react-native-localize": "^3.0.6",
     "react-native-markdown-display": "6.1.6",
     "react-native-mime-types": "^2.3.0",
     "react-native-mmkv": "2.5.1",

--- a/src/jobs/request-interception.ts
+++ b/src/jobs/request-interception.ts
@@ -2,7 +2,7 @@ import i18n from 'i18next';
 
 import { SessionModel } from '@entities/session';
 import { httpService } from '@shared/api';
-import { createJob } from '@shared/lib';
+import { createJob, TIMEZONE } from '@shared/lib';
 
 export default createJob(() => {
   httpService.interceptors.request.use(
@@ -14,6 +14,7 @@ export default createJob(() => {
       }
 
       config.headers['Content-Language'] = i18n.resolvedLanguage;
+      config.headers['X-Timezone'] = TIMEZONE;
 
       return config;
     },

--- a/src/shared/lib/constants/dateTime.ts
+++ b/src/shared/lib/constants/dateTime.ts
@@ -1,3 +1,5 @@
+import { getTimeZone } from 'react-native-localize';
+
 export const MS_IN_MINUTE = 60000;
 export const MS_IN_SECOND = 1000;
 export const SECONDS_IN_MINUTE = 60;
@@ -8,3 +10,5 @@ date.setHours(0);
 date.setMinutes(0);
 date.setSeconds(0);
 export const MIDNIGHT_DATE = date;
+
+export const TIMEZONE = getTimeZone();

--- a/yarn.lock
+++ b/yarn.lock
@@ -7170,6 +7170,11 @@ react-native-keyboard-aware-scroll-view@^0.9.5:
     prop-types "^15.6.2"
     react-native-iphone-x-helper "^1.0.3"
 
+react-native-localize@^3.0.6:
+  version "3.0.6"
+  resolved "https://registry.yarnpkg.com/react-native-localize/-/react-native-localize-3.0.6.tgz#6df2e317038c0cafe051184b2f0280f89ef8050c"
+  integrity sha512-pfwwNKRfXcxp0LZEzj5oW2/uo5oZOhiQ4PYlg8uLlsl9pDLcWg03yLCHohTWKX02vE/BFz9hkrHT/nQtlO/iFg==
+
 react-native-markdown-display@6.1.6:
   version "6.1.6"
   resolved "https://registry.yarnpkg.com/react-native-markdown-display/-/react-native-markdown-display-6.1.6.tgz#74cbc9e1e2b2169a7ca8d959883e18790ea2b2aa"


### PR DESCRIPTION
- [x] `react-native-localize` package added to MindLogger [SOUP (Software of Unknown Provenance)](https://mindlogger.atlassian.net/wiki/spaces/MINDLOGGER1/pages/262701228/Mobile+Applications)

### 📝 Description

🔗 [Jira Ticket M2-5899](https://mindlogger.atlassian.net/browse/M2-5899)

Changes include:

- [react-native-localize](https://github.com/zoontek/react-native-localize)
- X-Timezone header in the request interceptor.
