### PR TITLE
M2-6036: Timezone offset in answers

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mindlogger-mobile",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "private": true,
   "scripts": {
     "android": "yarn android:dev",

--- a/src/entities/activity/lib/services/AnswersUploadService.ts
+++ b/src/entities/activity/lib/services/AnswersUploadService.ts
@@ -388,6 +388,7 @@ class AnswersUploadService implements IAnswersUploadService {
         localEndDate: formatToDtoDate(data.endTime),
         localEndTime: formatToDtoTime(data.endTime, true),
         scheduledEventId: data.eventId,
+        tzOffset: data.tzOffset,
       },
       createdAt: data.createdAt,
       client: data.client,

--- a/src/entities/activity/lib/types/uploadAnswers.ts
+++ b/src/entities/activity/lib/types/uploadAnswers.ts
@@ -29,6 +29,7 @@ export type SendAnswersInput = {
     height: number;
   };
   alerts: AnswerAlertsDto;
+  tzOffset: number;
   logActivityName?: string;
   logCompletedAt?: string;
 };

--- a/src/shared/api/services/answerService.ts
+++ b/src/shared/api/services/answerService.ts
@@ -162,6 +162,7 @@ export type EncryptedAnswerDto = {
   scheduledEventId: string;
   localEndDate: string;
   localEndTime: string;
+  tzOffset: number;
 };
 
 export type UserActionDto = {

--- a/src/shared/lib/utils/dateTime.ts
+++ b/src/shared/lib/utils/dateTime.ts
@@ -213,3 +213,10 @@ export const getDateFromString = (dateString: string) => {
 
   return new Date(Number(year), Number(month) - 1, Number(day));
 };
+
+/**
+ *
+ * @returns The difference, in minutes, between date as evaluated in the UTC time zone
+ * but with the opposite sign which is expected by the Backend server.
+ */
+export const getTimezoneOffset = () => new Date().getTimezoneOffset() * -1;

--- a/src/widgets/survey/ui/Finish.tsx
+++ b/src/widgets/survey/ui/Finish.tsx
@@ -20,6 +20,7 @@ import {
   useAppSelector,
   MixProperties,
   MixEvents,
+  getTimezoneOffset,
 } from '@shared/lib';
 import { Center, ImageBackground, Text, Button } from '@shared/ui';
 
@@ -196,6 +197,7 @@ function FinishItem({
       alerts,
       eventId,
       isFlowCompleted: !!flowId,
+      tzOffset: getTimezoneOffset(),
     });
 
     clearActivityStorageRecord();

--- a/src/widgets/survey/ui/Intermediate.tsx
+++ b/src/widgets/survey/ui/Intermediate.tsx
@@ -28,6 +28,7 @@ import {
   useAppSelector,
   MixProperties,
   MixEvents,
+  getTimezoneOffset,
 } from '@app/shared/lib';
 import { badge } from '@assets/images';
 import { Center, YStack, Text, Button, Image, XStack } from '@shared/ui';
@@ -301,6 +302,7 @@ function Intermediate({
       alerts,
       eventId,
       isFlowCompleted: false,
+      tzOffset: getTimezoneOffset(),
     });
 
     clearActivityStorageRecord();


### PR DESCRIPTION
### 📝 Description

🔗 [Jira Ticket M2-6036](https://mindlogger.atlassian.net/browse/M2-6036)

Changes include:

- Timezone offset calculation
- Assigning the offset to the responses at the moment of finishing an activity

### ✏️ Notes

The previous implementation considered having a timezone in the request header (X-Timezone) that the Backend server picked up and stored in the DB along with the received responses.
However, in the case when the actual **moment of finishing an activity** and the actual **moment of sending the data** over to the server are different and the user changes their timezone then it may lead to unexpected data in the DB.
That is why it was decided to save a timezone offset at the moment when the user finishes the activity to keep the data consistent.