### PR TITLE
M2-6037: Allow to divide the space 50/50 between Drawing Example and Drawing Area  

### DIFF
--- a/src/entities/activity/lib/types/activity.ts
+++ b/src/entities/activity/lib/types/activity.ts
@@ -38,6 +38,10 @@ export type StabilityTrackerConfig = {
 type DrawingTestTestConfig = {
   imageUrl: string | null;
   backgroundImageUrl: string | null;
+  ratio: {
+    exampleImage: number;
+    canvas: number;
+  } | null;
 };
 
 type TextInputConfig = {

--- a/src/entities/activity/model/mappers.ts
+++ b/src/entities/activity/model/mappers.ts
@@ -82,6 +82,17 @@ function mapToDrawing(dto: DrawingItemDto): ActivityItem {
     config: {
       imageUrl: dto.responseValues.drawingExample,
       backgroundImageUrl: dto.responseValues.drawingBackground,
+      ratio: dto.responseValues.proportion?.enabled
+        ? /*
+           * For now, we set 1 / 1 ratio as a default value.
+           * When business requirements are ready and the backend changes are deployed,
+           * we will use the values provided by Backend.
+           */
+          {
+            exampleImage: 1,
+            canvas: 1,
+          }
+        : null,
     },
     timer: mapTimerValue(dto.config.timer),
     order: dto.order,

--- a/src/entities/drawer/ui/DrawingBoard.tsx
+++ b/src/entities/drawer/ui/DrawingBoard.tsx
@@ -17,8 +17,6 @@ const DrawingBoard: FC<Props> = props => {
 
   const vector = width / 100;
   const borderWidth = 1;
-  const paddingSize = 1;
-  const containerSize = width + borderWidth + paddingSize;
 
   const sketchCanvasRef = useRef<SketchCanvasRef | null>(null);
 
@@ -87,16 +85,15 @@ const DrawingBoard: FC<Props> = props => {
 
   return (
     <Box
-      width={containerSize}
-      height={containerSize}
+      flex={1}
       zIndex={1}
+      maxWidth={width}
       borderWidth={borderWidth}
       borderColor="$lightGrey2"
       accessibilityLabel="drawing-area"
     >
       <SketchCanvas
         ref={sketchCanvasRef}
-        width={width}
         initialLines={initialLines}
         onStrokeStart={onTouchStart}
         onStrokeChanged={onTouchProgress}

--- a/src/entities/drawer/ui/DrawingTest/DrawingTest.tsx
+++ b/src/entities/drawer/ui/DrawingTest/DrawingTest.tsx
@@ -1,0 +1,31 @@
+import { BoxProps } from '@app/shared/ui';
+import { DrawingStreamEvent, StreamEventLoggable } from '@shared/lib';
+
+import DrawingTestLegacy from './DrawingTestLegacy';
+import DrawingTestWithRatio from './DrawingTestWithRatio';
+import { DrawLine, DrawResult } from '../../lib';
+
+type Props = {
+  value: { lines: DrawLine[]; fileName: string | null };
+  imageUrl: string | null;
+  backgroundImageUrl: string | null;
+  ratio: {
+    exampleImage: number;
+    canvas: number;
+  } | null;
+  onResult: (result: DrawResult) => void;
+  toggleScroll: (isScrollEnabled: boolean) => void;
+} & StreamEventLoggable<DrawingStreamEvent> &
+  BoxProps;
+
+const DrawingTest = (props: Props) => {
+  return props.ratio ? (
+    <DrawingTestWithRatio {...props} ratio={props.ratio} />
+  ) : (
+    <DrawingTestLegacy {...props} />
+  );
+};
+
+export type DrawingTestProps = Props;
+
+export default DrawingTest;

--- a/src/entities/drawer/ui/DrawingTest/DrawingTestLegacy.tsx
+++ b/src/entities/drawer/ui/DrawingTest/DrawingTestLegacy.tsx
@@ -13,7 +13,7 @@ const RectPadding = 15;
 
 type Props = Omit<DrawingTestProps, 'ratio'>;
 
-const DrawingTest: FC<Props> = props => {
+const DrawingTestLegacy: FC<Props> = props => {
   const [width, setWidth] = useState<number | null>(null);
 
   const { value, backgroundImageUrl, imageUrl, onLog } = props;
@@ -80,4 +80,4 @@ const DrawingTest: FC<Props> = props => {
   );
 };
 
-export default DrawingTest;
+export default DrawingTestLegacy;

--- a/src/entities/drawer/ui/DrawingTest/DrawingTestLegacy.tsx
+++ b/src/entities/drawer/ui/DrawingTest/DrawingTestLegacy.tsx
@@ -3,22 +3,15 @@ import { FC, useState } from 'react';
 
 import { CachedImage } from '@georstat/react-native-image-cache';
 
-import { Box, BoxProps, XStack } from '@app/shared/ui';
-import { DrawingStreamEvent, StreamEventLoggable } from '@shared/lib';
+import { XStack, YStack } from '@app/shared/ui';
 
-import DrawingBoard from './DrawingBoard';
-import { DrawLine, DrawResult, SvgFileManager } from '../lib';
+import { DrawingTestProps } from './DrawingTest';
+import { DrawResult, SvgFileManager } from '../../lib';
+import DrawingBoard from '../DrawingBoard';
 
 const RectPadding = 15;
 
-type Props = {
-  value: { lines: DrawLine[]; fileName: string | null };
-  imageUrl: string | null;
-  backgroundImageUrl: string | null;
-  onResult: (result: DrawResult) => void;
-  toggleScroll: (isScrollEnabled: boolean) => void;
-} & StreamEventLoggable<DrawingStreamEvent> &
-  BoxProps;
+type Props = Omit<DrawingTestProps, 'ratio'>;
 
 const DrawingTest: FC<Props> = props => {
   const [width, setWidth] = useState<number | null>(null);
@@ -38,8 +31,9 @@ const DrawingTest: FC<Props> = props => {
   };
 
   return (
-    <Box
+    <YStack
       {...props}
+      alignItems="center"
       onLayout={x => {
         const containerWidth = x.nativeEvent.layout.width - RectPadding * 2;
 
@@ -65,7 +59,7 @@ const DrawingTest: FC<Props> = props => {
       )}
 
       {!!width && (
-        <XStack jc="center">
+        <XStack jc="center" width={width} height={width}>
           {!!backgroundImageUrl && (
             <CachedImage
               source={backgroundImageUrl}
@@ -82,7 +76,7 @@ const DrawingTest: FC<Props> = props => {
           />
         </XStack>
       )}
-    </Box>
+    </YStack>
   );
 };
 

--- a/src/entities/drawer/ui/DrawingTest/DrawingTestWithRatio.tsx
+++ b/src/entities/drawer/ui/DrawingTest/DrawingTestWithRatio.tsx
@@ -15,7 +15,7 @@ type Props = DrawingTestProps & {
   ratio: Ratio;
 };
 
-const DrawingTest: FC<Props> = props => {
+const DrawingTestWithRatio: FC<Props> = props => {
   const [canvasWidth, setCanvasWidth] = useState<number>(0);
 
   const { value, backgroundImageUrl, imageUrl, onLog, ratio } = props;
@@ -85,4 +85,4 @@ const styles = StyleSheet.create({
   },
 });
 
-export default DrawingTest;
+export default DrawingTestWithRatio;

--- a/src/entities/drawer/ui/DrawingTest/DrawingTestWithRatio.tsx
+++ b/src/entities/drawer/ui/DrawingTest/DrawingTestWithRatio.tsx
@@ -1,0 +1,88 @@
+import { FC, useState } from 'react';
+import { StyleSheet } from 'react-native';
+
+import { CachedImage } from '@georstat/react-native-image-cache';
+
+import { XStack, YStack } from '@app/shared/ui';
+
+import { DrawingTestProps } from './DrawingTest';
+import { DrawResult, SvgFileManager } from '../../lib';
+import DrawingBoard from '../DrawingBoard';
+
+type Ratio = NonNullable<DrawingTestProps['ratio']>;
+
+type Props = DrawingTestProps & {
+  ratio: Ratio;
+};
+
+const DrawingTest: FC<Props> = props => {
+  const [canvasWidth, setCanvasWidth] = useState<number>(0);
+
+  const { value, backgroundImageUrl, imageUrl, onLog, ratio } = props;
+
+  const onResult = async (result: DrawResult) => {
+    let fileName = value.fileName;
+
+    const fileMeta = SvgFileManager.getFileMeta(fileName);
+
+    result.fileName = fileMeta.fileName;
+    result.type = fileMeta.type;
+    result.uri = fileMeta.uri;
+
+    props.onResult(result);
+  };
+
+  return (
+    <YStack {...props} alignItems="center" flex={1}>
+      {!!imageUrl && (
+        <XStack jc="center" flex={ratio.exampleImage} mb={20}>
+          <CachedImage
+            source={imageUrl}
+            style={styles.example}
+            resizeMode="contain"
+          />
+        </XStack>
+      )}
+
+      <XStack
+        jc="center"
+        flex={ratio.canvas}
+        onLayout={e => {
+          if (!canvasWidth) {
+            setCanvasWidth(e.nativeEvent.layout.height);
+          }
+        }}
+        width={canvasWidth ? canvasWidth : 'auto'}
+      >
+        {!!backgroundImageUrl && (
+          <CachedImage
+            source={backgroundImageUrl}
+            style={styles.backgroundImage}
+            resizeMode="contain"
+          />
+        )}
+
+        <DrawingBoard
+          value={value.lines}
+          onResult={onResult}
+          width={canvasWidth}
+          onLog={onLog}
+        />
+      </XStack>
+    </YStack>
+  );
+};
+
+const styles = StyleSheet.create({
+  example: {
+    width: '100%',
+    height: '100%',
+  },
+  backgroundImage: {
+    position: 'absolute',
+    width: '100%',
+    height: '100%',
+  },
+});
+
+export default DrawingTest;

--- a/src/entities/drawer/ui/DrawingTest/index.tsx
+++ b/src/entities/drawer/ui/DrawingTest/index.tsx
@@ -1,0 +1,1 @@
+export { default as DrawingTest } from './DrawingTest';

--- a/src/entities/drawer/ui/index.ts
+++ b/src/entities/drawer/ui/index.ts
@@ -1,1 +1,1 @@
-export { default as DrawingTest } from './DrawingTest';
+export * from './DrawingTest';

--- a/src/features/pass-survey/lib/types/payload.ts
+++ b/src/features/pass-survey/lib/types/payload.ts
@@ -67,6 +67,10 @@ type SplashPayload = { imageUrl: string };
 type DrawingPayload = {
   imageUrl: string | null;
   backgroundImageUrl: string | null;
+  ratio: {
+    exampleImage: number;
+    canvas: number;
+  } | null;
 };
 
 type SliderPayload = {

--- a/src/features/pass-survey/model/hooks/mockActivities.ts
+++ b/src/features/pass-survey/model/hooks/mockActivities.ts
@@ -48,6 +48,7 @@ const grid: ActivityDto = {
         drawingExample: '',
         drawingBackground:
           'https://mindlogger-applet-contents.s3.amazonaws.com/image/9qPz3D1kyzwD2pAAHpP5Hv.jpeg',
+        proportion: null,
       },
       conditionalLogic: null,
     },
@@ -96,6 +97,7 @@ const vortex: ActivityDto = {
         drawingExample: '',
         drawingBackground:
           'https://mindlogger-applet-contents.s3.amazonaws.com/image/w93voaqZA7ZGoZryorBvQc.jpeg',
+        proportion: null,
       },
       conditionalLogic: null,
     },

--- a/src/features/pass-survey/ui/ActivityItem.tsx
+++ b/src/features/pass-survey/ui/ActivityItem.tsx
@@ -51,6 +51,8 @@ type Props = ActivityItemProps &
     context: Record<string, unknown>;
   };
 
+const HEIGHT_REDUCTION_FACTOR = 0.85;
+
 function ActivityItem({
   type,
   value,
@@ -67,6 +69,7 @@ function ActivityItem({
   const initialScrollEnabled = type !== 'StabilityTracker' && type !== 'AbTest';
 
   const [scrollEnabled, setScrollEnabled] = useState(initialScrollEnabled);
+  const [height, setHeight] = useState(0);
 
   const { sendLiveEvent } = useSendEvent(
     streamingDetails?.streamEnabled || false,
@@ -146,7 +149,7 @@ function ActivityItem({
 
     case 'DrawingTest':
       item = (
-        <Box flex={1} mb="$6">
+        <Box mb="$6" height={height * HEIGHT_REDUCTION_FACTOR}>
           <DrawingTest
             flex={1}
             {...pipelineItem.payload}
@@ -376,7 +379,15 @@ function ActivityItem({
 
   return (
     <ScrollableContent scrollEnabled={scrollEnabled}>
-      <Box flex={1} justifyContent="center">
+      <Box
+        flex={1}
+        justifyContent="center"
+        onLayout={e => {
+          if (!height) {
+            setHeight(e.nativeEvent.layout.height);
+          }
+        }}
+      >
         {question && (
           <Box mx={16} mb={20}>
             <MarkdownMessage

--- a/src/shared/api/services/ActivityItemDto.ts
+++ b/src/shared/api/services/ActivityItemDto.ts
@@ -345,6 +345,9 @@ type DrawingConfiguration = ButtonsConfiguration &
 type DrawingAnswerSettings = {
   drawingExample: string | null;
   drawingBackground: string | null;
+  proportion: {
+    enabled: boolean;
+  } | null;
 };
 
 type PhotoConfiguration = ButtonsConfiguration &

--- a/src/shared/api/services/mockActivities.ts
+++ b/src/shared/api/services/mockActivities.ts
@@ -48,6 +48,7 @@ const grid: ActivityDto = {
         drawingExample: '',
         drawingBackground:
           'https://mindlogger-applet-contents.s3.amazonaws.com/image/9qPz3D1kyzwD2pAAHpP5Hv.jpeg',
+        proportion: null,
       },
       conditionalLogic: null,
     },
@@ -96,6 +97,7 @@ const vortex: ActivityDto = {
         drawingExample: '',
         drawingBackground:
           'https://mindlogger-applet-contents.s3.amazonaws.com/image/w93voaqZA7ZGoZryorBvQc.jpeg',
+        proportion: null,
       },
       conditionalLogic: null,
     },

--- a/src/shared/ui/SketchCanvas/SketchCanvas.tsx
+++ b/src/shared/ui/SketchCanvas/SketchCanvas.tsx
@@ -1,10 +1,4 @@
-import {
-  forwardRef,
-  memo,
-  useImperativeHandle,
-  useMemo,
-  useState,
-} from 'react';
+import { forwardRef, memo, useImperativeHandle, useState } from 'react';
 import { StyleSheet } from 'react-native';
 
 import { Canvas, Group, Path, Skia, SkPath } from '@shopify/react-native-skia';
@@ -27,7 +21,6 @@ export type SketchCanvasRef = {
 
 type Props = {
   initialLines: Array<Point[]>;
-  width: number;
   onStrokeStart: (x: number, y: number, time: number) => void;
   onStrokeChanged: (x: number, y: number, time: number) => void;
   onStrokeEnd: () => void;
@@ -36,8 +29,7 @@ type Props = {
 const MAX_POINTS_PER_LINE = 50;
 
 const SketchCanvas = forwardRef<SketchCanvasRef, Props>((props, ref) => {
-  const { initialLines, width, onStrokeStart, onStrokeChanged, onStrokeEnd } =
-    props;
+  const { initialLines, onStrokeStart, onStrokeChanged, onStrokeEnd } = props;
 
   const [paths, setPaths] = useState<Array<SkPath>>(() =>
     initialLines.map(points => createPathFromPoints(points)),
@@ -49,6 +41,7 @@ const SketchCanvas = forwardRef<SketchCanvasRef, Props>((props, ref) => {
 
   const activePath = useSharedValue<SkPath>(Skia.Path.Make());
   const tempPath = useSharedValue<SkPath>(Skia.Path.Make());
+  const width = useSharedValue(0);
 
   useImperativeHandle(ref, () => {
     return {
@@ -148,18 +141,12 @@ const SketchCanvas = forwardRef<SketchCanvasRef, Props>((props, ref) => {
     { onTouchStart, onTouchProgress, onTouchEnd },
   );
 
-  const styles = useMemo(
-    () =>
-      StyleSheet.flatten({
-        width,
-        height: width,
-      }),
-    [width],
-  );
-
   return (
     <GestureDetector gesture={drawingGesture}>
-      <Canvas style={styles}>
+      <Canvas
+        style={styles.canvas}
+        onLayout={e => (width.value = e.nativeEvent.layout.width)}
+      >
         <Group>
           <DrawnPaths paths={paths} />
 
@@ -202,5 +189,11 @@ const DrawnPaths = memo(
   ),
   (prevProps, nextProps) => prevProps.paths.length === nextProps.paths.length,
 );
+
+const styles = StyleSheet.create({
+  canvas: {
+    flex: 1,
+  },
+});
 
 export default SketchCanvas;

--- a/src/shared/ui/SketchCanvas/useDrawingGesture.ts
+++ b/src/shared/ui/SketchCanvas/useDrawingGesture.ts
@@ -4,14 +4,14 @@ import {
   State as EventState,
   GestureTouchEvent,
 } from 'react-native-gesture-handler';
-import { useSharedValue } from 'react-native-reanimated';
+import { SharedValue, useSharedValue } from 'react-native-reanimated';
 
 import { IS_IOS } from '@app/shared/lib';
 
 import { Point } from './LineSketcher';
 
 type Options = {
-  areaSize: number;
+  areaSize: SharedValue<number>;
 };
 
 type Callbacks = {
@@ -40,7 +40,10 @@ function useDrawingGesture(
   const isOutOfCanvas = (point: Point) => {
     'worklet';
     return (
-      point.x > areaSize || point.y > areaSize || point.x < 0 || point.y < 0
+      point.x > areaSize.value ||
+      point.y > areaSize.value ||
+      point.x < 0 ||
+      point.y < 0
     );
   };
 
@@ -54,8 +57,8 @@ function useDrawingGesture(
         return 0 + deviation;
       }
 
-      if (value > areaSize) {
-        return areaSize - deviation;
+      if (value > areaSize.value) {
+        return areaSize.value - deviation;
       }
 
       return value;


### PR DESCRIPTION
### 📝 Description

🔗 [Jira Ticket M2-6037](https://mindlogger.atlassian.net/browse/M2-6037)

Changes include:

- Support for the previous approach when the Example Image was of fixed size (300px) and the Drawing Canvas took over most of the screen. Named it `DrawingTestLegacy`
- Add a `DrawingTestWithRatio` component with a brand new layout that supports the ratio between the Drawing Canvas and the Example Image
- Backend integration
- Default 1 / 1 ratio value provided the Drawing Item has been configured to have a ratio.

### 📸 Screenshots

<!--
If your work here contains visual changes, provide before (optional) and after screenshots, GIFs, or videos.

If not, then delete this section
-->

| Before (Legacy Approach)                    | After (New Approach)                                |
| -------------------------------------- | ------------------------------------- |
| ![image](https://github.com/ChildMindInstitute/mindlogger-app-refactor/assets/20073193/6cb0311c-5779-4aeb-b06f-7c95eb3210e0) | ![image](https://github.com/ChildMindInstitute/mindlogger-app-refactor/assets/20073193/77d2c571-b256-47eb-b608-6776b509d874) |

### 🪤 Peer Testing

To explore the new view do the following steps:
- add an Example Image to the Drawing Item on the Admin Panel. Save it.
- go to src/entities/activity/model/mappers.ts
- navigate `mapToDrawing` function
- Change the boolean sign here:
`ratio: dto.responseValues.proportion?.enabled`
to this:
`ratio: !dto.responseValues.proportion?.enabled
`