### PR TITLE
M2-6037: Allow to divide the space 50/50 between Drawing Example and Drawing Area

### DIFF
--- a/jest.config.ts
+++ b/jest.config.ts
@@ -19,7 +19,7 @@ const jestConfig: JestConfigWithTsJest = {
   transformIgnorePatterns: [
     'node_modules/(?!(jest-)?@?react-native|@react-native-community|@react-navigation|@react-native-device-info|@notifee|@miblanchard/react-native-slider|victory-*|@shopify/react-native-skia|react-native-reanimated)',
   ],
-  setupFiles: ['<rootDir>/jest.setup.js'],
+  setupFiles: ['<rootDir>/jest.setup.js', '<rootDir>/jest.components.jsx'],
   moduleDirectories: ['node_modules', '<rootDir>'],
   moduleNameMapper: {
     ...pathsToModuleNameMapper({

--- a/jest.setup.js
+++ b/jest.setup.js
@@ -1,8 +1,6 @@
 import { jest } from '@jest/globals';
 import mockRNDeviceInfo from 'react-native-device-info/jest/react-native-device-info-mock';
 
-import './jest.components.jsx';
-
 jest.mock('react-native-file-access', () => {
   return {
     FileSystem: {

--- a/src/entities/drawer/lib/utils/constants.ts
+++ b/src/entities/drawer/lib/utils/constants.ts
@@ -1,0 +1,4 @@
+export const RECT_PADDING = 15;
+export const CANVAS_HEIGHT_FACTOR = 0.62;
+export const EXAMPLE_HEIGHT_FACTOR = 0.38;
+export const ELEMENTS_GAP = 20;

--- a/src/entities/drawer/lib/utils/helpers.ts
+++ b/src/entities/drawer/lib/utils/helpers.ts
@@ -1,6 +1,12 @@
 import { Skia, SkPath } from '@shopify/react-native-skia';
 
 import { getBezierArray } from './bezier';
+import {
+  CANVAS_HEIGHT_FACTOR,
+  ELEMENTS_GAP,
+  EXAMPLE_HEIGHT_FACTOR,
+  RECT_PADDING,
+} from './constants';
 import { DrawLine, Point } from '../types';
 
 export const convertToSkPaths = (
@@ -44,4 +50,69 @@ export const getChunkedPointsAsStrings = (lines: DrawLine[]) => {
     }
   }
   return results;
+};
+
+export type Dimensions = {
+  width: number;
+  height: number;
+};
+
+export const getCanvasSize = (
+  dimensions: Dimensions,
+  hasExampleImage: boolean,
+) => {
+  const factor = hasExampleImage ? CANVAS_HEIGHT_FACTOR : 1;
+  const canvasHeight = dimensions.height * factor - ELEMENTS_GAP;
+  const containerWidth = dimensions.width - RECT_PADDING * 2;
+
+  let result = canvasHeight;
+
+  if (canvasHeight > containerWidth) {
+    result = containerWidth;
+  } else if (containerWidth > canvasHeight) {
+    result = canvasHeight;
+  }
+
+  return result;
+};
+
+export const getExampleImageSize = (
+  height: number,
+  hasExampleImage: boolean,
+) => {
+  return hasExampleImage ? height * EXAMPLE_HEIGHT_FACTOR : 0;
+};
+
+export const getCanvasContainerHeight = (
+  dimensions: Dimensions,
+  hasExampleImage: boolean,
+) => {
+  return (
+    (hasExampleImage
+      ? dimensions.height * CANVAS_HEIGHT_FACTOR
+      : dimensions.height) - ELEMENTS_GAP
+  );
+};
+
+export const getElementsDimensions = (
+  dimensions: Dimensions,
+  hasExampleImage: boolean,
+) => {
+  const exampleImageHeight = getExampleImageSize(
+    dimensions.height,
+    hasExampleImage,
+  );
+
+  const canvasContainerHeight = getCanvasContainerHeight(
+    dimensions,
+    hasExampleImage,
+  );
+
+  const canvasSize = getCanvasSize(dimensions, hasExampleImage);
+
+  return {
+    exampleImageHeight,
+    canvasContainerHeight,
+    canvasSize,
+  };
 };

--- a/src/entities/drawer/lib/utils/helpers.ts
+++ b/src/entities/drawer/lib/utils/helpers.ts
@@ -1,39 +1,10 @@
-import { Skia, SkPath } from '@shopify/react-native-skia';
-
-import { getBezierArray } from './bezier';
 import {
   CANVAS_HEIGHT_FACTOR,
   ELEMENTS_GAP,
   EXAMPLE_HEIGHT_FACTOR,
   RECT_PADDING,
 } from './constants';
-import { DrawLine, Point } from '../types';
-
-export const convertToSkPaths = (
-  lines: DrawLine[],
-  startFrom: number,
-): SkPath[] => {
-  const skPaths: SkPath[] = [];
-
-  for (let line of lines.slice(startFrom)) {
-    if (!line.points.length) {
-      continue;
-    }
-
-    const curvePoints: Point[] = getBezierArray(line.points, []);
-
-    const { x, y } = curvePoints[0];
-
-    const path = Skia.Path.Make().moveTo(x, y);
-
-    for (let point of curvePoints.slice(1)) {
-      path.lineTo(point.x, point.y);
-    }
-    skPaths.push(path);
-  }
-
-  return skPaths;
-};
+import { DrawLine } from '../types';
 
 export const getChunkedPointsAsStrings = (lines: DrawLine[]) => {
   const results: string[] = [];
@@ -57,40 +28,23 @@ export type Dimensions = {
   height: number;
 };
 
-export const getCanvasSize = (
-  dimensions: Dimensions,
-  hasExampleImage: boolean,
-) => {
+const getCanvasSize = (dimensions: Dimensions, hasExampleImage: boolean) => {
   const factor = hasExampleImage ? CANVAS_HEIGHT_FACTOR : 1;
   const canvasHeight = dimensions.height * factor - ELEMENTS_GAP;
   const containerWidth = dimensions.width - RECT_PADDING * 2;
 
-  let result = canvasHeight;
-
-  if (canvasHeight > containerWidth) {
-    result = containerWidth;
-  } else if (containerWidth > canvasHeight) {
-    result = canvasHeight;
-  }
+  const result = canvasHeight > containerWidth ? containerWidth : canvasHeight;
 
   return result;
 };
 
-export const getExampleImageSize = (
-  height: number,
-  hasExampleImage: boolean,
-) => {
+const getExampleImageSize = (height: number, hasExampleImage: boolean) => {
   return hasExampleImage ? height * EXAMPLE_HEIGHT_FACTOR : 0;
 };
 
-export const getCanvasContainerHeight = (
-  dimensions: Dimensions,
-  hasExampleImage: boolean,
-) => {
+const getCanvasContainerHeight = (height: number, hasExampleImage: boolean) => {
   return (
-    (hasExampleImage
-      ? dimensions.height * CANVAS_HEIGHT_FACTOR
-      : dimensions.height) - ELEMENTS_GAP
+    (hasExampleImage ? height * CANVAS_HEIGHT_FACTOR : height) - ELEMENTS_GAP
   );
 };
 
@@ -104,7 +58,7 @@ export const getElementsDimensions = (
   );
 
   const canvasContainerHeight = getCanvasContainerHeight(
-    dimensions,
+    dimensions.height,
     hasExampleImage,
   );
 

--- a/src/entities/drawer/lib/utils/index.ts
+++ b/src/entities/drawer/lib/utils/index.ts
@@ -1,4 +1,5 @@
 export * from './helpers';
 export * from './bezier';
+export * from './constants';
 export { default as ResponseSerializer } from './serialization';
 export { default as SvgFileManager } from './SvgFileManager';

--- a/src/entities/drawer/test/helpers.test.ts
+++ b/src/entities/drawer/test/helpers.test.ts
@@ -1,0 +1,153 @@
+import { DrawLine, DrawPoint } from '../lib';
+import {
+  getChunkedPointsAsStrings,
+  getElementsDimensions,
+} from '../lib/utils/helpers';
+
+describe('Test getElementsDimensions function', () => {
+  const testCases = [
+    {
+      dimensions: {
+        width: 300,
+        height: 800,
+      },
+      hasExampleImage: true,
+    },
+    {
+      dimensions: {
+        width: 800,
+        height: 800,
+      },
+      hasExampleImage: true,
+    },
+    {
+      dimensions: {
+        width: 300,
+        height: 800,
+      },
+      hasExampleImage: false,
+    },
+    {
+      dimensions: {
+        width: 800,
+        height: 800,
+      },
+      hasExampleImage: false,
+    },
+  ];
+
+  const expectedResults = [
+    {
+      exampleImageHeight: 304,
+      canvasContainerHeight: 476,
+      canvasSize: 270,
+    },
+    {
+      exampleImageHeight: 304,
+      canvasContainerHeight: 476,
+      canvasSize: 476,
+    },
+    {
+      exampleImageHeight: 0,
+      canvasContainerHeight: 780,
+      canvasSize: 270,
+    },
+    {
+      exampleImageHeight: 0,
+      canvasContainerHeight: 780,
+      canvasSize: 770,
+    },
+  ];
+
+  testCases.forEach((testCase, i) => {
+    const expectedResult = expectedResults[i];
+
+    it(`should return exampleImageHeight: ${
+      expectedResult.exampleImageHeight
+    }, canvasContainerHeight: ${
+      expectedResult.canvasContainerHeight
+    }, canvasSize: ${expectedResult.canvasSize} when height is ${
+      testCase.dimensions.height
+    }, width is ${testCase.dimensions.width} and the example image is ${
+      testCase.hasExampleImage ? '' : 'NOT'
+    } present`, () => {
+      expect(
+        getElementsDimensions(testCase.dimensions, testCase.hasExampleImage),
+      ).toMatchObject(expectedResult);
+    });
+  });
+});
+
+describe('Test getChunkedPointsAsStrings function', () => {
+  it('should return an empty array when lines array is empty', () => {
+    const lines: DrawLine[] = [];
+
+    expect(getChunkedPointsAsStrings(lines)).toEqual([]);
+  });
+
+  it('should correctly chunk points into strings', () => {
+    const points: DrawPoint[] = [
+      { x: 1, y: 1, time: 0 },
+      { x: 2, y: 2, time: 1 },
+      { x: 3, y: 3, time: 2 },
+      { x: 4, y: 4, time: 3 },
+      { x: 5, y: 5, time: 4 },
+    ];
+
+    const lines: DrawLine[] = [{ points, startTime: 0 }];
+
+    const expected = ['1,1 2,2 3,3 4,4 5,5'];
+
+    expect(getChunkedPointsAsStrings(lines)).toEqual(expected);
+  });
+
+  it('should correctly chunk points into strings with two lines', () => {
+    const points1: DrawPoint[] = [
+      { x: 1, y: 1, time: 0 },
+      { x: 2, y: 2, time: 1 },
+      { x: 3, y: 3, time: 2 },
+    ];
+
+    const points2: DrawPoint[] = [
+      { x: 4, y: 4, time: 3 },
+      { x: 5, y: 5, time: 4 },
+      { x: 6, y: 6, time: 5 },
+    ];
+
+    const lines: DrawLine[] = [
+      { points: points1, startTime: 0 },
+      { points: points2, startTime: 6 },
+    ];
+
+    const expected = ['1,1 2,2 3,3', '4,4 5,5 6,6'];
+
+    expect(getChunkedPointsAsStrings(lines)).toEqual(expected);
+  });
+
+  it('should correctly chunk points into strings with three lines', () => {
+    const points1: DrawPoint[] = [
+      { x: 1, y: 1, time: 0 },
+      { x: 2, y: 2, time: 1 },
+    ];
+
+    const points2: DrawPoint[] = [
+      { x: 3, y: 3, time: 2 },
+      { x: 4, y: 4, time: 3 },
+    ];
+
+    const points3: DrawPoint[] = [
+      { x: 5, y: 5, time: 4 },
+      { x: 6, y: 6, time: 5 },
+    ];
+
+    const lines: DrawLine[] = [
+      { points: points1, startTime: 0 },
+      { points: points2, startTime: 2 },
+      { points: points3, startTime: 4 },
+    ];
+
+    const expected = ['1,1 2,2', '3,3 4,4', '5,5 6,6'];
+
+    expect(getChunkedPointsAsStrings(lines)).toEqual(expected);
+  });
+});

--- a/src/entities/drawer/ui/DrawingBoard.tsx
+++ b/src/entities/drawer/ui/DrawingBoard.tsx
@@ -17,8 +17,6 @@ const DrawingBoard: FC<Props> = props => {
 
   const vector = width / 100;
   const borderWidth = 1;
-  const paddingSize = 1;
-  const containerSize = width + borderWidth + paddingSize;
 
   const sketchCanvasRef = useRef<SketchCanvasRef | null>(null);
 
@@ -87,16 +85,15 @@ const DrawingBoard: FC<Props> = props => {
 
   return (
     <Box
-      width={containerSize}
-      height={containerSize}
+      flex={1}
       zIndex={1}
+      maxWidth={width}
       borderWidth={borderWidth}
       borderColor="$lightGrey2"
       accessibilityLabel="drawing-area"
     >
       <SketchCanvas
         ref={sketchCanvasRef}
-        width={width}
         initialLines={initialLines}
         onStrokeStart={onTouchStart}
         onStrokeChanged={onTouchProgress}

--- a/src/features/pass-survey/ui/ActivityItem.tsx
+++ b/src/features/pass-survey/ui/ActivityItem.tsx
@@ -67,6 +67,8 @@ function ActivityItem({
   const initialScrollEnabled = type !== 'StabilityTracker' && type !== 'AbTest';
 
   const [scrollEnabled, setScrollEnabled] = useState(initialScrollEnabled);
+  const [height, setHeight] = useState(0);
+  const [width, setWidth] = useState(0);
 
   const { sendLiveEvent } = useSendEvent(
     streamingDetails?.streamEnabled || false,
@@ -145,10 +147,17 @@ function ActivityItem({
       break;
 
     case 'DrawingTest':
-      item = (
-        <Box flex={1} mb="$6">
+      const heightReductionFactor = 0.85;
+      const itemHeight = height * heightReductionFactor;
+
+      item = height ? (
+        <Box height={itemHeight} mb="$6">
           <DrawingTest
             flex={1}
+            dimensions={{
+              height: itemHeight,
+              width,
+            }}
             {...pipelineItem.payload}
             toggleScroll={setScrollEnabled}
             value={{
@@ -159,7 +168,7 @@ function ActivityItem({
             onLog={processLiveEvent}
           />
         </Box>
-      );
+      ) : null;
       break;
 
     case 'Flanker':
@@ -376,7 +385,16 @@ function ActivityItem({
 
   return (
     <ScrollableContent scrollEnabled={scrollEnabled}>
-      <Box flex={1} justifyContent="center">
+      <Box
+        flex={1}
+        justifyContent="center"
+        onLayout={e => {
+          if (!height) {
+            setHeight(e.nativeEvent.layout.height);
+            setWidth(e.nativeEvent.layout.width);
+          }
+        }}
+      >
         {question && (
           <Box mx={16} mb={20}>
             <MarkdownMessage

--- a/src/shared/ui/SketchCanvas/SketchCanvas.tsx
+++ b/src/shared/ui/SketchCanvas/SketchCanvas.tsx
@@ -1,10 +1,4 @@
-import {
-  forwardRef,
-  memo,
-  useImperativeHandle,
-  useMemo,
-  useState,
-} from 'react';
+import { forwardRef, memo, useImperativeHandle, useState } from 'react';
 import { StyleSheet } from 'react-native';
 
 import { Canvas, Group, Path, Skia, SkPath } from '@shopify/react-native-skia';
@@ -27,7 +21,6 @@ export type SketchCanvasRef = {
 
 type Props = {
   initialLines: Array<Point[]>;
-  width: number;
   onStrokeStart: (x: number, y: number, time: number) => void;
   onStrokeChanged: (x: number, y: number, time: number) => void;
   onStrokeEnd: () => void;
@@ -36,8 +29,7 @@ type Props = {
 const MAX_POINTS_PER_LINE = 50;
 
 const SketchCanvas = forwardRef<SketchCanvasRef, Props>((props, ref) => {
-  const { initialLines, width, onStrokeStart, onStrokeChanged, onStrokeEnd } =
-    props;
+  const { initialLines, onStrokeStart, onStrokeChanged, onStrokeEnd } = props;
 
   const [paths, setPaths] = useState<Array<SkPath>>(() =>
     initialLines.map(points => createPathFromPoints(points)),
@@ -49,6 +41,8 @@ const SketchCanvas = forwardRef<SketchCanvasRef, Props>((props, ref) => {
 
   const activePath = useSharedValue<SkPath>(Skia.Path.Make());
   const tempPath = useSharedValue<SkPath>(Skia.Path.Make());
+
+  const width = useSharedValue(0);
 
   useImperativeHandle(ref, () => {
     return {
@@ -148,18 +142,12 @@ const SketchCanvas = forwardRef<SketchCanvasRef, Props>((props, ref) => {
     { onTouchStart, onTouchProgress, onTouchEnd },
   );
 
-  const styles = useMemo(
-    () =>
-      StyleSheet.flatten({
-        width,
-        height: width,
-      }),
-    [width],
-  );
-
   return (
     <GestureDetector gesture={drawingGesture}>
-      <Canvas style={styles}>
+      <Canvas
+        style={styles.canvas}
+        onLayout={e => (width.value = e.nativeEvent.layout.width)}
+      >
         <Group>
           <DrawnPaths paths={paths} />
 
@@ -202,5 +190,11 @@ const DrawnPaths = memo(
   ),
   (prevProps, nextProps) => prevProps.paths.length === nextProps.paths.length,
 );
+
+const styles = StyleSheet.create({
+  canvas: {
+    flex: 1,
+  },
+});
 
 export default SketchCanvas;

--- a/src/shared/ui/SketchCanvas/useDrawingGesture.ts
+++ b/src/shared/ui/SketchCanvas/useDrawingGesture.ts
@@ -4,14 +4,14 @@ import {
   State as EventState,
   GestureTouchEvent,
 } from 'react-native-gesture-handler';
-import { useSharedValue } from 'react-native-reanimated';
+import { SharedValue, useSharedValue } from 'react-native-reanimated';
 
 import { IS_IOS } from '@app/shared/lib';
 
 import { Point } from './LineSketcher';
 
 type Options = {
-  areaSize: number;
+  areaSize: SharedValue<number>;
 };
 
 type Callbacks = {
@@ -40,7 +40,10 @@ function useDrawingGesture(
   const isOutOfCanvas = (point: Point) => {
     'worklet';
     return (
-      point.x > areaSize || point.y > areaSize || point.x < 0 || point.y < 0
+      point.x > areaSize.value ||
+      point.y > areaSize.value ||
+      point.x < 0 ||
+      point.y < 0
     );
   };
 
@@ -54,8 +57,8 @@ function useDrawingGesture(
         return 0 + deviation;
       }
 
-      if (value > areaSize) {
-        return areaSize - deviation;
+      if (value > areaSize.value) {
+        return areaSize.value - deviation;
       }
 
       return value;


### PR DESCRIPTION
### 📝 Description

🔗 [Jira Ticket M2-6037](https://mindlogger.atlassian.net/browse/M2-6037)

Changes include:

- Changed the`DrawingTest` component with a brand new layout that supports the ratio between the Drawing Canvas and the Example Image
- Unit tests
- Default 0.38 / 0.62 ratio

### 📸 Screenshots

<!--
If your work here contains visual changes, provide before (optional) and after screenshots, GIFs, or videos.

If not, then delete this section
-->

| (New Approach)                                |
| ------------------------------------- |
| ![image](https://github.com/ChildMindInstitute/mindlogger-app-refactor/assets/20073193/effa407e-f951-4c5f-983a-8084a4446c30) |
