### PR TITLE
M2-6301: NIMH Applet Scheduling is not working as expected

### DIFF
--- a/src/entities/applet/model/slice.ts
+++ b/src/entities/applet/model/slice.ts
@@ -25,6 +25,10 @@ type InProgressEntity = {
   eventId: string;
 };
 
+type CompletionFixation = {
+  endAt: number;
+};
+
 type InProgressFlow = {
   appletId: string;
   flowId: string;
@@ -131,10 +135,11 @@ const slice = createSlice({
       event.totalActivitiesInPipeline = totalActivities;
     },
 
-    entityCompleted: (state, action: PayloadAction<InProgressEntity>) => {
-      const { appletId, entityId, eventId } = action.payload;
-
-      const now = new Date().getTime();
+    entityCompleted: (
+      state,
+      action: PayloadAction<InProgressEntity & CompletionFixation>,
+    ) => {
+      const { appletId, entityId, eventId, endAt } = action.payload;
 
       const { availableTo } = state.inProgress[appletId][entityId][eventId];
 
@@ -142,13 +147,13 @@ const slice = createSlice({
 
       state.inProgress[appletId][entityId][eventId].endAt = isExpired
         ? availableTo
-        : now;
+        : endAt;
 
       const completedEntities = state.completedEntities ?? {};
 
       const completions = state.completions ?? {};
 
-      completedEntities[entityId] = now;
+      completedEntities[entityId] = endAt;
 
       if (!completions[entityId]) {
         completions[entityId] = {};
@@ -159,7 +164,7 @@ const slice = createSlice({
       if (!entityCompletions[eventId]) {
         entityCompletions[eventId] = [];
       }
-      entityCompletions[eventId].push(now);
+      entityCompletions[eventId].push(endAt);
     },
 
     entityAnswersSent: (state, action: PayloadAction<InProgressEntity>) => {

--- a/src/screens/model/checkEntityAvailability.ts
+++ b/src/screens/model/checkEntityAvailability.ts
@@ -8,7 +8,13 @@ import {
   onCompletedToday,
   onScheduledToday,
 } from '@app/features/tap-on-notification/lib';
-import { ILogger, isReadyForAutocompletion, Logger } from '@app/shared/lib';
+import {
+  getEntityProgress,
+  getNow,
+  ILogger,
+  isReadyForAutocompletion,
+  Logger,
+} from '@app/shared/lib';
 import {
   ActivityGroupType,
   ActivityGroupsModel,
@@ -41,6 +47,12 @@ export const checkEntityAvailability = ({
     `[checkEntityAvailability]: Checking.. Entity = "${entityName}", appletId = ${appletId}, entityId = ${entityId}, entityType = ${entityType}, eventId = ${eventId} `,
   );
 
+  const record = getEntityProgress(appletId, entityId, eventId, storeProgress);
+
+  Logger.log(
+    `[checkEntityAvailability] Now is ${getNow().toUTCString()}, record = ${JSON.stringify(record)}`,
+  );
+
   const shouldBeAutocompleted = isReadyForAutocompletion(
     { appletId, entityId, eventId, entityType },
     storeProgress,
@@ -49,8 +61,7 @@ export const checkEntityAvailability = ({
   const applyInProgressFilter = !shouldBeAutocompleted;
 
   Logger.log(
-    '[checkEntityAvailability] applyInProgressFilter is set to ' +
-      applyInProgressFilter,
+    `[checkEntityAvailability] applyInProgressFilter is set to ${applyInProgressFilter}`,
   );
 
   const groupsResult = ActivityGroupsModel.ActivityGroupsBuildManager.process(
@@ -100,8 +111,6 @@ export const checkEntityAvailability = ({
 
     return false;
   }
-
-  const record = storeProgress[appletId]?.[entityId]?.[eventId];
 
   const completedToday = record && record.endAt && isToday(record.endAt);
 

--- a/src/widgets/activity-group/model/factories/GroupUtility.ts
+++ b/src/widgets/activity-group/model/factories/GroupUtility.ts
@@ -209,7 +209,7 @@ export class GroupUtility {
     return this.isInInterval(
       {
         from: startDate ?? undefined,
-        to: endDate ?? undefined,
+        to: endDate ? this.getEndOfDay(endDate) : undefined,
       },
       now,
       'both',

--- a/src/widgets/survey/model/hooks/useAutoCompletion.ts
+++ b/src/widgets/survey/model/hooks/useAutoCompletion.ts
@@ -71,7 +71,10 @@ const useAutoCompletion = (): Result => {
     constructService: ConstructCompletionsService,
   ) => {
     try {
-      await constructService.construct(collectOutput);
+      await constructService.construct({
+        ...collectOutput,
+        isAutocompletion: true,
+      });
     } catch (error) {
       Logger.warn(
         '[useAutoCompletion.constructInternal] Error occurred:\n' + error,

--- a/src/widgets/survey/model/services/ConstructCompletionsService.ts
+++ b/src/widgets/survey/model/services/ConstructCompletionsService.ts
@@ -65,7 +65,7 @@ type ConstructForFinishInput = {
   isAutocompletion: boolean;
 };
 
-type CompletionType = 'intermediate' | 'finish';
+export type CompletionType = 'intermediate' | 'finish';
 
 export type ConstructInput = (
   | ConstructForIntermediateInput

--- a/src/widgets/survey/model/services/ConstructCompletionsService.ts
+++ b/src/widgets/survey/model/services/ConstructCompletionsService.ts
@@ -74,7 +74,7 @@ export type ConstructInput = (
   completionType: CompletionType;
 };
 
-const DistinguishInterimAndFinishLag = 1; // For correct sort on BE, Admin
+const DistinguishInterimAndFinishLag = 1; // For correct sort on BE, Admin, TODO
 
 export class ConstructCompletionsService {
   private saveActivitySummary: SaveActivitySummary | null;

--- a/src/widgets/survey/model/services/tests/testHelpers.ts
+++ b/src/widgets/survey/model/services/tests/testHelpers.ts
@@ -364,6 +364,7 @@ export const getInputsForIntermediate = (): ConstructInput => {
     eventId: 'mock-event-id-1',
     flowId: 'mock-flow-id-1',
     order: 0,
+    isAutocompletion: false,
   };
 };
 
@@ -376,6 +377,7 @@ export const getInputsForFinish = (entityType: EntityType): ConstructInput => {
     eventId: 'mock-event-id-1',
     flowId: entityType === 'flow' ? 'mock-flow-id-1' : undefined,
     order: 0,
+    isAutocompletion: false,
   };
 };
 

--- a/src/widgets/survey/ui/Finish.tsx
+++ b/src/widgets/survey/ui/Finish.tsx
@@ -81,6 +81,7 @@ function FinishItem({
       flowId,
       order,
       completionType: 'finish',
+      isAutocompletion: false,
     });
 
     const exclude: EntityPathParams = {

--- a/src/widgets/survey/ui/Intermediate.tsx
+++ b/src/widgets/survey/ui/Intermediate.tsx
@@ -169,6 +169,7 @@ function Intermediate({
       flowId,
       order,
       completionType: 'intermediate',
+      isAutocompletion: false,
     });
 
     const exclude: EntityPathParams = {


### PR DESCRIPTION
### 📝 Description

🔗 [Jira Ticket M2-6301](https://mindlogger.atlassian.net/browse/M2-6301)

<!-- Replace this with a high-level description of the features/functionality proposed in the pull request. -->

Changes include:

- Fixes how the mobile and server side save/keep/analyze the date-time moment of activity/flow completion. In case of autocompletion this moment should be equal to availableTo - the right part of the current time window based on the event. Previously, for autocompletion it was Date.now() and that value set to the dto that transfered to server, whereas mobile app considered availableTo instead.
- Fixes how the available/scheduled group evaluators filter activitiy+event items based on dateFrom, dateTo. Previously we had a bug - endDate handled wrong way - considered start of day (00:00:00) i.o. end of day (23:59:59)
- Fixes the progress sync service - as consequence of the 1st error in this list - the progress overwritren by the wrong endAt value that received from api.