### PR TITLE
hotfix: Fix infinite deep linking redirection on Android (M2-6600)

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -33,7 +33,7 @@
             <action android:name="android.intent.action.VIEW" />
             <category android:name="android.intent.category.DEFAULT" />
             <category android:name="android.intent.category.BROWSABLE" />
-            <data android:scheme="https" android:host="${domainName}" />
+            <data android:scheme="https" android:host="${domainName}" android:pathPrefix="/password-recovery" />
         </intent-filter>
       </activity>
     </application>


### PR DESCRIPTION
### 📝 Description

🔗 [Jira Ticket M2-6600](https://mindlogger.atlassian.net/browse/M2-6600)

I've included an explicit `android:pathPrefix` attribute in the deep linking intent filter in the Android manifest file. Right now we only support one path for deep linking: `/password-recovery/...`. By explicitly proving this value at build time, it will prevent the OS from launching the app for any other paths on an associated domain.

### 📸 Screenshots

#### Before

Clicking an invite link in an email will launch the production app

https://github.com/ChildMindInstitute/mindlogger-app-refactor/assets/14842108/d55ae339-4533-41ca-b1f1-7fd5661cd89e

#### After

Clicking an invite link in an email will launch the device's browser

https://github.com/ChildMindInstitute/mindlogger-app-refactor/assets/14842108/47574bf8-1abf-478d-b0d0-7d497474c959

Password reset links still launch the mobile app

https://github.com/ChildMindInstitute/mindlogger-app-refactor/assets/14842108/9fed0bd5-b8d0-4d42-a2a9-bd61e3579ed8

### ✏️ Notes

N/A