### PR TITLE
fix(feature-flags): Change the flag name from camelCase to dash-case

### DIFF
--- a/src/shared/lib/featureFlags/FeatureFlags.types.ts
+++ b/src/shared/lib/featureFlags/FeatureFlags.types.ts
@@ -1,7 +1,7 @@
 import { LDFlagValue } from '@launchdarkly/react-native-client-sdk';
 
 export const FeatureFlagsKeys = {
-  enableConsentsCapability: 'enableLorisIntegration',
+  enableConsentsCapability: 'enable-loris-integration',
 };
 
 export type FeatureFlags = Partial<


### PR DESCRIPTION
### 📝 Description

It just fixes feature flags naming convention: from camelCase to dash-case. Apparently, LaunchDarkly for React Native accepts only the latter though they don't mention that in the docs.