### PR TITLE
M2-6930: Added new application Id for Production app to 2.0.4-hotfix

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -152,6 +152,8 @@ android {
             manifestPlaceholders = [domainName: "web-uat.cmiml.net"]
         }
         production {
+            resValue "string", "app_name", "Mindlogger Assessments"
+            applicationIdSuffix ".production"
             manifestPlaceholders = [domainName: "web.mindlogger.org"]
         }
     }

--- a/android/app/src/production/google-services.json
+++ b/android/app/src/production/google-services.json
@@ -70,7 +70,7 @@
               "client_id": "614448177385-justd3j2a3u11ufco9a96mvlsd5n3jak.apps.googleusercontent.com",
               "client_type": 2,
               "ios_info": {
-                "bundle_id": "lab.childmindinstitute.data"
+                "bundle_id": "lab.childmindinstitute.data.production"
               }
             }
           ]

--- a/android/app/src/production/google-services.json
+++ b/android/app/src/production/google-services.json
@@ -40,6 +40,42 @@
           ]
         }
       }
+    },
+    {
+      "client_info": {
+        "mobilesdk_app_id": "1:614448177385:android:f06342ca12d626fa67d078",
+        "android_client_info": {
+          "package_name": "lab.childmindinstitute.data.production"
+        }
+      },
+      "oauth_client": [
+        {
+          "client_id": "614448177385-jml8gh7d4npdefru7k49ijo4t74nfrpc.apps.googleusercontent.com",
+          "client_type": 3
+        }
+      ],
+      "api_key": [
+        {
+          "current_key": "AIzaSyDDVi6Zhb_Ebdxis0PrfwpCoKVjvmVrpS4"
+        }
+      ],
+      "services": {
+        "appinvite_service": {
+          "other_platform_oauth_client": [
+            {
+              "client_id": "614448177385-jml8gh7d4npdefru7k49ijo4t74nfrpc.apps.googleusercontent.com",
+              "client_type": 3
+            },
+            {
+              "client_id": "614448177385-justd3j2a3u11ufco9a96mvlsd5n3jak.apps.googleusercontent.com",
+              "client_type": 2,
+              "ios_info": {
+                "bundle_id": "lab.childmindinstitute.data"
+              }
+            }
+          ]
+        }
+      }
     }
   ],
   "configuration_version": "1"


### PR DESCRIPTION
### 📝 Description

🔗 [Jira Ticket M2-6930](https://mindlogger.atlassian.net/browse/M2-6930)

Same PR as https://github.com/ChildMindInstitute/mindlogger-app-refactor/pull/800 but to `2.0.4-hotfix.1` release branch

1. Added `applicationIdSuffix` for Production Flavor to be able to upload new production builds to new app on Google Play Console.
2. Added a new `google-services.json `for Production Flavor to enable Crashlytics and Firebase Messaging