### PR TITLE
M2-7065,M2-6962,M2-6963,M2-6964,M2-6956,M2-6952: [Mobile] Autocompletion plase #2: delivery part #1

### DIFF
--- a/assets/translations/en.json
+++ b/assets/translations/en.json
@@ -447,7 +447,8 @@
     "end": "End"
   },
   "system": {
-    "migration_not_applied_text": "Data migration was not successfully applied. Please, contact support."
+    "migration_not_applied_text": "Data migration was not successfully applied. Please, contact support.",
+    "ok": "OK"
   },
   "activity_skip_popup" : {
     "popup_title": "Skip to the next trial?",

--- a/assets/translations/fr.json
+++ b/assets/translations/fr.json
@@ -556,7 +556,8 @@
     "end": "Fin"
   },
   "system": {
-    "migration_not_applied_text": "La migration des données n'a pas été appliquée avec succès. Veuillez contacter le support."
+    "migration_not_applied_text": "La migration des données n'a pas été appliquée avec succès. Veuillez contacter le support.",
+    "ok": "OK"
   },
   "activity_skip_popup" : {
     "popup_title": "Passer à l'essai suivant ?",

--- a/src/abstract/lib/interfaces/evaluator.ts
+++ b/src/abstract/lib/interfaces/evaluator.ts
@@ -1,3 +1,4 @@
-export interface IEvaluator<TValue> {
-  evaluate: (valuesToEvaluate: TValue[]) => TValue[];
+export interface IEvaluator<TEvaluate, TEvent> {
+  evaluate: (valuesToEvaluate: TEvaluate[]) => TEvaluate[];
+  isInGroup(event: TEvent): boolean;
 }

--- a/src/entities/event/model/mappers.ts
+++ b/src/entities/event/model/mappers.ts
@@ -9,7 +9,11 @@ export function mapEventsFromDto(
 ): ScheduleEvent[] {
   return eventsDto.map<ScheduleEvent>(x => mapEventFromDto(x));
 }
-export function mapEventFromDto(dto: ScheduleEventDto): ScheduleEvent {
+export function mapEventFromDto(dto: ScheduleEventDto | null): ScheduleEvent {
+  if (!dto) {
+    throw new Error('[mapEventFromDto]: dto must be an instance');
+  }
+
   return {
     id: dto.id,
     entityId: dto.entityId,

--- a/src/features/enter-foreground/model/hooks/useRestackNotifications.ts
+++ b/src/features/enter-foreground/model/hooks/useRestackNotifications.ts
@@ -5,9 +5,9 @@ import { AppletModel } from '@app/entities/applet';
 import { NotificationModel } from '@app/entities/notification';
 import { SessionModel } from '@app/entities/session';
 import { LogTrigger } from '@app/shared/api';
-import { useAppSelector, useOnForeground } from '@app/shared/lib';
+import { Logger, useAppSelector, useOnForeground } from '@app/shared/lib';
 
-function useRestackNotifications() {
+function useRestackNotifications(hasExpiredEntity: () => boolean) {
   const queryClient = useQueryClient();
   const isRestoring = useIsRestoring();
   const hasSession = SessionModel.useHasSession();
@@ -20,6 +20,13 @@ function useRestackNotifications() {
 
   useOnForeground(
     () => {
+      if (hasExpiredEntity()) {
+        Logger.log(
+          '[useRestackNotifications]: Cancelled due to hasExpiredEntity',
+        );
+        return;
+      }
+
       NotificationModel.NotificationRefreshService.refresh(
         queryClient,
         storeProgress,

--- a/src/features/tap-on-notification/lib/alerts.ts
+++ b/src/features/tap-on-notification/lib/alerts.ts
@@ -10,15 +10,33 @@ export function onAppletNotFound() {
   );
 }
 
-export function onActivityNotAvailable() {
-  Alert.alert(i18n.t('firebase_messaging:activity_not_found'));
+export function onActivityNotAvailable(onOk: () => void) {
+  Alert.alert(i18n.t('firebase_messaging:activity_not_found'), undefined, [
+    {
+      onPress: onOk,
+      text: i18n.t('system:ok'),
+    },
+  ]);
 }
 
-export function onCompletedToday(name: string) {
-  Alert.alert(`${i18n.t('firebase_messaging:already_completed')} '${name}'`);
+export function onCompletedToday(name: string, onOk: () => void) {
+  Alert.alert(
+    `${i18n.t('firebase_messaging:already_completed')} '${name}'`,
+    undefined,
+    [
+      {
+        onPress: onOk,
+        text: i18n.t('system:ok'),
+      },
+    ],
+  );
 }
 
-export function onScheduledToday(name: string, timeFrom: Date) {
+export function onScheduledToday(
+  name: string,
+  timeFrom: Date,
+  onOk: () => void,
+) {
   const from = format(timeFrom, 'HH:mm');
 
   Alert.alert(
@@ -29,5 +47,11 @@ export function onScheduledToday(name: string, timeFrom: Date) {
       `${i18n.t('firebase_messaging:scheduled_to_start_at')} ${from} ${i18n.t(
         'firebase_messaging:today',
       )}`,
+    [
+      {
+        onPress: onOk,
+        text: i18n.t('system:ok'),
+      },
+    ],
   );
 }

--- a/src/screens/ui/ActivityListScreen.tsx
+++ b/src/screens/ui/ActivityListScreen.tsx
@@ -8,6 +8,7 @@ import { EntityPath, StoreProgress } from '@app/abstract/lib';
 import { AppletModel } from '@app/entities/applet';
 import {
   AnalyticsService,
+  Emitter,
   MixEvents,
   MixProperties,
   useAppSelector,
@@ -47,13 +48,13 @@ const ActivityListScreen: FC<Props> = props => {
         identifiers: { appletId, eventId, entityId, entityType },
         queryClient,
         storeProgress,
+        alertCallback: () => Emitter.emit('autocomplete'),
       });
     },
     [appletId, queryClient, storeProgress],
   );
 
-  const { completeEntityIntoUploadToQueue, process: processAutocompletion } =
-    SurveyModel.useAutoCompletion();
+  const { completeEntityIntoUploadToQueue } = SurveyModel.useAutoCompletion();
 
   return (
     <Box flex={1}>
@@ -68,7 +69,6 @@ const ActivityListScreen: FC<Props> = props => {
           appletId={appletId}
           completeEntity={completeEntityIntoUploadToQueue}
           checkAvailability={checkAvailability}
-          processAutocompletion={processAutocompletion}
         />
       )}
     </Box>

--- a/src/screens/ui/InProgressActivityScreen.tsx
+++ b/src/screens/ui/InProgressActivityScreen.tsx
@@ -1,8 +1,9 @@
-import { FC } from 'react';
+import { FC, useEffect } from 'react';
 
 import { NativeStackScreenProps } from '@react-navigation/native-stack';
 
-import { FlowSurvey } from '@app/widgets/survey';
+import { Emitter } from '@app/shared/lib';
+import { FlowSurvey, SurveyModel } from '@app/widgets/survey';
 import { useUpcomingNotificationsObserver } from '@entities/notification';
 import { RootStackParamList } from '@screens/config';
 import { Box } from '@shared/ui';
@@ -13,6 +14,18 @@ const InProgressActivityScreen: FC<Props> = ({ navigation, route }) => {
   const { appletId, eventId, entityId, entityType } = route.params;
 
   useUpcomingNotificationsObserver(eventId, entityId);
+
+  useEffect(() => {
+    const callback = navigation.addListener('beforeRemove', () => {
+      Emitter.emit<SurveyModel.AutocompletionExecuteOptions>('autocomplete', {
+        checksToExclude: ['in-progress-activity'],
+      });
+    });
+
+    return () => {
+      navigation.removeListener('beforeRemove', callback);
+    };
+  }, [navigation]);
 
   return (
     <Box flex={1} backgroundColor="white">

--- a/src/shared/lib/services/Emitter.ts
+++ b/src/shared/lib/services/Emitter.ts
@@ -6,7 +6,8 @@ type Events =
   | 'on-notification-refresh'
   | 'refresh-token-fail'
   | 'stepper:reset'
-  | 'logout';
+  | 'logout'
+  | 'autocomplete';
 
 const Emitter = {
   on: <TPayload>(event: Events, fn: (payload?: TPayload) => void) =>

--- a/src/shared/lib/utils/survey/survey.ts
+++ b/src/shared/lib/utils/survey/survey.ts
@@ -1,3 +1,5 @@
+import { isToday } from 'date-fns';
+
 import {
   EntityPath,
   StoreProgress,
@@ -54,3 +56,7 @@ export function isReadyForAutocompletion(
 
 export const isEntityExpired = (availableTo: number | null | undefined) =>
   !!availableTo && getNow().getTime() > availableTo;
+
+export const isCompletedToday = (
+  record: StoreProgressPayload | null | undefined,
+) => record && record.endAt && isToday(record.endAt);

--- a/src/widgets/activity-group/lib/types/activityGroupsBuilder.ts
+++ b/src/widgets/activity-group/lib/types/activityGroupsBuilder.ts
@@ -1,4 +1,4 @@
-import { ActivityPipelineType } from '@app/abstract/lib';
+import { ActivityPipelineType, Progress } from '@app/abstract/lib';
 import { ActivityType } from '@entities/activity';
 import { ScheduleEvent } from '@entities/event';
 
@@ -27,4 +27,10 @@ export type Entity = Activity | ActivityFlow;
 export type EventEntity = {
   entity: Entity;
   event: ScheduleEvent;
+};
+
+export type GroupsBuildContext = {
+  progress: Progress;
+  appletId: string;
+  allAppletActivities: Activity[];
 };

--- a/src/widgets/activity-group/model/factories/ActivityGroupsBuilder.test.ts
+++ b/src/widgets/activity-group/model/factories/ActivityGroupsBuilder.test.ts
@@ -29,8 +29,12 @@ import {
   ActivityGroupsBuilder,
   createActivityGroupsBuilder,
 } from './ActivityGroupsBuilder';
-import { GroupsBuildContext } from './GroupUtility';
-import { ActivityListGroup, EventEntity, Entity } from '../../lib';
+import {
+  ActivityListGroup,
+  EventEntity,
+  Entity,
+  GroupsBuildContext,
+} from '../../lib';
 
 jest.mock('@app/shared/lib/constants', () => ({
   ...jest.requireActual('@app/shared/lib/constants'),
@@ -158,7 +162,7 @@ const getScheduledEventEntity = (settings: {
         startDate,
         endDate,
       },
-      entityId: 'test-id-1',
+      entityId: 'test-entity-id-1',
       id: 'test-event-id-1',
       notificationSettings: {
         notifications: [],
@@ -183,7 +187,7 @@ const getAlwaysAvailableEventEntity = (settings: {
     entity: getActivity(),
     event: {
       availability: getAlwaysAvailableSection(),
-      entityId: 'test-id-1',
+      entityId: 'test-entity-id-1',
       id: 'test-event-id-1',
       notificationSettings: {
         notifications: [],
@@ -231,7 +235,6 @@ describe('ActivityGroupsBuilder', () => {
         allAppletActivities: [],
         progress,
         appletId: 'test-applet-id-1',
-        applyInProgressFilter: true,
       };
 
       const builder = createActivityGroupsBuilder(input);
@@ -264,7 +267,6 @@ describe('ActivityGroupsBuilder', () => {
         allAppletActivities: [],
         progress,
         appletId: 'test-applet-id-1',
-        applyInProgressFilter: true,
       };
 
       const builder = createActivityGroupsBuilder(input);
@@ -293,7 +295,6 @@ describe('ActivityGroupsBuilder', () => {
         allAppletActivities: [],
         progress,
         appletId: 'test-applet-id-1',
-        applyInProgressFilter: true,
       };
 
       const builder = createActivityGroupsBuilder(input);
@@ -322,7 +323,6 @@ describe('ActivityGroupsBuilder', () => {
         allAppletActivities: [],
         progress,
         appletId: 'test-applet-id-1',
-        applyInProgressFilter: true,
       };
 
       const builder = createActivityGroupsBuilder(input);
@@ -358,7 +358,6 @@ describe('ActivityGroupsBuilder', () => {
         allAppletActivities: [],
         progress,
         appletId: 'test-applet-id-1',
-        applyInProgressFilter: true,
       };
 
       const builder = createActivityGroupsBuilder(input);
@@ -402,7 +401,6 @@ describe('ActivityGroupsBuilder', () => {
         allAppletActivities: [],
         progress,
         appletId: 'test-applet-id-1',
-        applyInProgressFilter: true,
       };
 
       const builder = createActivityGroupsBuilder(input);
@@ -446,7 +444,6 @@ describe('ActivityGroupsBuilder', () => {
         allAppletActivities: [],
         progress,
         appletId: 'test-applet-id-1',
-        applyInProgressFilter: true,
       };
 
       const builder = createActivityGroupsBuilder(input);
@@ -492,7 +489,6 @@ describe('ActivityGroupsBuilder', () => {
         allAppletActivities: [],
         progress,
         appletId: 'test-applet-id-1',
-        applyInProgressFilter: true,
       };
 
       const builder = createActivityGroupsBuilder(input);
@@ -531,7 +527,6 @@ describe('ActivityGroupsBuilder', () => {
         allAppletActivities: [],
         progress,
         appletId: 'test-applet-id-1',
-        applyInProgressFilter: true,
       };
 
       const builder = createActivityGroupsBuilder(input);
@@ -570,7 +565,6 @@ describe('ActivityGroupsBuilder', () => {
         allAppletActivities: [],
         progress,
         appletId: 'test-applet-id-1',
-        applyInProgressFilter: true,
       };
 
       const builder = createActivityGroupsBuilder(input);
@@ -612,7 +606,6 @@ describe('ActivityGroupsBuilder', () => {
           allAppletActivities: [],
           progress,
           appletId: 'test-applet-id-1',
-          applyInProgressFilter: true,
         };
 
         const builder = createActivityGroupsBuilder(input);
@@ -658,7 +651,6 @@ describe('ActivityGroupsBuilder', () => {
         allAppletActivities: [],
         progress,
         appletId: 'test-applet-id-1',
-        applyInProgressFilter: true,
       };
 
       const builder = createActivityGroupsBuilder(input);
@@ -707,7 +699,6 @@ describe('ActivityGroupsBuilder', () => {
         allAppletActivities: [],
         progress,
         appletId: 'test-applet-id-1',
-        applyInProgressFilter: true,
       };
 
       const builder = createActivityGroupsBuilder(input);
@@ -757,7 +748,6 @@ describe('ActivityGroupsBuilder', () => {
         allAppletActivities: [],
         progress,
         appletId: 'test-applet-id-1',
-        applyInProgressFilter: true,
       };
 
       const builder = createActivityGroupsBuilder(input);
@@ -804,7 +794,6 @@ describe('ActivityGroupsBuilder', () => {
         allAppletActivities: [],
         progress,
         appletId: 'test-applet-id-1',
-        applyInProgressFilter: true,
       };
 
       const builder = createActivityGroupsBuilder(input);
@@ -844,7 +833,6 @@ describe('ActivityGroupsBuilder', () => {
         allAppletActivities: [],
         progress,
         appletId: 'test-applet-id-1',
-        applyInProgressFilter: true,
       };
 
       const builder = createActivityGroupsBuilder(input);
@@ -883,7 +871,6 @@ describe('ActivityGroupsBuilder', () => {
         allAppletActivities: [],
         progress,
         appletId: 'test-applet-id-1',
-        applyInProgressFilter: true,
       };
 
       const builder = createActivityGroupsBuilder(input);
@@ -925,7 +912,6 @@ describe('ActivityGroupsBuilder', () => {
         allAppletActivities: [],
         progress,
         appletId: 'test-applet-id-1',
-        applyInProgressFilter: true,
       };
 
       let builder = createActivityGroupsBuilder(input);
@@ -953,7 +939,6 @@ describe('ActivityGroupsBuilder', () => {
         allAppletActivities: [],
         progress,
         appletId: 'test-applet-id-1',
-        applyInProgressFilter: true,
       };
 
       builder = createActivityGroupsBuilder(input);
@@ -975,7 +960,6 @@ describe('ActivityGroupsBuilder', () => {
         allAppletActivities: [],
         progress,
         appletId: 'test-applet-id-1',
-        applyInProgressFilter: true,
       };
 
       let builder = createActivityGroupsBuilder(input);
@@ -1003,7 +987,6 @@ describe('ActivityGroupsBuilder', () => {
         allAppletActivities: [],
         progress,
         appletId: 'test-applet-id-1',
-        applyInProgressFilter: true,
       };
 
       builder = createActivityGroupsBuilder(input);
@@ -1032,7 +1015,6 @@ describe('ActivityGroupsBuilder', () => {
           allAppletActivities: [],
           progress,
           appletId: 'test-applet-id-1',
-          applyInProgressFilter: true,
         };
 
         const builder = createActivityGroupsBuilder(input);
@@ -1078,7 +1060,6 @@ describe('ActivityGroupsBuilder', () => {
         allAppletActivities: [],
         progress,
         appletId: 'test-applet-id-1',
-        applyInProgressFilter: true,
       };
 
       const builder = createActivityGroupsBuilder(input);
@@ -1121,7 +1102,6 @@ describe('ActivityGroupsBuilder', () => {
         allAppletActivities: [],
         progress,
         appletId: 'test-applet-id-1',
-        applyInProgressFilter: true,
       };
 
       const builder = createActivityGroupsBuilder(input);
@@ -1172,7 +1152,6 @@ describe('ActivityGroupsBuilder', () => {
         allAppletActivities: [],
         progress,
         appletId: 'test-applet-id-1',
-        applyInProgressFilter: true,
       };
 
       const builder = createActivityGroupsBuilder(input);
@@ -1221,7 +1200,6 @@ describe('ActivityGroupsBuilder', () => {
         allAppletActivities: [],
         progress,
         appletId: 'test-applet-id-1',
-        applyInProgressFilter: true,
       };
 
       const builder = createActivityGroupsBuilder(input);
@@ -1264,7 +1242,6 @@ describe('ActivityGroupsBuilder', () => {
         allAppletActivities: [],
         progress,
         appletId: 'test-applet-id-1',
-        applyInProgressFilter: true,
       };
 
       const builder = createActivityGroupsBuilder(input);
@@ -1304,7 +1281,6 @@ describe('ActivityGroupsBuilder', () => {
         allAppletActivities: [],
         progress,
         appletId: 'test-applet-id-1',
-        applyInProgressFilter: true,
       };
 
       const builder = createActivityGroupsBuilder(input);
@@ -1353,7 +1329,6 @@ describe('ActivityGroupsBuilder', () => {
           allAppletActivities: [],
           progress,
           appletId: 'test-applet-id-1',
-          applyInProgressFilter: true,
         };
 
         const builder = createActivityGroupsBuilder(input);
@@ -1401,7 +1376,6 @@ describe('ActivityGroupsBuilder', () => {
         allAppletActivities: [],
         progress,
         appletId: 'test-applet-id-1',
-        applyInProgressFilter: true,
       };
 
       const builder = createActivityGroupsBuilder(input);
@@ -1452,7 +1426,6 @@ describe('ActivityGroupsBuilder', () => {
         allAppletActivities: [],
         progress,
         appletId: 'test-applet-id-1',
-        applyInProgressFilter: true,
       };
 
       const builder = createActivityGroupsBuilder(input);
@@ -1503,7 +1476,6 @@ describe('ActivityGroupsBuilder', () => {
         allAppletActivities: [],
         progress,
         appletId: 'test-applet-id-1',
-        applyInProgressFilter: true,
       };
 
       let builder = createActivityGroupsBuilder(input);
@@ -1547,7 +1519,6 @@ describe('ActivityGroupsBuilder', () => {
         allAppletActivities: [],
         progress,
         appletId: 'test-applet-id-1',
-        applyInProgressFilter: true,
       };
 
       builder = createActivityGroupsBuilder(input);
@@ -1570,7 +1541,6 @@ describe('ActivityGroupsBuilder', () => {
         allAppletActivities: [],
         progress,
         appletId: 'test-applet-id-1',
-        applyInProgressFilter: true,
       };
 
       const builder = createActivityGroupsBuilder(input);
@@ -1613,7 +1583,6 @@ describe('ActivityGroupsBuilder', () => {
         allAppletActivities: [],
         progress,
         appletId: 'test-applet-id-1',
-        applyInProgressFilter: true,
       };
 
       const builder = createActivityGroupsBuilder(input);
@@ -1693,7 +1662,6 @@ describe('ActivityGroupsBuilder', () => {
         ],
         progress,
         appletId: 'test-applet-id-1',
-        applyInProgressFilter: true,
       };
 
       const builder = createActivityGroupsBuilder(input);
@@ -1713,7 +1681,7 @@ describe('ActivityGroupsBuilder', () => {
         entity: activityFlow,
         event: {
           availability: getAlwaysAvailableSection(),
-          entityId: 'test-id-1',
+          entityId: 'test-flow-id-1',
           id: 'test-event-id-1',
           notificationSettings: {
             notifications: [],

--- a/src/widgets/activity-group/model/factories/AvailableGroupEvaluator.test.ts
+++ b/src/widgets/activity-group/model/factories/AvailableGroupEvaluator.test.ts
@@ -18,8 +18,7 @@ import { EventAvailability } from '@app/entities/event';
 import { HourMinute } from '@app/shared/lib';
 
 import { AvailableGroupEvaluator } from './AvailableGroupEvaluator';
-import { GroupsBuildContext } from './GroupUtility';
-import { EventEntity, Entity } from '../../lib';
+import { EventEntity, Entity, GroupsBuildContext } from '../../lib';
 
 jest.mock('@app/shared/lib/constants', () => ({
   ...jest.requireActual('@app/shared/lib/constants'),
@@ -103,7 +102,7 @@ const getScheduledEventEntity = (settings: {
         startDate,
         endDate,
       },
-      entityId: 'test-id-1',
+      entityId: 'test-entity-id-1',
       id: 'test-event-id-1',
       notificationSettings: {
         notifications: [],
@@ -147,7 +146,6 @@ describe('AvailableGroupEvaluator cross-day tests when access before start time 
       allAppletActivities: [],
       progress,
       appletId: 'test-applet-id-1',
-      applyInProgressFilter: true,
     };
 
     const eventEntity: EventEntity = getScheduledEventEntity({
@@ -156,7 +154,10 @@ describe('AvailableGroupEvaluator cross-day tests when access before start time 
       endDate: addDays(startAt, 2),
     });
 
-    const evaluator = new AvailableGroupEvaluator(input);
+    const evaluator = new AvailableGroupEvaluator(
+      input.progress,
+      input.appletId,
+    );
 
     let now = buildDateTime(startAt, TimeFrom);
     now = subMinutes(now, 1);
@@ -202,7 +203,6 @@ describe('AvailableGroupEvaluator cross-day tests when access before start time 
       allAppletActivities: [],
       progress,
       appletId: 'test-applet-id-1',
-      applyInProgressFilter: true,
     };
 
     const eventEntity: EventEntity = getScheduledEventEntity({
@@ -211,7 +211,10 @@ describe('AvailableGroupEvaluator cross-day tests when access before start time 
       endDate: addDays(startAt, 2),
     });
 
-    const evaluator = new AvailableGroupEvaluator(input);
+    const evaluator = new AvailableGroupEvaluator(
+      input.progress,
+      input.appletId,
+    );
 
     const now = buildDateTime(startAt, TimeFrom);
     mockGetNow(evaluator, now);
@@ -256,7 +259,6 @@ describe('AvailableGroupEvaluator cross-day tests when access before start time 
       allAppletActivities: [],
       progress,
       appletId: 'test-applet-id-1',
-      applyInProgressFilter: true,
     };
 
     const eventEntity: EventEntity = getScheduledEventEntity({
@@ -265,7 +267,10 @@ describe('AvailableGroupEvaluator cross-day tests when access before start time 
       endDate: addDays(startAt, 2),
     });
 
-    const evaluator = new AvailableGroupEvaluator(input);
+    const evaluator = new AvailableGroupEvaluator(
+      input.progress,
+      input.appletId,
+    );
 
     let now = buildDateTime(startAt, TimeFrom);
     now = addMinutes(now, 10);
@@ -318,7 +323,6 @@ describe('AvailableGroupEvaluator cross-day tests when access before start time 
       allAppletActivities: [],
       progress,
       appletId: 'test-applet-id-1',
-      applyInProgressFilter: true,
     };
 
     const eventEntity: EventEntity = getScheduledEventEntity({
@@ -327,7 +331,10 @@ describe('AvailableGroupEvaluator cross-day tests when access before start time 
       endDate: addDays(startAt, 2),
     });
 
-    const evaluator = new AvailableGroupEvaluator(input);
+    const evaluator = new AvailableGroupEvaluator(
+      input.progress,
+      input.appletId,
+    );
 
     mockGetNow(evaluator, now);
 
@@ -378,7 +385,6 @@ describe('AvailableGroupEvaluator cross-day tests when access before start time 
       allAppletActivities: [],
       progress,
       appletId: 'test-applet-id-1',
-      applyInProgressFilter: true,
     };
 
     const eventEntity: EventEntity = getScheduledEventEntity({
@@ -387,7 +393,10 @@ describe('AvailableGroupEvaluator cross-day tests when access before start time 
       endDate: addDays(startAt, 2),
     });
 
-    const evaluator = new AvailableGroupEvaluator(input);
+    const evaluator = new AvailableGroupEvaluator(
+      input.progress,
+      input.appletId,
+    );
 
     mockGetNow(evaluator, now);
 
@@ -431,7 +440,6 @@ describe('AvailableGroupEvaluator cross-day tests when access before start time 
       allAppletActivities: [],
       progress,
       appletId: 'test-applet-id-1',
-      applyInProgressFilter: true,
     };
 
     const eventEntity: EventEntity = getScheduledEventEntity({
@@ -440,7 +448,10 @@ describe('AvailableGroupEvaluator cross-day tests when access before start time 
       endDate: addDays(startAt, 2),
     });
 
-    const evaluator = new AvailableGroupEvaluator(input);
+    const evaluator = new AvailableGroupEvaluator(
+      input.progress,
+      input.appletId,
+    );
 
     let now = buildDateTime(addDays(startAt, 1), TimeTo);
     now = subMinutes(now, 1);
@@ -487,7 +498,6 @@ describe('AvailableGroupEvaluator cross-day tests when access before start time 
       allAppletActivities: [],
       progress,
       appletId: 'test-applet-id-1',
-      applyInProgressFilter: true,
     };
 
     const eventEntity: EventEntity = getScheduledEventEntity({
@@ -496,7 +506,10 @@ describe('AvailableGroupEvaluator cross-day tests when access before start time 
       endDate: addDays(startAt, 2),
     });
 
-    const evaluator = new AvailableGroupEvaluator(input);
+    const evaluator = new AvailableGroupEvaluator(
+      input.progress,
+      input.appletId,
+    );
 
     mockGetNow(evaluator, now);
 
@@ -543,7 +556,6 @@ describe('AvailableGroupEvaluator cross-day tests when access before start time 
       allAppletActivities: [],
       progress,
       appletId: 'test-applet-id-1',
-      applyInProgressFilter: true,
     };
 
     const eventEntity: EventEntity = getScheduledEventEntity({
@@ -552,7 +564,10 @@ describe('AvailableGroupEvaluator cross-day tests when access before start time 
       endDate: addDays(startAt, 2),
     });
 
-    const evaluator = new AvailableGroupEvaluator(input);
+    const evaluator = new AvailableGroupEvaluator(
+      input.progress,
+      input.appletId,
+    );
 
     mockGetNow(evaluator, now);
 
@@ -590,7 +605,6 @@ describe('AvailableGroupEvaluator cross-day tests when access before start time 
       allAppletActivities: [],
       progress,
       appletId: 'test-applet-id-1',
-      applyInProgressFilter: true,
     };
 
     const eventEntity: EventEntity = getScheduledEventEntity({
@@ -599,7 +613,10 @@ describe('AvailableGroupEvaluator cross-day tests when access before start time 
       endDate: addDays(startAt, 2),
     });
 
-    const evaluator = new AvailableGroupEvaluator(input);
+    const evaluator = new AvailableGroupEvaluator(
+      input.progress,
+      input.appletId,
+    );
 
     const now = buildDateTime(addDays(startAt, 1), TimeTo);
     mockGetNow(evaluator, now);
@@ -644,7 +661,6 @@ describe('AvailableGroupEvaluator cross-day tests when access before start time 
       allAppletActivities: [],
       progress,
       appletId: 'test-applet-id-1',
-      applyInProgressFilter: true,
     };
 
     const eventEntity: EventEntity = getScheduledEventEntity({
@@ -653,7 +669,10 @@ describe('AvailableGroupEvaluator cross-day tests when access before start time 
       endDate: addDays(startAt, 2),
     });
 
-    const evaluator = new AvailableGroupEvaluator(input);
+    const evaluator = new AvailableGroupEvaluator(
+      input.progress,
+      input.appletId,
+    );
 
     let now = buildDateTime(startAt, TimeTo);
     now = addMinutes(now, 10);
@@ -704,7 +723,6 @@ describe('AvailableGroupEvaluator cross-day tests when access before start time 
       allAppletActivities: [],
       progress,
       appletId: 'test-applet-id-1',
-      applyInProgressFilter: true,
     };
 
     const eventEntity: EventEntity = getScheduledEventEntity({
@@ -713,7 +731,10 @@ describe('AvailableGroupEvaluator cross-day tests when access before start time 
       endDate: addDays(startAt, 2),
     });
 
-    const evaluator = new AvailableGroupEvaluator(input);
+    const evaluator = new AvailableGroupEvaluator(
+      input.progress,
+      input.appletId,
+    );
 
     it('Test Weekdays when now is later', () => {
       let now = buildDateTime(startAt, TimeTo);
@@ -745,7 +766,6 @@ describe('AvailableGroupEvaluator cross-day tests when access before start time 
       allAppletActivities: [],
       progress,
       appletId: 'test-applet-id-1',
-      applyInProgressFilter: true,
     };
 
     const eventEntity: EventEntity = getScheduledEventEntity({
@@ -754,7 +774,10 @@ describe('AvailableGroupEvaluator cross-day tests when access before start time 
       endDate: addDays(startAt, 2),
     });
 
-    const evaluator = new AvailableGroupEvaluator(input);
+    const evaluator = new AvailableGroupEvaluator(
+      input.progress,
+      input.appletId,
+    );
 
     let now = buildDateTime(startAt, TimeTo);
     now = subMinutes(now, 1);
@@ -804,7 +827,6 @@ describe('AvailableGroupEvaluator cross-day tests when access before start time 
       allAppletActivities: [],
       progress,
       appletId: 'test-applet-id-1',
-      applyInProgressFilter: true,
     };
 
     const eventEntity: EventEntity = getScheduledEventEntity({
@@ -813,7 +835,10 @@ describe('AvailableGroupEvaluator cross-day tests when access before start time 
       endDate: addDays(startAt, 2),
     });
 
-    const evaluator = new AvailableGroupEvaluator(input);
+    const evaluator = new AvailableGroupEvaluator(
+      input.progress,
+      input.appletId,
+    );
 
     let now = buildDateTime(startAt, TimeTo);
     now = addMinutes(now, 10);
@@ -863,7 +888,6 @@ describe('AvailableGroupEvaluator cross-day tests when access before start time 
       allAppletActivities: [],
       progress,
       appletId: 'test-applet-id-1',
-      applyInProgressFilter: true,
     };
 
     const eventEntity: EventEntity = getScheduledEventEntity({
@@ -872,7 +896,10 @@ describe('AvailableGroupEvaluator cross-day tests when access before start time 
       endDate: addDays(startAt, 2),
     });
 
-    const evaluator = new AvailableGroupEvaluator(input);
+    const evaluator = new AvailableGroupEvaluator(
+      input.progress,
+      input.appletId,
+    );
 
     let now = buildDateTime(addDays(startAt, 1), TimeTo);
     now = addMinutes(now, 10);
@@ -920,7 +947,6 @@ describe('AvailableGroupEvaluator cross-day tests when access before start time 
       allAppletActivities: [],
       progress,
       appletId: 'test-applet-id-1',
-      applyInProgressFilter: true,
     };
 
     const eventEntity: EventEntity = getScheduledEventEntity({
@@ -930,7 +956,10 @@ describe('AvailableGroupEvaluator cross-day tests when access before start time 
     });
     eventEntity.event.availability.allowAccessBeforeFromTime = true;
 
-    const evaluator = new AvailableGroupEvaluator(input);
+    const evaluator = new AvailableGroupEvaluator(
+      input.progress,
+      input.appletId,
+    );
 
     const now = buildDateTime(startAt, { hours: 0, minutes: 0 });
     mockGetNow(evaluator, now);
@@ -975,7 +1004,6 @@ describe('AvailableGroupEvaluator cross-day tests when access before start time 
       allAppletActivities: [],
       progress,
       appletId: 'test-applet-id-1',
-      applyInProgressFilter: true,
     };
 
     const eventEntity: EventEntity = getScheduledEventEntity({
@@ -985,7 +1013,10 @@ describe('AvailableGroupEvaluator cross-day tests when access before start time 
     });
     eventEntity.event.availability.allowAccessBeforeFromTime = true;
 
-    const evaluator = new AvailableGroupEvaluator(input);
+    const evaluator = new AvailableGroupEvaluator(
+      input.progress,
+      input.appletId,
+    );
 
     let now = buildDateTime(startAt, TimeFrom);
     now = subMinutes(now, 1);
@@ -1031,7 +1062,6 @@ describe('AvailableGroupEvaluator cross-day tests when access before start time 
       allAppletActivities: [],
       progress,
       appletId: 'test-applet-id-1',
-      applyInProgressFilter: true,
     };
 
     const eventEntity: EventEntity = getScheduledEventEntity({
@@ -1041,7 +1071,10 @@ describe('AvailableGroupEvaluator cross-day tests when access before start time 
     });
     eventEntity.event.availability.allowAccessBeforeFromTime = true;
 
-    const evaluator = new AvailableGroupEvaluator(input);
+    const evaluator = new AvailableGroupEvaluator(
+      input.progress,
+      input.appletId,
+    );
 
     const now = buildDateTime(startAt, TimeFrom);
     mockGetNow(evaluator, now);
@@ -1086,7 +1119,6 @@ describe('AvailableGroupEvaluator cross-day tests when access before start time 
       allAppletActivities: [],
       progress,
       appletId: 'test-applet-id-1',
-      applyInProgressFilter: true,
     };
 
     const eventEntity: EventEntity = getScheduledEventEntity({
@@ -1096,7 +1128,10 @@ describe('AvailableGroupEvaluator cross-day tests when access before start time 
     });
     eventEntity.event.availability.allowAccessBeforeFromTime = true;
 
-    const evaluator = new AvailableGroupEvaluator(input);
+    const evaluator = new AvailableGroupEvaluator(
+      input.progress,
+      input.appletId,
+    );
 
     let now = buildDateTime(startAt, TimeFrom);
     now = addMinutes(now, 10);
@@ -1149,7 +1184,6 @@ describe('AvailableGroupEvaluator cross-day tests when access before start time 
       allAppletActivities: [],
       progress,
       appletId: 'test-applet-id-1',
-      applyInProgressFilter: true,
     };
 
     const eventEntity: EventEntity = getScheduledEventEntity({
@@ -1159,7 +1193,10 @@ describe('AvailableGroupEvaluator cross-day tests when access before start time 
     });
     eventEntity.event.availability.allowAccessBeforeFromTime = true;
 
-    const evaluator = new AvailableGroupEvaluator(input);
+    const evaluator = new AvailableGroupEvaluator(
+      input.progress,
+      input.appletId,
+    );
 
     mockGetNow(evaluator, now);
 
@@ -1207,7 +1244,6 @@ describe('AvailableGroupEvaluator cross-day tests when access before start time 
       allAppletActivities: [],
       progress,
       appletId: 'test-applet-id-1',
-      applyInProgressFilter: true,
     };
 
     const eventEntity: EventEntity = getScheduledEventEntity({
@@ -1217,7 +1253,10 @@ describe('AvailableGroupEvaluator cross-day tests when access before start time 
     });
     eventEntity.event.availability.allowAccessBeforeFromTime = true;
 
-    const evaluator = new AvailableGroupEvaluator(input);
+    const evaluator = new AvailableGroupEvaluator(
+      input.progress,
+      input.appletId,
+    );
 
     mockGetNow(evaluator, now);
 
@@ -1261,7 +1300,6 @@ describe('AvailableGroupEvaluator cross-day tests when access before start time 
       allAppletActivities: [],
       progress,
       appletId: 'test-applet-id-1',
-      applyInProgressFilter: true,
     };
 
     const eventEntity: EventEntity = getScheduledEventEntity({
@@ -1271,7 +1309,10 @@ describe('AvailableGroupEvaluator cross-day tests when access before start time 
     });
     eventEntity.event.availability.allowAccessBeforeFromTime = true;
 
-    const evaluator = new AvailableGroupEvaluator(input);
+    const evaluator = new AvailableGroupEvaluator(
+      input.progress,
+      input.appletId,
+    );
 
     let now = buildDateTime(addDays(startAt, 1), TimeTo);
     now = subMinutes(now, 1);
@@ -1318,7 +1359,6 @@ describe('AvailableGroupEvaluator cross-day tests when access before start time 
       allAppletActivities: [],
       progress,
       appletId: 'test-applet-id-1',
-      applyInProgressFilter: true,
     };
 
     const eventEntity: EventEntity = getScheduledEventEntity({
@@ -1328,7 +1368,10 @@ describe('AvailableGroupEvaluator cross-day tests when access before start time 
     });
     eventEntity.event.availability.allowAccessBeforeFromTime = true;
 
-    const evaluator = new AvailableGroupEvaluator(input);
+    const evaluator = new AvailableGroupEvaluator(
+      input.progress,
+      input.appletId,
+    );
 
     mockGetNow(evaluator, now);
 
@@ -1374,7 +1417,6 @@ describe('AvailableGroupEvaluator cross-day tests when access before start time 
       allAppletActivities: [],
       progress,
       appletId: 'test-applet-id-1',
-      applyInProgressFilter: true,
     };
 
     const eventEntity: EventEntity = getScheduledEventEntity({
@@ -1384,7 +1426,10 @@ describe('AvailableGroupEvaluator cross-day tests when access before start time 
     });
     eventEntity.event.availability.allowAccessBeforeFromTime = true;
 
-    const evaluator = new AvailableGroupEvaluator(input);
+    const evaluator = new AvailableGroupEvaluator(
+      input.progress,
+      input.appletId,
+    );
 
     mockGetNow(evaluator, now);
 
@@ -1429,7 +1474,6 @@ describe('AvailableGroupEvaluator cross-day tests when access before start time 
       allAppletActivities: [],
       progress,
       appletId: 'test-applet-id-1',
-      applyInProgressFilter: true,
     };
 
     const eventEntity: EventEntity = getScheduledEventEntity({
@@ -1439,7 +1483,10 @@ describe('AvailableGroupEvaluator cross-day tests when access before start time 
     });
     eventEntity.event.availability.allowAccessBeforeFromTime = true;
 
-    const evaluator = new AvailableGroupEvaluator(input);
+    const evaluator = new AvailableGroupEvaluator(
+      input.progress,
+      input.appletId,
+    );
 
     mockGetNow(evaluator, now);
 
@@ -1477,7 +1524,6 @@ describe('AvailableGroupEvaluator cross-day tests when access before start time 
       allAppletActivities: [],
       progress,
       appletId: 'test-applet-id-1',
-      applyInProgressFilter: true,
     };
 
     const eventEntity: EventEntity = getScheduledEventEntity({
@@ -1487,7 +1533,10 @@ describe('AvailableGroupEvaluator cross-day tests when access before start time 
     });
     eventEntity.event.availability.allowAccessBeforeFromTime = true;
 
-    const evaluator = new AvailableGroupEvaluator(input);
+    const evaluator = new AvailableGroupEvaluator(
+      input.progress,
+      input.appletId,
+    );
 
     const now = buildDateTime(addDays(startAt, 1), TimeTo);
     mockGetNow(evaluator, now);
@@ -1526,7 +1575,6 @@ describe('AvailableGroupEvaluator cross-day tests when access before start time 
       allAppletActivities: [],
       progress,
       appletId: 'test-applet-id-1',
-      applyInProgressFilter: true,
     };
 
     const eventEntity: EventEntity = getScheduledEventEntity({
@@ -1536,7 +1584,10 @@ describe('AvailableGroupEvaluator cross-day tests when access before start time 
     });
     eventEntity.event.availability.allowAccessBeforeFromTime = true;
 
-    const evaluator = new AvailableGroupEvaluator(input);
+    const evaluator = new AvailableGroupEvaluator(
+      input.progress,
+      input.appletId,
+    );
 
     let now = buildDateTime(startAt, TimeTo);
     now = addMinutes(now, 10);
@@ -1586,7 +1637,6 @@ describe('AvailableGroupEvaluator cross-day tests when access before start time 
       allAppletActivities: [],
       progress,
       appletId: 'test-applet-id-1',
-      applyInProgressFilter: true,
     };
 
     const eventEntity: EventEntity = getScheduledEventEntity({
@@ -1596,7 +1646,10 @@ describe('AvailableGroupEvaluator cross-day tests when access before start time 
     });
     eventEntity.event.availability.allowAccessBeforeFromTime = true;
 
-    const evaluator = new AvailableGroupEvaluator(input);
+    const evaluator = new AvailableGroupEvaluator(
+      input.progress,
+      input.appletId,
+    );
 
     let now = buildDateTime(startAt, TimeTo);
     now = subMinutes(now, 1);
@@ -1646,7 +1699,6 @@ describe('AvailableGroupEvaluator cross-day tests when access before start time 
       allAppletActivities: [],
       progress,
       appletId: 'test-applet-id-1',
-      applyInProgressFilter: true,
     };
 
     const eventEntity: EventEntity = getScheduledEventEntity({
@@ -1656,7 +1708,10 @@ describe('AvailableGroupEvaluator cross-day tests when access before start time 
     });
     eventEntity.event.availability.allowAccessBeforeFromTime = true;
 
-    const evaluator = new AvailableGroupEvaluator(input);
+    const evaluator = new AvailableGroupEvaluator(
+      input.progress,
+      input.appletId,
+    );
 
     let now = buildDateTime(startAt, TimeTo);
     now = addMinutes(now, 10);
@@ -1706,7 +1761,6 @@ describe('AvailableGroupEvaluator cross-day tests when access before start time 
       allAppletActivities: [],
       progress,
       appletId: 'test-applet-id-1',
-      applyInProgressFilter: true,
     };
 
     const eventEntity: EventEntity = getScheduledEventEntity({
@@ -1716,7 +1770,10 @@ describe('AvailableGroupEvaluator cross-day tests when access before start time 
     });
     eventEntity.event.availability.allowAccessBeforeFromTime = true;
 
-    const evaluator = new AvailableGroupEvaluator(input);
+    const evaluator = new AvailableGroupEvaluator(
+      input.progress,
+      input.appletId,
+    );
 
     let now = buildDateTime(addDays(startAt, 1), TimeTo);
     now = addMinutes(now, 10);

--- a/src/widgets/activity-group/model/factories/ScheduledGroupEvaluator.test.ts
+++ b/src/widgets/activity-group/model/factories/ScheduledGroupEvaluator.test.ts
@@ -10,9 +10,8 @@ import { ActivityType } from '@app/entities/activity/lib';
 import { EventAvailability } from '@app/entities/event';
 import { HourMinute } from '@app/shared/lib';
 
-import { GroupsBuildContext } from './GroupUtility';
 import { ScheduledGroupEvaluator } from './ScheduledGroupEvaluator';
-import { EventEntity, Entity } from '../../lib';
+import { EventEntity, Entity, GroupsBuildContext } from '../../lib';
 
 jest.mock('@app/shared/lib/constants', () => ({
   ...jest.requireActual('@app/shared/lib/constants'),
@@ -96,7 +95,7 @@ const getScheduledEventEntity = (settings: {
         startDate,
         endDate,
       },
-      entityId: 'test-id-1',
+      entityId: 'test-entity-id-1',
       id: 'test-event-id-1',
       notificationSettings: {
         notifications: [],
@@ -140,7 +139,6 @@ describe('ScheduledGroupEvaluator cross-day tests', () => {
       allAppletActivities: [],
       progress,
       appletId: 'test-applet-id-1',
-      applyInProgressFilter: true,
     };
 
     const eventEntity: EventEntity = getScheduledEventEntity({
@@ -149,7 +147,10 @@ describe('ScheduledGroupEvaluator cross-day tests', () => {
       endDate: addDays(startAt, 2),
     });
 
-    const evaluator = new ScheduledGroupEvaluator(input);
+    const evaluator = new ScheduledGroupEvaluator(
+      input.progress,
+      input.appletId,
+    );
 
     let now = buildDateTime(startAt, TimeFrom);
     now = subMinutes(now, 1);
@@ -206,10 +207,12 @@ describe('ScheduledGroupEvaluator cross-day tests', () => {
       allAppletActivities: [],
       progress,
       appletId: 'test-applet-id-1',
-      applyInProgressFilter: true,
     };
 
-    const evaluator = new ScheduledGroupEvaluator(input);
+    const evaluator = new ScheduledGroupEvaluator(
+      input.progress,
+      input.appletId,
+    );
 
     now = subMinutes(now, 1);
     mockGetNow(evaluator, now);
@@ -254,7 +257,6 @@ describe('ScheduledGroupEvaluator cross-day tests', () => {
       allAppletActivities: [],
       progress,
       appletId: 'test-applet-id-1',
-      applyInProgressFilter: true,
     };
 
     const eventEntity: EventEntity = getScheduledEventEntity({
@@ -263,7 +265,10 @@ describe('ScheduledGroupEvaluator cross-day tests', () => {
       endDate: addDays(startAt, 2),
     });
 
-    const evaluator = new ScheduledGroupEvaluator(input);
+    const evaluator = new ScheduledGroupEvaluator(
+      input.progress,
+      input.appletId,
+    );
 
     let now = buildDateTime(startAt, TimeFrom);
     now = addMinutes(now, 1);
@@ -309,7 +314,6 @@ describe('ScheduledGroupEvaluator cross-day tests', () => {
       allAppletActivities: [],
       progress,
       appletId: 'test-applet-id-1',
-      applyInProgressFilter: true,
     };
 
     const eventEntity: EventEntity = getScheduledEventEntity({
@@ -318,7 +322,10 @@ describe('ScheduledGroupEvaluator cross-day tests', () => {
       endDate: addDays(startAt, 2),
     });
 
-    const evaluator = new ScheduledGroupEvaluator(input);
+    const evaluator = new ScheduledGroupEvaluator(
+      input.progress,
+      input.appletId,
+    );
 
     let now = buildDateTime(startAt, TimeTo);
     now = addMinutes(now, 1);
@@ -364,7 +371,6 @@ describe('ScheduledGroupEvaluator cross-day tests', () => {
       allAppletActivities: [],
       progress,
       appletId: 'test-applet-id-1',
-      applyInProgressFilter: true,
     };
 
     const eventEntity: EventEntity = getScheduledEventEntity({
@@ -373,7 +379,10 @@ describe('ScheduledGroupEvaluator cross-day tests', () => {
       endDate: addDays(startAt, 2),
     });
 
-    const evaluator = new ScheduledGroupEvaluator(input);
+    const evaluator = new ScheduledGroupEvaluator(
+      input.progress,
+      input.appletId,
+    );
 
     let now = buildDateTime(startAt, TimeTo);
     now = subMinutes(now, 1);
@@ -411,7 +420,6 @@ describe('ScheduledGroupEvaluator cross-day tests', () => {
       allAppletActivities: [],
       progress,
       appletId: 'test-applet-id-1',
-      applyInProgressFilter: true,
     };
 
     const eventEntity: EventEntity = getScheduledEventEntity({
@@ -420,7 +428,10 @@ describe('ScheduledGroupEvaluator cross-day tests', () => {
       endDate: addDays(startAt, 2),
     });
 
-    const evaluator = new ScheduledGroupEvaluator(input);
+    const evaluator = new ScheduledGroupEvaluator(
+      input.progress,
+      input.appletId,
+    );
 
     let now = buildDateTime(startAt, TimeTo);
     now = subMinutes(now, 1);
@@ -453,7 +464,6 @@ describe('ScheduledGroupEvaluator cross-day tests', () => {
       allAppletActivities: [],
       progress,
       appletId: 'test-applet-id-1',
-      applyInProgressFilter: true,
     };
 
     const eventEntity: EventEntity = getScheduledEventEntity({
@@ -462,7 +472,10 @@ describe('ScheduledGroupEvaluator cross-day tests', () => {
       endDate: addDays(startAt, 2),
     });
 
-    const evaluator = new ScheduledGroupEvaluator(input);
+    const evaluator = new ScheduledGroupEvaluator(
+      input.progress,
+      input.appletId,
+    );
 
     let now = buildDateTime(startAt, TimeTo);
     now = subMinutes(now, 1);

--- a/src/widgets/activity-group/model/factories/ScheduledGroupEvaluator.ts
+++ b/src/widgets/activity-group/model/factories/ScheduledGroupEvaluator.ts
@@ -2,104 +2,110 @@ import {
   AvailabilityType,
   IEvaluator,
   PeriodicityType,
+  Progress,
 } from '@app/abstract/lib';
+import { ScheduleEvent } from '@app/entities/event';
 import { DatesFromTo } from '@shared/lib';
 
-import { GroupUtility, GroupsBuildContext } from './GroupUtility';
+import { GroupUtility } from './GroupUtility';
 import { EventEntity } from '../../lib';
 
-export class ScheduledGroupEvaluator implements IEvaluator<EventEntity> {
+export class ScheduledGroupEvaluator
+  implements IEvaluator<EventEntity, ScheduleEvent>
+{
   private utility: GroupUtility;
 
-  constructor(inputParams: GroupsBuildContext) {
-    this.utility = new GroupUtility(inputParams);
+  constructor(progress: Progress, appletId: string) {
+    this.utility = new GroupUtility(progress, appletId);
+  }
+
+  public isInGroup(event: ScheduleEvent): boolean {
+    const now = this.utility.getNow();
+
+    if (!this.utility.isInsideValidDatesInterval(event)) {
+      return false;
+    }
+
+    const isTypeScheduled =
+      event.availability.availabilityType === AvailabilityType.ScheduledAccess;
+
+    const isAccessBeforeTimeFrom = event.availability.allowAccessBeforeFromTime;
+
+    const isCompletedToday = this.utility.isCompletedToday(event);
+
+    const isScheduledToday = this.utility.isToday(event.scheduledAt);
+
+    const isSpreadToNextDay = this.utility.isSpreadToNextDay(event);
+
+    const isCandidateForBeingScheduled: boolean =
+      isTypeScheduled &&
+      isScheduledToday &&
+      now < event.scheduledAt! &&
+      !isAccessBeforeTimeFrom;
+
+    if (!isCandidateForBeingScheduled) {
+      return false;
+    }
+
+    if (!isSpreadToNextDay) {
+      return !isCompletedToday;
+    }
+
+    const periodicity = event.availability.periodicityType;
+
+    const isMonday = now.getDay() === 1;
+
+    const doSimpleSpreadCheck: boolean =
+      periodicity === PeriodicityType.Weekly ||
+      periodicity === PeriodicityType.Monthly ||
+      periodicity === PeriodicityType.Once ||
+      (periodicity === PeriodicityType.Weekdays && isMonday);
+
+    if (doSimpleSpreadCheck) {
+      return !isCompletedToday;
+    }
+
+    const isFromTueToFri = now.getDay() >= 2 && now.getDay() <= 5;
+
+    const doAdvancedSpreadCheck =
+      periodicity === PeriodicityType.Daily ||
+      (periodicity === PeriodicityType.Weekdays && isFromTueToFri);
+
+    const considerSpread = doAdvancedSpreadCheck;
+
+    const voidInterval: DatesFromTo = this.utility.getVoidInterval(
+      event,
+      considerSpread,
+    );
+
+    const isInVoidInterval = this.utility.isInInterval(
+      voidInterval,
+      now,
+      'from',
+    );
+
+    const isCompletedInVoidInterval = this.utility.isInInterval(
+      voidInterval,
+      this.utility.getCompletedAt(event),
+      'from',
+    );
+
+    if (
+      doAdvancedSpreadCheck &&
+      isInVoidInterval &&
+      !isCompletedInVoidInterval
+    ) {
+      return true;
+    }
+
+    return false;
   }
 
   public evaluate(eventsEntities: Array<EventEntity>): Array<EventEntity> {
     const result: Array<EventEntity> = [];
 
-    const now = this.utility.getNow();
-
     for (const eventEntity of eventsEntities) {
-      const { event } = eventEntity;
-
-      if (!this.utility.isInsideValidDatesInterval(event)) {
-        continue;
-      }
-
-      const isTypeScheduled =
-        event.availability.availabilityType ===
-        AvailabilityType.ScheduledAccess;
-
-      const isAccessBeforeTimeFrom =
-        event.availability.allowAccessBeforeFromTime;
-
-      const isCompletedToday = this.utility.isCompletedToday(eventEntity);
-
-      const isScheduledToday = this.utility.isToday(event.scheduledAt);
-
-      const isSpreadToNextDay = this.utility.isSpreadToNextDay(event);
-
-      const isCandidateForBeingScheduled: boolean =
-        isTypeScheduled &&
-        isScheduledToday &&
-        now < event.scheduledAt! &&
-        !isAccessBeforeTimeFrom;
-
-      if (!isCandidateForBeingScheduled) {
-        continue;
-      }
-
-      if (!isSpreadToNextDay) {
-        !isCompletedToday && result.push(eventEntity);
-        continue;
-      }
-
-      const periodicity = event.availability.periodicityType;
-
-      const isMonday = now.getDay() === 1;
-
-      const doSimpleSpreadCheck: boolean =
-        periodicity === PeriodicityType.Weekly ||
-        periodicity === PeriodicityType.Monthly ||
-        periodicity === PeriodicityType.Once ||
-        (periodicity === PeriodicityType.Weekdays && isMonday);
-
-      if (doSimpleSpreadCheck) {
-        !isCompletedToday && result.push(eventEntity);
-        continue;
-      }
-
-      const isFromTueToFri = now.getDay() >= 2 && now.getDay() <= 5;
-
-      const doAdvancedSpreadCheck =
-        periodicity === PeriodicityType.Daily ||
-        (periodicity === PeriodicityType.Weekdays && isFromTueToFri);
-
-      const considerSpread = doAdvancedSpreadCheck;
-
-      const voidInterval: DatesFromTo = this.utility.getVoidInterval(
-        eventEntity.event,
-        considerSpread,
-      );
-
-      const isInVoidInterval = this.utility.isInInterval(
-        voidInterval,
-        now,
-        'from',
-      );
-
-      const isCompletedInVoidInterval = this.utility.isInInterval(
-        voidInterval,
-        this.utility.getCompletedAt(eventEntity),
-        'from',
-      );
-
-      if (
-        doAdvancedSpreadCheck &&
-        isInVoidInterval &&
-        !isCompletedInVoidInterval
-      ) {
+      if (this.isInGroup(eventEntity.event)) {
         result.push(eventEntity);
       }
     }

--- a/src/widgets/activity-group/model/factories/index.ts
+++ b/src/widgets/activity-group/model/factories/index.ts
@@ -1,1 +1,3 @@
 export * from './GroupUtility';
+export * from './AvailableGroupEvaluator';
+export * from './ScheduledGroupEvaluator';

--- a/src/widgets/activity-group/model/services/ActivityGroupsBuildManager.ts
+++ b/src/widgets/activity-group/model/services/ActivityGroupsBuildManager.ts
@@ -64,7 +64,6 @@ const createActivityGroupsBuildManager = (logger: ILogger) => {
     appletId: string,
     entitiesProgress: StoreProgress,
     queryClient: QueryClient,
-    applyInProgressFilter: boolean,
   ): BuildResult => {
     const appletResponse = getDataFromQuery<AppletDetailsResponse>(
       getAppletDetailsKey(appletId),
@@ -112,7 +111,6 @@ const createActivityGroupsBuildManager = (logger: ILogger) => {
       allAppletActivities: activities,
       appletId: appletId,
       progress: convertProgress(entitiesProgress),
-      applyInProgressFilter,
     });
 
     let entityEvents = events
@@ -168,17 +166,11 @@ const createActivityGroupsBuildManager = (logger: ILogger) => {
     appletId: string,
     entitiesProgress: StoreProgress,
     queryClient: QueryClient,
-    applyInProgressFilter: boolean = true,
   ): BuildResult => {
     try {
       logger.log('[ActivityGroupsBuildManager.process]: Building groups..');
 
-      const result = processInternal(
-        appletId,
-        entitiesProgress,
-        queryClient,
-        applyInProgressFilter,
-      );
+      const result = processInternal(appletId, entitiesProgress, queryClient);
 
       logger.log('[ActivityGroupsBuildManager.process]: Build is done');
 

--- a/src/widgets/activity-group/ui/ActivityGroups.tsx
+++ b/src/widgets/activity-group/ui/ActivityGroups.tsx
@@ -5,7 +5,6 @@ import { useIsFetching } from '@tanstack/react-query';
 import {
   CheckAvailability,
   CompleteEntityIntoUploadToQueue,
-  ProcessAutocompletion,
 } from '@app/abstract/lib';
 import { getAppletCompletedEntitiesKey } from '@app/shared/lib';
 import {
@@ -24,7 +23,6 @@ import { useActivityGroups } from '../model';
 type Props = {
   appletId: string;
   completeEntity: CompleteEntityIntoUploadToQueue;
-  processAutocompletion: ProcessAutocompletion;
   checkAvailability: CheckAvailability;
 } & BoxProps;
 
@@ -88,7 +86,6 @@ const ActivityGroups: FC<Props> = props => {
           appletId={props.appletId}
           groups={groups}
           completeEntity={props.completeEntity}
-          processAutocompletion={props.processAutocompletion}
           checkAvailability={props.checkAvailability}
         />
       </YStack>

--- a/src/widgets/activity-group/ui/ActivitySectionList.tsx
+++ b/src/widgets/activity-group/ui/ActivitySectionList.tsx
@@ -8,7 +8,6 @@ import {
   CheckAvailability,
   CompleteEntityIntoUploadToQueue,
   EntityType,
-  ProcessAutocompletion,
 } from '@app/abstract/lib';
 import { Logger, useUploadObservable } from '@app/shared/lib';
 import { AutoCompletionMutex } from '@app/widgets/survey/model';
@@ -28,7 +27,6 @@ type Props = {
   appletId: string;
   groups: Array<ActivityListGroup>;
   completeEntity: CompleteEntityIntoUploadToQueue;
-  processAutocompletion: ProcessAutocompletion;
   checkAvailability: CheckAvailability;
 };
 
@@ -37,7 +35,6 @@ function ActivitySectionList({
   groups,
   completeEntity,
   checkAvailability,
-  processAutocompletion,
 }: Props) {
   const { t } = useTranslation();
 
@@ -79,7 +76,7 @@ function ActivitySectionList({
     });
   }
 
-  const startActivityOrFlow = ({
+  const startActivityOrFlow = async ({
     activityId,
     eventId,
     flowId,
@@ -99,49 +96,41 @@ function ActivitySectionList({
       : name;
 
     if (flowId) {
-      startFlow(appletId, flowId, eventId, entityName, isTimerElapsed).then(
-        result => {
-          if (
-            result.cannotBeStartedDueToMediaFound ||
-            result.cannotBeStartedDueToMigrationsNotApplied ||
-            result.cannotBeStartedDueToAllItemsHidden ||
-            result.cannotBeStarted
-          ) {
-            processAutocompletion();
-            return;
-          }
-
-          if (result.startedFromScratch) {
-            clearStorageRecords.byEventId(eventId);
-          }
-
-          navigateSurvey(flowId, 'flow', eventId);
-        },
+      const result = await startFlow(
+        appletId,
+        flowId,
+        eventId,
+        entityName,
+        isTimerElapsed,
       );
+
+      if (result.failed) {
+        return;
+      }
+
+      if (result.fromScratch) {
+        clearStorageRecords.byEventId(eventId);
+      }
+
+      navigateSurvey(flowId, 'flow', eventId);
     } else {
-      startActivity(
+      const result = await startActivity(
         appletId,
         activityId,
         eventId,
         entityName,
         isTimerElapsed,
-      ).then(result => {
-        if (
-          result.cannotBeStartedDueToMediaFound ||
-          result.cannotBeStartedDueToMigrationsNotApplied ||
-          result.cannotBeStartedDueToAllItemsHidden ||
-          result.cannotBeStarted
-        ) {
-          processAutocompletion();
-          return;
-        }
+      );
 
-        if (result.startedFromScratch) {
-          clearStorageRecords.byEventId(eventId);
-        }
+      if (result.failed) {
+        return;
+      }
 
-        navigateSurvey(activityId, 'regular', eventId);
-      });
+      if (result.fromScratch) {
+        clearStorageRecords.byEventId(eventId);
+      }
+
+      navigateSurvey(activityId, 'regular', eventId);
     }
   };
 
@@ -159,6 +148,7 @@ function ActivitySectionList({
             if (!isFocused()) {
               return;
             }
+
             startActivityOrFlow(item);
           }}
         />

--- a/src/widgets/survey/model/hooks/index.ts
+++ b/src/widgets/survey/model/hooks/index.ts
@@ -5,3 +5,6 @@ export * from './useActivityRecordsInitialization';
 export * from './useSummaryData';
 export { default as useAutoCompletion } from './useAutoCompletion';
 export { AutoCompletionMutex } from './useAutoCompletion';
+export { default as useOnAutoCompletion } from './useOnAutoCompletion';
+export { default as useAutoCompletionExecute } from './useAutoCompletionExecute';
+export type { AutocompletionExecuteOptions } from './useAutoCompletionExecute';

--- a/src/widgets/survey/model/hooks/useAutoCompletion.ts
+++ b/src/widgets/survey/model/hooks/useAutoCompletion.ts
@@ -33,6 +33,7 @@ type Result = {
   process: ProcessAutocompletion;
   completeEntityIntoUploadToQueue: CompleteEntityIntoUploadToQueue;
   hasItemsInQueue: boolean;
+  hasExpiredEntity: () => boolean;
 };
 
 export const AutoCompletionMutex = Mutex();
@@ -189,9 +190,20 @@ const useAutoCompletion = (): Result => {
     [notCompletedEntities, mutex, createConstructService],
   );
 
+  const hasExpiredEntity = (): boolean => {
+    const result = new CollectCompletionsService(
+      notCompletedEntities,
+    ).hasExpiredEntity();
+
+    Logger.log(`[useAutoCompletion.hasExpiredEntity]: ${String(result)}`);
+
+    return result;
+  };
+
   return {
     process: processAutocompletion,
     completeEntityIntoUploadToQueue,
+    hasExpiredEntity,
     hasItemsInQueue: hasItemsInQueue(),
   };
 };

--- a/src/widgets/survey/model/hooks/useAutoCompletionExecute.ts
+++ b/src/widgets/survey/model/hooks/useAutoCompletionExecute.ts
@@ -1,0 +1,64 @@
+import { useCallback } from 'react';
+
+import { AppletModel } from '@app/entities/applet';
+import { Logger, useCurrentRoute } from '@app/shared/lib';
+
+import { useAutoCompletion } from './';
+
+type SafeChecks = 'in-progress-activity' | 'refresh' | 'start-entity';
+
+export type AutocompletionExecuteOptions = {
+  checksToExclude: Array<SafeChecks>;
+};
+
+const useAutoCompletionExecute = () => {
+  const { getCurrentRoute } = useCurrentRoute();
+
+  const { process: processAutocompletion } = useAutoCompletion();
+
+  const autocomplete = useCallback(
+    async (options: AutocompletionExecuteOptions = { checksToExclude: [] }) => {
+      const { checksToExclude } = options;
+
+      const executing = getCurrentRoute() === 'InProgressActivity';
+
+      Logger.log('[useAutoCompletionExecute.autocomplete] Started');
+
+      if (!checksToExclude.includes('in-progress-activity') && executing) {
+        Logger.info(
+          '[useAutoCompletionExecute.autocomplete]: Postponed due to entity is in progress',
+        );
+        return;
+      }
+
+      if (
+        !checksToExclude.includes('refresh') &&
+        AppletModel.RefreshService.isBusy()
+      ) {
+        Logger.info(
+          '[useAutoCompletionExecute.autocomplete]: Postponed due to RefreshService.mutex is busy',
+        );
+        return;
+      }
+
+      if (
+        !checksToExclude.includes('start-entity') &&
+        AppletModel.StartEntityMutex.isBusy()
+      ) {
+        Logger.log(
+          '[useAutoCompletionExecute.startActivityOrFlow] Postponed due to StartEntityMutex is busy',
+        );
+        return;
+      }
+
+      await processAutocompletion();
+    },
+    [getCurrentRoute, processAutocompletion],
+  );
+
+  return {
+    executeAutocompletion: autocomplete,
+  };
+};
+
+export default useAutoCompletionExecute;

--- a/src/widgets/survey/model/hooks/useAvailabilityTimer.ts
+++ b/src/widgets/survey/model/hooks/useAvailabilityTimer.ts
@@ -1,26 +1,22 @@
 import { useEffect } from 'react';
 import { useRef } from 'react';
 
-import { HourMinute, getMsFromHours, getMsFromMinutes } from '@app/shared/lib';
+import { getNow } from '@app/shared/lib';
 import { AppTimer } from '@app/shared/lib';
 
 import InterimInActionPostponer from '../services/InterimInActionPostponer';
 
 type UseTimerInput = {
   onFinish: () => void;
-  entityStartedAt: number;
-  timerHourMinute?: HourMinute | null;
+  availableTo: number | null;
 };
 
-const useTimer = (input: UseTimerInput) => {
-  const { onFinish, entityStartedAt, timerHourMinute } = input;
+const useAvailabilityTimer = (input: UseTimerInput) => {
+  const { onFinish, availableTo } = input;
 
-  const durationBySettings = timerHourMinute
-    ? getMsFromHours(timerHourMinute.hours) +
-      getMsFromMinutes(timerHourMinute.minutes)
-    : 0;
+  const duration = availableTo ? availableTo - getNow().getTime() : 0;
 
-  const timerLogicIsUsed = durationBySettings > 0;
+  const timerLogicIsUsed = duration > 0;
 
   const finishRef = useRef(onFinish);
 
@@ -35,24 +31,15 @@ const useTimer = (input: UseTimerInput) => {
       return;
     }
 
-    const alreadyElapsed: number = Date.now() - entityStartedAt;
-
-    const noTimeLeft: boolean = alreadyElapsed > durationBySettings;
-
-    if (noTimeLeft) {
-      finishRef.current();
-      return;
-    }
-
-    const durationLeft = durationBySettings - alreadyElapsed;
-
     const timer = new AppTimer(
       () => {
+        console.log('useAvailabilityTimer, tick');
+
         postponer.tryExecute();
         timer.stop();
       },
       false,
-      durationLeft,
+      duration,
     );
 
     timer.start();
@@ -65,4 +52,4 @@ const useTimer = (input: UseTimerInput) => {
   }, []);
 };
 
-export default useTimer;
+export default useAvailabilityTimer;

--- a/src/widgets/survey/model/hooks/useEventTimer.ts
+++ b/src/widgets/survey/model/hooks/useEventTimer.ts
@@ -1,0 +1,68 @@
+import { useEffect } from 'react';
+import { useRef } from 'react';
+
+import { HourMinute, getMsFromHours, getMsFromMinutes } from '@app/shared/lib';
+import { AppTimer } from '@app/shared/lib';
+
+import InterimInActionPostponer from '../services/InterimInActionPostponer';
+
+type UseTimerInput = {
+  onFinish: () => void;
+  entityStartedAt: number;
+  timerHourMinute?: HourMinute | null;
+};
+
+const useEventTimer = (input: UseTimerInput) => {
+  const { onFinish, entityStartedAt, timerHourMinute } = input;
+
+  const durationBySettings = timerHourMinute
+    ? getMsFromHours(timerHourMinute.hours) +
+      getMsFromMinutes(timerHourMinute.minutes)
+    : 0;
+
+  const timerLogicIsUsed = durationBySettings > 0;
+
+  const finishRef = useRef(onFinish);
+
+  finishRef.current = onFinish;
+
+  const postponer = useRef(
+    new InterimInActionPostponer(() => finishRef.current()),
+  ).current;
+
+  useEffect(() => {
+    if (!timerLogicIsUsed) {
+      return;
+    }
+
+    const alreadyElapsed: number = Date.now() - entityStartedAt;
+
+    const noTimeLeft: boolean = alreadyElapsed > durationBySettings;
+
+    if (noTimeLeft) {
+      finishRef.current();
+      return;
+    }
+
+    const durationLeft = durationBySettings - alreadyElapsed;
+
+    const timer = new AppTimer(
+      () => {
+        postponer.tryExecute();
+        timer.stop();
+      },
+      false,
+      durationLeft,
+    );
+
+    timer.start();
+
+    return () => {
+      timer.stop();
+      postponer.reset();
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+};
+
+export default useEventTimer;

--- a/src/widgets/survey/model/hooks/useFlowStateActions.ts
+++ b/src/widgets/survey/model/hooks/useFlowStateActions.ts
@@ -130,14 +130,17 @@ export function useFlowStateActions({
     }
   }
 
-  function completeByTimer(): void {
+  function completeByTimer(timerType: 'event' | 'availability'): void {
     const record: FlowState = getCurrentFlowStorageRecord()!;
 
     Logger.log(
-      `[useFlowStateActions.completeByTimer] Executing, current step is: ${record.step}`,
+      `[useFlowStateActions.completeByTimer] Executing, current step is: ${record.step}, timer type: ${timerType}`,
     );
 
     if (isLastStep(record) || isSummaryStep(record)) {
+      Logger.log(
+        `[useFlowStateActions.completeByTimer] Cancelled as we're on either finish or summary step, timer type: ${timerType}`,
+      );
       return;
     }
 

--- a/src/widgets/survey/model/hooks/useOnAutoCompletion.ts
+++ b/src/widgets/survey/model/hooks/useOnAutoCompletion.ts
@@ -1,0 +1,38 @@
+/* eslint-disable @typescript-eslint/no-floating-promises */
+import { useCallback, useEffect, useRef } from 'react';
+
+import { Emitter } from '@shared/lib';
+
+import { AutocompletionExecuteOptions, useAutoCompletionExecute } from './';
+
+function useOnAutoCompletion(callback?: () => void) {
+  const callbackRef = useRef(callback);
+
+  callbackRef.current = callback;
+
+  const { executeAutocompletion } = useAutoCompletionExecute();
+
+  const processAutocompletion = useCallback(
+    (payload?: AutocompletionExecuteOptions) => {
+      executeAutocompletion(payload).then(() => {
+        if (callbackRef.current) {
+          callbackRef.current();
+        }
+      });
+    },
+    [executeAutocompletion],
+  );
+
+  useEffect(() => {
+    Emitter.on<AutocompletionExecuteOptions>(
+      'autocomplete',
+      processAutocompletion,
+    );
+
+    return () => {
+      Emitter.off('autocomplete', processAutocompletion);
+    };
+  }, [processAutocompletion]);
+}
+
+export default useOnAutoCompletion;

--- a/src/widgets/survey/ui/FlowSurvey.tsx
+++ b/src/widgets/survey/ui/FlowSurvey.tsx
@@ -9,7 +9,8 @@ import {
   useFlowState,
   useFlowStateActions,
 } from '../model';
-import useTimer from '../model/hooks/useTimer';
+import useAvailabilityTimer from '../model/hooks/useAvailabilityTimer';
+import useEventTimer from '../model/hooks/useEventTimer';
 
 type Props = {
   onClose: () => void;
@@ -50,10 +51,15 @@ function FlowSurvey({
 
   const entityStartedAt = progressRecord.startAt;
 
-  useTimer({
+  useEventTimer({
     entityStartedAt,
-    onFinish: completeByTimer,
     timerHourMinute: event.timers?.timer,
+    onFinish: () => completeByTimer('event'),
+  });
+
+  useAvailabilityTimer({
+    availableTo: progressRecord.availableTo,
+    onFinish: () => completeByTimer('availability'),
   });
 
   const flowPipelineItem = pipeline[step];


### PR DESCRIPTION
### 📝 Description

<!-- Contributions are welcome! If there is a corresponding      -->
<!-- JIRA ticket, link to it by replacing `#` with ticket number -->

🔗 [Jira Ticket M2-7065](https://mindlogger.atlassian.net/browse/M2-7065)
🔗 [Jira Ticket M2-6962](https://mindlogger.atlassian.net/browse/M2-6962)
🔗 [Jira Ticket M2-6963](https://mindlogger.atlassian.net/browse/M2-6963)
🔗 [Jira Ticket M2-6964](https://mindlogger.atlassian.net/browse/M2-6964)
🔗 [Jira Ticket M2-6956](https://mindlogger.atlassian.net/browse/M2-6956)
🔗 [Jira Ticket M2-6952](https://mindlogger.atlassian.net/browse/M2-6952)

Autocompletion, phase # 2, delivery # 1

Changes include:

- Check entity avaiability is rewritten, now we use evaluators directly, i.o. groups-builders
- Evaluators adopted for usage them directly
- Fixes related unit-tests
- Refactored useStartEntity to return more crisp result
- Added new triggers: activity closed, app goes to foreground
- Refactored/extended RootNavigator to support all this
- Added Activity-level availability timer and related hook
