### PR TITLE
fix(drawing): Fixed reducing of drawing height after a merge conflict

### DIFF
--- a/src/entities/drawer/ui/DrawingTest/DrawingTestNewLayout.tsx
+++ b/src/entities/drawer/ui/DrawingTest/DrawingTestNewLayout.tsx
@@ -41,7 +41,7 @@ const DrawingTest: FC<DrawingTestProps> = props => {
   } = useImageDimensions(imageUrl);
 
   const { exampleImageHeight, canvasContainerHeight, canvasSize } =
-    getElementsDimensions(props.dimensions, exampleImageDimensions);
+    getElementsDimensions(dimensions, exampleImageDimensions);
 
   const containerHeight = exampleImageHeight + canvasSize;
 


### PR DESCRIPTION
### 📝 Description

Fixed passing a wrong value to the `getElementsDimensions` function due to a mistake in a merge conflict resolvement