### PR TITLE
Set correct cocoapods version that works with RN 0.73

### DIFF
--- a/ios/MindloggerMobile.xcodeproj/project.pbxproj
+++ b/ios/MindloggerMobile.xcodeproj/project.pbxproj
@@ -1843,11 +1843,7 @@
 					"-DFOLLY_MOBILE=1",
 					"-DFOLLY_USE_LIBCPP=1",
 				);
-				OTHER_LDFLAGS = (
-					"$(inherited)",
-					"-Wl",
-					"-ld_classic",
-				);
+				OTHER_LDFLAGS = "$(inherited)";
 				REACT_NATIVE_PATH = "${PODS_ROOT}/../../node_modules/react-native";
 				SDKROOT = iphoneos;
 				USE_HERMES = true;
@@ -1929,11 +1925,7 @@
 					"-DFOLLY_MOBILE=1",
 					"-DFOLLY_USE_LIBCPP=1",
 				);
-				OTHER_LDFLAGS = (
-					"$(inherited)",
-					"-Wl",
-					"-ld_classic",
-				);
+				OTHER_LDFLAGS = "$(inherited)";
 				REACT_NATIVE_PATH = "${PODS_ROOT}/../../node_modules/react-native";
 				SDKROOT = iphoneos;
 				USE_HERMES = true;

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -1629,7 +1629,7 @@ SPEC CHECKSUMS:
   boost: d3f49c53809116a5d38da093a8aa78bf551aed09
   CocoaAsyncSocket: 065fd1e645c7abab64f7a6a2007a48038fdc6a99
   CocoaLumberjack: f8d89a516e7710fdb2e9b8f1560b16ec6040eef0
-  DoubleConversion: 5189b271737e1565bdce30deb4a08d647e3f5f54
+  DoubleConversion: fea03f2699887d960129cc54bba7e52542b6f953
   FBLazyVector: 84f6edbe225f38aebd9deaf1540a4160b1f087d7
   FBReactNativeSpec: d0086a479be91c44ce4687a962956a352d2dc697
   Firebase: 63ce8ece0d43743dc28eacac0c6867a2d7fd5a9d
@@ -1649,7 +1649,7 @@ SPEC CHECKSUMS:
   Flipper-PeerTalk: 116d8f857dc6ef55c7a5a75ea3ceaafe878aadc9
   FlipperKit: 2efad7007d6745a3f95e4034d547be637f89d3f6
   fmt: ff9d55029c625d3757ed641535fd4a75fedc7ce9
-  glog: 04b94705f318337d7ead9e6d17c019bd9b1f6b1b
+  glog: c5d68082e772fa1c511173d6b30a9de2c05a69a2
   GoogleDataTransport: 57c22343ab29bc686febbf7cbb13bad167c2d8fe
   GoogleUtilities: 0759d1a57ebb953965c2dfe0ba4c82e95ccc2e34
   hermes-engine: b2669ce35fc4ac14f523b307aff8896799829fe2
@@ -1739,4 +1739,4 @@ SPEC CHECKSUMS:
 
 PODFILE CHECKSUM: 407c2bad1f5a0b2a39e0f4ece4251ac7baf4239e
 
-COCOAPODS: 1.15.2
+COCOAPODS: 1.14.3


### PR DESCRIPTION
### 📝 Description

React Native 0.73.x works correctly Cocoapods of < 0.15 version because of a bug. React Native team recommends using versions >= 1.13 and < 1.15:
<img width="640" alt="image" src="https://github.com/ChildMindInstitute/mindlogger-app-refactor/assets/20073193/4becdb4f-6317-4d88-95e4-85db47e08dab">

