### PR TITLE
M2-6440, M2-6442, M2-6437: Fixed layout for very narrow example images

### DIFF
--- a/src/entities/drawer/lib/utils/helpers.ts
+++ b/src/entities/drawer/lib/utils/helpers.ts
@@ -1,3 +1,5 @@
+import { ImageDimensions } from '@app/shared/lib';
+
 import {
   CANVAS_HEIGHT_FACTOR,
   ELEMENTS_GAP,
@@ -28,18 +30,33 @@ export type Dimensions = {
   height: number;
 };
 
-const getCanvasSize = (dimensions: Dimensions, hasExampleImage: boolean) => {
+const getCanvasSize = (
+  itemDimensions: Dimensions,
+  hasExampleImage: boolean,
+) => {
   const factor = hasExampleImage ? CANVAS_HEIGHT_FACTOR : 1;
-  const canvasHeight = dimensions.height * factor - ELEMENTS_GAP;
-  const containerWidth = dimensions.width - RECT_PADDING * 2;
+  const canvasHeight = itemDimensions.height * factor - ELEMENTS_GAP;
+  const containerWidth = itemDimensions.width - RECT_PADDING * 2;
 
   const result = canvasHeight > containerWidth ? containerWidth : canvasHeight;
 
   return result;
 };
 
-const getExampleImageSize = (height: number, hasExampleImage: boolean) => {
-  return hasExampleImage ? height * EXAMPLE_HEIGHT_FACTOR : 0;
+const getExampleImageSize = (
+  itemDimensions: Dimensions,
+  exampleImageDimensions: ImageDimensions | null,
+) => {
+  if (!exampleImageDimensions) {
+    return 0;
+  }
+
+  const maxHeight = itemDimensions.height * EXAMPLE_HEIGHT_FACTOR;
+  const height = Math.floor(
+    itemDimensions.width / exampleImageDimensions.aspectRatio,
+  );
+
+  return height > maxHeight ? maxHeight : height;
 };
 
 const getCanvasContainerHeight = (height: number, hasExampleImage: boolean) => {
@@ -49,20 +66,20 @@ const getCanvasContainerHeight = (height: number, hasExampleImage: boolean) => {
 };
 
 export const getElementsDimensions = (
-  dimensions: Dimensions,
-  hasExampleImage: boolean,
+  itemDimensions: Dimensions,
+  exampleImageDimensions: ImageDimensions | null,
 ) => {
   const exampleImageHeight = getExampleImageSize(
-    dimensions.height,
-    hasExampleImage,
+    itemDimensions,
+    exampleImageDimensions,
   );
 
   const canvasContainerHeight = getCanvasContainerHeight(
-    dimensions.height,
-    hasExampleImage,
+    itemDimensions.height,
+    !!exampleImageDimensions,
   );
 
-  const canvasSize = getCanvasSize(dimensions, hasExampleImage);
+  const canvasSize = getCanvasSize(itemDimensions, !!exampleImageDimensions);
 
   return {
     exampleImageHeight,

--- a/src/entities/drawer/test/helpers.test.ts
+++ b/src/entities/drawer/test/helpers.test.ts
@@ -11,41 +11,81 @@ describe('Test getElementsDimensions function', () => {
         width: 300,
         height: 800,
       },
-      hasExampleImage: true,
+      exampleImageDimensions: {
+        width: 300,
+        height: 300,
+        aspectRatio: 1,
+      },
     },
     {
       dimensions: {
         width: 800,
         height: 800,
       },
-      hasExampleImage: true,
+      exampleImageDimensions: {
+        width: 800,
+        height: 300,
+        aspectRatio: 2.666667,
+      },
     },
     {
       dimensions: {
         width: 300,
         height: 800,
       },
-      hasExampleImage: false,
+      exampleImageDimensions: {
+        width: 300,
+        height: 800,
+        aspectRatio: 0.375,
+      },
+    },
+    {
+      dimensions: {
+        width: 300,
+        height: 800,
+      },
+      exampleImageDimensions: {
+        width: 200,
+        height: 100,
+        aspectRatio: 2,
+      },
+    },
+    {
+      dimensions: {
+        width: 300,
+        height: 800,
+      },
+      exampleImageDimensions: null,
     },
     {
       dimensions: {
         width: 800,
         height: 800,
       },
-      hasExampleImage: false,
+      exampleImageDimensions: null,
     },
   ];
 
   const expectedResults = [
+    {
+      exampleImageHeight: 300,
+      canvasContainerHeight: 476,
+      canvasSize: 270,
+    },
+    {
+      exampleImageHeight: 299,
+      canvasContainerHeight: 476,
+      canvasSize: 476,
+    },
     {
       exampleImageHeight: 304,
       canvasContainerHeight: 476,
       canvasSize: 270,
     },
     {
-      exampleImageHeight: 304,
+      exampleImageHeight: 150,
       canvasContainerHeight: 476,
-      canvasSize: 476,
+      canvasSize: 270,
     },
     {
       exampleImageHeight: 0,
@@ -69,10 +109,13 @@ describe('Test getElementsDimensions function', () => {
     }, canvasSize: ${expectedResult.canvasSize} when height is ${
       testCase.dimensions.height
     }, width is ${testCase.dimensions.width} and the example image is ${
-      testCase.hasExampleImage ? '' : 'NOT'
+      testCase.exampleImageDimensions ? '' : 'NOT'
     } present`, () => {
       expect(
-        getElementsDimensions(testCase.dimensions, testCase.hasExampleImage),
+        getElementsDimensions(
+          testCase.dimensions,
+          testCase.exampleImageDimensions,
+        ),
       ).toMatchObject(expectedResult);
     });
   });

--- a/src/entities/drawer/ui/DrawingTest.tsx
+++ b/src/entities/drawer/ui/DrawingTest.tsx
@@ -1,10 +1,13 @@
 import { FC } from 'react';
-import { StyleSheet } from 'react-native';
 
 import { CachedImage } from '@georstat/react-native-image-cache';
 
 import { BoxProps, XStack, YStack } from '@app/shared/ui';
-import { DrawingStreamEvent, StreamEventLoggable } from '@shared/lib';
+import {
+  DrawingStreamEvent,
+  StreamEventLoggable,
+  useImageDimensions,
+} from '@shared/lib';
 
 import DrawingBoard from './DrawingBoard';
 import {
@@ -43,23 +46,30 @@ const DrawingTest: FC<Props> = props => {
     props.onResult(result);
   };
 
+  const {
+    dimensions: exampleImageDimensions,
+    isLoading: isEvaluatingDimensions,
+  } = useImageDimensions(imageUrl);
+
   const { exampleImageHeight, canvasContainerHeight, canvasSize } =
-    getElementsDimensions(props.dimensions, !!imageUrl);
+    getElementsDimensions(props.dimensions, exampleImageDimensions);
+
+  const height = exampleImageHeight + canvasContainerHeight + ELEMENTS_GAP;
 
   return (
-    <YStack {...props} alignItems="center" space={ELEMENTS_GAP}>
+    <YStack {...props} height={height} alignItems="center" space={ELEMENTS_GAP}>
       {!!imageUrl && (
-        <XStack jc="center" height={exampleImageHeight}>
+        <XStack height={exampleImageHeight}>
           <CachedImage
             source={imageUrl}
-            style={styles.exampleImage}
+            style={{ height: exampleImageHeight, width: canvasSize }}
             resizeMode="contain"
           />
         </XStack>
       )}
 
       <YStack height={canvasContainerHeight}>
-        {!!canvasSize && (
+        {!!canvasSize && !isEvaluatingDimensions && (
           <XStack width={canvasSize} height={canvasSize}>
             {!!backgroundImageUrl && (
               <CachedImage
@@ -88,12 +98,5 @@ const canvasStyles = (canvasSize: number) =>
     width: canvasSize,
     height: canvasSize,
   }) as const;
-
-const styles = StyleSheet.create({
-  exampleImage: {
-    width: '100%',
-    height: '100%',
-  },
-});
 
 export default DrawingTest;

--- a/src/features/pass-survey/ui/ActivityItem.tsx
+++ b/src/features/pass-survey/ui/ActivityItem.tsx
@@ -151,9 +151,8 @@ function ActivityItem({
       const itemHeight = height * heightReductionFactor;
 
       item = height ? (
-        <Box height={itemHeight} mb="$6">
+        <Box flex={1} mb="$6">
           <DrawingTest
-            flex={1}
             dimensions={{
               height: itemHeight,
               width,

--- a/src/shared/lib/hooks/index.ts
+++ b/src/shared/lib/hooks/index.ts
@@ -28,4 +28,5 @@ export { default as useOnceRef } from './useOnceRef';
 export { default as useUploadObservable } from './useUploadObservable';
 export { default as useToast } from './useToast';
 
+export * from './useImageDimensions';
 export * from './redux';

--- a/src/shared/lib/hooks/useImageDimensions.ts
+++ b/src/shared/lib/hooks/useImageDimensions.ts
@@ -1,0 +1,27 @@
+import { useImageDimensions as useImageDimensionsBase } from '@react-native-community/hooks';
+
+export type ImageDimensions = {
+  width: number;
+  height: number;
+  aspectRatio: number;
+};
+
+type UseImageDimensionsReturn = {
+  dimensions: ImageDimensions | null;
+  isLoading: boolean;
+};
+
+export function useImageDimensions(
+  url: string | null,
+): UseImageDimensionsReturn {
+  const result = useImageDimensionsBase({ uri: url ?? '' });
+
+  if (result.error) {
+    return { dimensions: null, isLoading: false };
+  }
+
+  return {
+    dimensions: result.dimensions ?? null,
+    isLoading: result.loading,
+  };
+}


### PR DESCRIPTION
https://mindlogger.atlassian.net/browse/M2-6440 https://mindlogger.atlassian.net/browse/M2-6442

- [x] Tests for the changes have been added


### 📝 Description

🔗 [Jira Ticket M2-6440](https://mindlogger.atlassian.net/browse/M2-6440)
🔗 [Jira Ticket M2-6442](https://mindlogger.atlassian.net/browse/M2-6442)
🔗 [Jira Ticket M2-6442](https://mindlogger.atlassian.net/browse/M2-6437)

Changed the algorithm responsible for calculating elements so that it:
- works out the example image height: the example image should have a real height within but not exceeding 38% of the drawing component’s height
- sets the height of the drawing item that should not exceed the sum of the example image height and the canvas board.

### 📸 Screenshots
![image](https://github.com/ChildMindInstitute/mindlogger-app-refactor/assets/20073193/9425dd7f-85d9-41a6-b94b-32c9bcccd24f)
![image](https://github.com/ChildMindInstitute/mindlogger-app-refactor/assets/20073193/8b527f6e-f7c4-4901-8cee-b5722fbbfa49)
![image](https://github.com/ChildMindInstitute/mindlogger-app-refactor/assets/20073193/9785a698-d971-4438-9383-8307384b6006)
