### PR TITLE
M2-6587: Swap USE_EXACT_ALARM for SCHEDULE_EXACT_ALARM

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -7,7 +7,7 @@
     <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
     <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" />
     <uses-permission android:name="android.permission.HIGH_SAMPLING_RATE_SENSORS" />
-    <uses-permission android:minSdkVersion="34" android:name="android.permission.USE_EXACT_ALARM" />
+    <uses-permission android:minSdkVersion="31" android:name="android.permission.SCHEDULE_EXACT_ALARM" />
 
     <application
       android:name=".MainApplication"


### PR DESCRIPTION
### 📝 Description

🔗 [Jira Ticket M2-6587](https://mindlogger.atlassian.net/browse/M2-6587)

<!-- Replace this with a high-level description of the features/functionality proposed in the pull request. -->

Changes include:

- Changes in permissions in the AndroidManifest file according to https://developer.android.com/about/versions/14/changes/schedule-exact-alarms