### PR TITLE
M2-7248, M2-7246: bugfixes for autocompletion delivery part 2

### DIFF
--- a/src/features/tap-on-notification/model/hooks/useOnNotificationTap.ts
+++ b/src/features/tap-on-notification/model/hooks/useOnNotificationTap.ts
@@ -26,6 +26,7 @@ import {
 import { LogTrigger, QueryDataUtils } from '@app/shared/api';
 import {
   AnalyticsService,
+  Emitter,
   getEntityProgress,
   HourMinute,
   isEntityInProgress,
@@ -214,6 +215,10 @@ export function useOnNotificationTap({
         ) === null;
     }
 
+    const autocomplete = () => {
+      Emitter.emit('autocomplete');
+    };
+
     if (entityType === 'flow') {
       const result = await startFlow(
         appletId,
@@ -222,6 +227,10 @@ export function useOnNotificationTap({
         entityName,
         isTimerElapsed,
       );
+
+      if (result.failReason === 'expired-while-alert-opened') {
+        return autocomplete();
+      }
 
       if (result.failed) {
         return;
@@ -240,6 +249,10 @@ export function useOnNotificationTap({
         entityName,
         isTimerElapsed,
       );
+
+      if (result.failReason === 'expired-while-alert-opened') {
+        return autocomplete();
+      }
 
       if (result.failed) {
         return;

--- a/src/screens/model/checkEntityAvailability.ts
+++ b/src/screens/model/checkEntityAvailability.ts
@@ -50,11 +50,11 @@ const checkEntityAvailabilityInternal = ({
   const record = getEntityProgress(appletId, entityId, eventId, storeProgress);
 
   logger.log(
-    `[checkEntityAvailability]: Checking.. Entity = "${entityName}", appletId = ${appletId}, entityId = ${entityId}, entityType = ${entityType}, eventId = ${eventId} `,
+    `[checkEntityAvailability]: Checking.. Entity = "${entityName}", appletId = "${appletId}", entityId = "${entityId}", entityType = "${entityType}", eventId = "${eventId}"`,
   );
 
   Logger.log(
-    `[checkEntityAvailability] Now is ${getNow().toUTCString()}, record = ${JSON.stringify(record)}`,
+    `[checkEntityAvailability] record = ${JSON.stringify(record, null, 2)}`,
   );
 
   const isInProgress = isEntityInProgress(record);

--- a/src/shared/lib/hooks/index.ts
+++ b/src/shared/lib/hooks/index.ts
@@ -8,6 +8,7 @@ export { default as useMicrophonePermissions } from './useMicrophonePermissions'
 export { default as useNotificationPermissions } from './useNotificationPermissions';
 export { default as useCacheHasData } from './useCacheHasData';
 export { default as useOnForeground } from './useOnForeground';
+export { default as useOnForegroundDebounced } from './useOnForegroundDebounced';
 export { default as useAlarmPermissions } from './useAlarmPermissions';
 export { default as useBackgroundTask } from './useBackgroundTask';
 export { default as usePrevious } from './usePrevious';

--- a/src/shared/lib/hooks/useOnForegroundDebounced.ts
+++ b/src/shared/lib/hooks/useOnForegroundDebounced.ts
@@ -3,29 +3,32 @@ import { AppState, AppStateStatus } from 'react-native';
 
 import { useDebouncedCallback } from 'use-debounce';
 
+import { IS_IOS, Logger } from '../';
+
 type Options = {
   enabled: boolean;
 };
 
-const DebounceInterval = 100;
+const DebounceInterval = 200;
 
 function useOnForegroundDebounced(
   callback: () => void,
   options?: Partial<Options>,
 ) {
-  const callbackRef = useRef(callback);
-
-  callbackRef.current = callback;
-
   const previousStatusRef = useRef<AppStateStatus | null>(null);
-
-  const previousStatus = previousStatusRef.current;
 
   const enabled = options?.enabled ?? true;
 
   const debouncedCallback = useDebouncedCallback((status: AppStateStatus) => {
-    if (status === 'active' && status !== previousStatus && enabled) {
-      callbackRef.current();
+    const previousStatus = previousStatusRef.current;
+
+    const isStatusChanged = IS_IOS ? status !== previousStatus : true;
+
+    if (status === 'active' && isStatusChanged && enabled) {
+      Logger.log(
+        '[useOnForegroundDebounced.useDebouncedCallback]: Call callback',
+      );
+      callback();
     }
 
     previousStatusRef.current = status;

--- a/src/shared/lib/hooks/useOnForegroundDebounced.ts
+++ b/src/shared/lib/hooks/useOnForegroundDebounced.ts
@@ -1,0 +1,43 @@
+import { useEffect, useRef } from 'react';
+import { AppState, AppStateStatus } from 'react-native';
+
+import { useDebouncedCallback } from 'use-debounce';
+
+type Options = {
+  enabled: boolean;
+};
+
+const DebounceInterval = 100;
+
+function useOnForegroundDebounced(
+  callback: () => void,
+  options?: Partial<Options>,
+) {
+  const callbackRef = useRef(callback);
+
+  callbackRef.current = callback;
+
+  const previousStatusRef = useRef<AppStateStatus | null>(null);
+
+  const previousStatus = previousStatusRef.current;
+
+  const enabled = options?.enabled ?? true;
+
+  const debouncedCallback = useDebouncedCallback((status: AppStateStatus) => {
+    if (status === 'active' && status !== previousStatus && enabled) {
+      callbackRef.current();
+    }
+
+    previousStatusRef.current = status;
+  }, DebounceInterval);
+
+  useEffect(() => {
+    const subscription = AppState.addEventListener('change', debouncedCallback);
+
+    return () => {
+      subscription.remove();
+    };
+  }, [debouncedCallback]);
+}
+
+export default useOnForegroundDebounced;

--- a/src/shared/lib/hooks/useOnceRef.ts
+++ b/src/shared/lib/hooks/useOnceRef.ts
@@ -1,14 +1,13 @@
 import { useEffect, useRef } from 'react';
 
 const useOnceRef = (callback: () => void) => {
-  const currentStateRef = useRef<boolean>(false);
+  const callbackRef = useRef(callback);
+
+  callbackRef.current = callback;
 
   useEffect(() => {
-    if (!currentStateRef.current) {
-      currentStateRef.current = true;
-      callback();
-    }
-  }, [callback]);
+    callbackRef.current();
+  }, []);
 };
 
 export default useOnceRef;

--- a/src/shared/lib/hooks/useOnlineEstablished.ts
+++ b/src/shared/lib/hooks/useOnlineEstablished.ts
@@ -10,6 +10,10 @@ The addEventListener is always fired on app start, so we ignore it by update the
 const useOnlineEstablished = (callback: () => void) => {
   const currentStateRef = useRef<boolean | null>(null);
 
+  const callbackRef = useRef(callback);
+
+  callbackRef.current = callback;
+
   useEffect(() => {
     return NetInfo.addEventListener(state => {
       const status =
@@ -19,12 +23,12 @@ const useOnlineEstablished = (callback: () => void) => {
 
       if (currentStateRef.current === false && status) {
         Logger.log('[useOnlineEstablished] Trigger');
-        callback();
+        callbackRef.current();
       }
 
       currentStateRef.current = status;
     });
-  }, [callback]);
+  }, []);
 };
 
 export default useOnlineEstablished;

--- a/src/widgets/activity-group/ui/ActivitySectionList.tsx
+++ b/src/widgets/activity-group/ui/ActivitySectionList.tsx
@@ -9,7 +9,7 @@ import {
   CompleteEntityIntoUploadToQueue,
   EntityType,
 } from '@app/abstract/lib';
-import { Logger, useUploadObservable } from '@app/shared/lib';
+import { Emitter, Logger, useUploadObservable } from '@app/shared/lib';
 import { AutoCompletionMutex } from '@app/widgets/survey/model';
 import {
   ActivityCard,
@@ -91,6 +91,10 @@ function ActivitySectionList({
       return;
     }
 
+    const autocomplete = () => {
+      Emitter.emit('autocomplete');
+    };
+
     const entityName = activityFlowDetails
       ? activityFlowDetails.activityFlowName
       : name;
@@ -103,6 +107,10 @@ function ActivitySectionList({
         entityName,
         isTimerElapsed,
       );
+
+      if (result.failReason === 'expired-while-alert-opened') {
+        return autocomplete();
+      }
 
       if (result.failed) {
         return;
@@ -121,6 +129,10 @@ function ActivitySectionList({
         entityName,
         isTimerElapsed,
       );
+
+      if (result.failReason === 'expired-while-alert-opened') {
+        return autocomplete();
+      }
 
       if (result.failed) {
         return;

--- a/src/widgets/survey/model/hooks/index.ts
+++ b/src/widgets/survey/model/hooks/index.ts
@@ -7,4 +7,7 @@ export { default as useAutoCompletion } from './useAutoCompletion';
 export { AutoCompletionMutex } from './useAutoCompletion';
 export { default as useOnAutoCompletion } from './useOnAutoCompletion';
 export { default as useAutoCompletionExecute } from './useAutoCompletionExecute';
-export type { AutocompletionExecuteOptions } from './useAutoCompletionExecute';
+export type {
+  AutocompletionExecuteOptions,
+  LogAutocompletionTrigger,
+} from './useAutoCompletionExecute';

--- a/src/widgets/survey/model/hooks/useAutoCompletion.ts
+++ b/src/widgets/survey/model/hooks/useAutoCompletion.ts
@@ -34,6 +34,7 @@ type Result = {
   completeEntityIntoUploadToQueue: CompleteEntityIntoUploadToQueue;
   hasItemsInQueue: boolean;
   hasExpiredEntity: () => boolean;
+  evaluateIfItemsInQueueExist: () => boolean;
 };
 
 export const AutoCompletionMutex = Mutex();
@@ -53,9 +54,9 @@ const useAutoCompletion = (): Result => {
 
   const queryClient = useQueryClient();
 
-  const hasItemsInQueue = (): boolean => {
+  const hasItemsInQueue = useCallback(() => {
     return AnswersQueueService.getLength() > 0;
-  };
+  }, []);
 
   const createConstructService = useCallback(() => {
     return new ConstructCompletionsService(
@@ -187,7 +188,7 @@ const useAutoCompletion = (): Result => {
 
       return result;
     },
-    [notCompletedEntities, mutex, createConstructService],
+    [mutex, notCompletedEntities, createConstructService, hasItemsInQueue],
   );
 
   const hasExpiredEntity = useCallback((): boolean => {
@@ -205,6 +206,7 @@ const useAutoCompletion = (): Result => {
     completeEntityIntoUploadToQueue,
     hasExpiredEntity,
     hasItemsInQueue: hasItemsInQueue(),
+    evaluateIfItemsInQueueExist: hasItemsInQueue,
   };
 };
 

--- a/src/widgets/survey/model/hooks/useAutoCompletionExecute.ts
+++ b/src/widgets/survey/model/hooks/useAutoCompletionExecute.ts
@@ -32,7 +32,7 @@ const useAutoCompletionExecute = () => {
 
   const navigation = useNavigation();
 
-  const { hasExpiredEntity, hasItemsInQueue } = useAutoCompletion();
+  const { hasExpiredEntity, evaluateIfItemsInQueueExist } = useAutoCompletion();
 
   const autocomplete = useCallback(
     (
@@ -52,8 +52,10 @@ const useAutoCompletionExecute = () => {
 
       const isUploading = UploadObservable.isLoading;
 
+      const hasItemsInQueue = evaluateIfItemsInQueueExist();
+
       Logger.log(
-        `[useAutoCompletionExecute.autocomplete] Started, logTrigger="${logTrigger}", forceUpload="${forceUpload}", checksToExclude=${JSON.stringify(checksToExclude)} `,
+        `[useAutoCompletionExecute.autocomplete] Started, logTrigger="${logTrigger}", forceUpload="${forceUpload}", checksToExclude=${JSON.stringify(checksToExclude)}, hasItemsInQueue=${hasItemsInQueue}`,
       );
 
       if (
@@ -115,7 +117,12 @@ const useAutoCompletionExecute = () => {
         closingInProgressEntityScreen ? CompleteCurrentNavigationDelay : 0,
       );
     },
-    [getCurrentRoute, hasExpiredEntity, hasItemsInQueue, navigation],
+    [
+      evaluateIfItemsInQueueExist,
+      getCurrentRoute,
+      hasExpiredEntity,
+      navigation,
+    ],
   );
 
   return {

--- a/src/widgets/survey/model/hooks/useOnAutoCompletion.ts
+++ b/src/widgets/survey/model/hooks/useOnAutoCompletion.ts
@@ -13,7 +13,7 @@ function useOnAutoCompletion(callback?: () => void) {
 
   const processAutocompletion = useCallback(
     (payload?: AutocompletionExecuteOptions) => {
-      executeAutocompletion(payload);
+      executeAutocompletion('unknown', payload);
 
       if (callbackRef.current) {
         callbackRef.current();

--- a/src/widgets/survey/ui/UploadRetryBanner.tsx
+++ b/src/widgets/survey/ui/UploadRetryBanner.tsx
@@ -27,7 +27,7 @@ const UploadRetryBanner: FC<Props> = () => {
 
     Emitter.emit<SurveyModel.AutocompletionExecuteOptions>('autocomplete', {
       checksToExclude: [],
-      considerUploadQueue: true,
+      forceUpload: true,
     });
   };
 


### PR DESCRIPTION
### 📝 Description

<!-- Contributions are welcome! If there is a corresponding      -->
<!-- JIRA ticket, link to it by replacing `#` with ticket number -->

🔗 [Jira Ticket M2-7248](https://mindlogger.atlassian.net/browse/M2-7248)
🔗 [Jira Ticket M2-7246](https://mindlogger.atlassian.net/browse/M2-7246)

<!-- Replace this with a high-level description of the features/functionality proposed in the pull request. -->

Changes include:

- Fix for iOS: swipe from up to down - previousy -  the event 'active' registered
- Fix for restart-resume, when alert opened for a long time, the entity could expire
- Lite refactoring in RootNavigator: triggers for autocompletion when: go-to-foreground, on-app-start, go-to-online
- Fix for isQueueEmpty when autocompletion with upload works, to make decision if blocker screens should be opened