### PR TITLE
M2-6377: A/B Trails: There is extra 'press_done' event when round was skipped

### DIFF
--- a/src/features/pass-survey/ui/ActivityStepper.tsx
+++ b/src/features/pass-survey/ui/ActivityStepper.tsx
@@ -249,8 +249,10 @@ function ActivityStepper({
     onClose('click-on-return');
   };
 
-  const onEndReached = (isForced: boolean) => {
-    if (!isForced) {
+  const onEndReached = (isForced: boolean, payload?: StepperPayload) => {
+    const { shouldIgnoreUserActionTrack = false } = payload || {};
+
+    if (!isForced && !shouldIgnoreUserActionTrack) {
       trackUserAction(userActionCreator.done());
     }
     onFinish('regular');

--- a/src/shared/ui/Stepper/index.tsx
+++ b/src/shared/ui/Stepper/index.tsx
@@ -36,7 +36,7 @@ type Props = PropsWithChildren<{
   onBeforeBack?: (step: number) => number;
 
   onStartReached?: () => void;
-  onEndReached?: (isForced: boolean) => void;
+  onEndReached?: (isForced: boolean, payload?: StepperPayload) => void;
 }>;
 
 export function Stepper({
@@ -103,7 +103,7 @@ export function Stepper({
           return;
         }
 
-        onEndReachedRef.current?.(isForced);
+        onEndReachedRef.current?.(isForced, payload);
       }
     },
     [stepsCount],


### PR DESCRIPTION
### 📝 Description

🔗 [Jira Ticket M2-6377](https://mindlogger.atlassian.net/browse/M2-6377)

Changes include:

- A/B Trails - Not adding "DONE" event to userActions when user clicks skip on the last round of AbTrails

### ✏️ Notes

Added payload to onEndReached function , which includes shouldIgnoreUserActionTrack: boolean value.