### PR TITLE
M2-6894: Disabled USE_FULL_SCREEN_INTENT to satisfy Google Policy

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -13,6 +13,9 @@
       android:name="android.permission.SCHEDULE_EXACT_ALARM"
       android:maxSdkVersion="${max_sdk_version}"
       tools:replace="android:maxSdkVersion" />
+    <uses-permission
+      android:name="android.permission.USE_FULL_SCREEN_INTENT"
+      tools:node="remove" />
 
     <application
       android:name=".MainApplication"


### PR DESCRIPTION
### 📝 Description

<!-- Contributions are welcome! If there is a corresponding      -->
<!-- JIRA ticket, link to it by replacing `#` with ticket number -->

🔗 [Jira Ticket M2-6894](https://mindlogger.atlassian.net/browse/M2-6894)

<!-- Replace this with a high-level description of the features/functionality proposed in the pull request. -->

Disabled unnecessary USE_FULL_SCREEN_INTENT used by Notifee to satisfy Google Policy:
![image](https://github.com/ChildMindInstitute/mindlogger-app-refactor/assets/20073193/5539fa26-ff5b-4747-b46a-4219201808f7)


