### PR TITLE
M2-6230: [Mobile app] Responses for Activity1 of Activity flow aren't…

### DIFF
--- a/src/widgets/survey/model/services/ConstructCompletionsService.ts
+++ b/src/widgets/survey/model/services/ConstructCompletionsService.ts
@@ -162,6 +162,10 @@ export class ConstructCompletionsService {
     activityStorageRecord: ActivityState,
     { activityName, activityId, order }: ConstructForIntermediateInput,
   ) {
+    if (!this.saveActivitySummary) {
+      return;
+    }
+
     const summaryAlerts: AnswerAlerts =
       PassSurveyModel.AlertsExtractor.extractForSummary(
         activityStorageRecord.items,


### PR DESCRIPTION
### 📝 Description

🔗 [Jira Ticket M2-6230](https://mindlogger.atlassian.net/browse/M2-6230)

<!-- Replace this with a high-level description of the features/functionality proposed in the pull request. -->

Changes include:
Check for null was missed. We have this function set to instance only when the construction service is build from Intermediate screen. The summary data is collected and required only on UI Summary compoment. It's not send to api and not needed anywhere else. That's why we do not need to collect it in case of autocompletion at all.

- Fix for construct of the intermediate upload item
