### PR TITLE
M2-7464: [Mobile] Fix DatePickerItem unit tests

### DIFF
--- a/src/shared/ui/survey/tests/DatePickerItem.test.tsx
+++ b/src/shared/ui/survey/tests/DatePickerItem.test.tsx
@@ -21,7 +21,7 @@ describe('Test DatePickerItem', () => {
     expect(placeholder).toBe(expected);
   });
 
-  it('Should render new Date(0) when value is 1970-01-01', () => {
+  it('Should consume new Date(1970, 0, 1) when props value is "1970-01-01"', () => {
     const testValue = '1970-01-01';
     const datePickerComponent = renderer.create(
       <TamaguiProvider>
@@ -34,8 +34,24 @@ describe('Test DatePickerItem', () => {
     });
 
     const resultDate = datePicker.props.value as Date;
-    expect(resultDate.getUTCFullYear()).toBe(new Date(0).getUTCFullYear());
-    expect(resultDate.getUTCMonth()).toBe(new Date(0).getUTCMonth());
-    expect(resultDate.getUTCDate()).toBe(new Date(0).getUTCDate());
+
+    expect(resultDate).toEqual(new Date(1970, 0, 1));
+  });
+
+  it('Should consume new Date(2010, 5, 8) when props value is "2010-06-08"', () => {
+    const testValue = '2010-06-08';
+    const datePickerComponent = renderer.create(
+      <TamaguiProvider>
+        <DatePickerItem value={testValue} onChange={jest.fn()} />
+      </TamaguiProvider>,
+    );
+
+    const datePicker = datePickerComponent.root.findByProps({
+      accessibilityLabel: 'date-picker',
+    });
+
+    const resultDate = datePicker.props.value as Date;
+
+    expect(resultDate).toEqual(new Date(2010, 5, 8));
   });
 });


### PR DESCRIPTION
### 📝 Description

After 
https://github.com/ChildMindInstitute/mindlogger-app-refactor/pull/833
I've got error (I'm under GMT+2/+3, ~12:30 PM)

![image](https://github.com/user-attachments/assets/61fd7532-fd68-42ba-9697-05eb67552623)

🔗 [Jira Ticket M2-7464](https://mindlogger.atlassian.net/browse/M2-7464)

Changes include:

- Modified useless unit test to get practical sence
- Added another unit test to the same component

The test itself was wrong:
it("Should render new Date(0) when value is 1970-01-01", ... )
new Date(0) doesn't equal to new Date(1970,0,1) because the 1st is based on UTC time, the 2nd - on local.
So, I've changed it to:
it('Should consume new Date(1970, 0, 1) when props value is "1970-01-01"', ... )

### 📸 Screenshots

Some information:

<img width="244" alt="image" src="https://github.com/user-attachments/assets/ee905fb0-4ef7-4911-baab-26222cd8560b">

<img width="609" alt="image" src="https://github.com/user-attachments/assets/136130c5-dd25-426c-804d-d765c54eb1c5">
