### PR TITLE
fix(migration): Changed migration keys to corresponds their versions

### DIFF
--- a/src/app/model/migrations/MigrationFactory.ts
+++ b/src/app/model/migrations/MigrationFactory.ts
@@ -10,7 +10,7 @@ type Migrations = Record<VersionFrom, IMigration>;
 export class MigrationFactory {
   public createMigrations(): Migrations {
     return {
-      0: new MigrationToVersion0001(__queryClient__),
+      1: new MigrationToVersion0001(__queryClient__),
     };
   }
 }

--- a/src/app/model/migrations/MigrationRunner.ts
+++ b/src/app/model/migrations/MigrationRunner.ts
@@ -19,7 +19,7 @@ export class MigrationRunner implements IMigrationRunner {
     inboundVersion: number,
   ): number[] {
     return Object.keys(this.migrations)
-      .map(parseInt)
+      .map(key => parseInt(key, 10))
       .filter(version => currentVersion >= version && version > inboundVersion)
       .sort((a, b) => a - b);
   }


### PR DESCRIPTION
### 📝 Description

Migration keys need to be started from "1".
Also, the `map` function call was fixed in the `getMigrationKeys` method so that it accepts an anonymous arrow function. The problem was that the map's callback provides three arguments: item, index and array; at the same time `parseInt` can accept two arguments: string to parse and radix. Since the the map function was called this way `.map(parseInt)` that made parseInt accept two arguments and change the radix breaking the logic.