### PR TITLE
M2-7538 unknown item types

### DIFF
--- a/src/features/pass-survey/model/pipelineBuilder.ts
+++ b/src/features/pass-survey/model/pipelineBuilder.ts
@@ -385,6 +385,7 @@ export function buildPipeline(activity: ActivityDetails): PipelineItem[] {
     .reduce<PipelineItem[]>((items, item) => {
       return Array.isArray(item) ? [...items, ...item] : [...items, item];
     }, [])
+    .filter(Boolean)
     .map(item => {
       const isAbleToMoveBack =
         activity.responseIsEditable && item.isAbleToMoveBack;

--- a/src/features/pass-survey/model/pipelineBuilder.ts
+++ b/src/features/pass-survey/model/pipelineBuilder.ts
@@ -1,4 +1,5 @@
 import { ActivityDetails, ActivityItem } from '@app/entities/activity';
+import { Logger } from '@app/shared/lib';
 
 import { getAbTrailsPipeline } from './precompiled-pipelines';
 import { PipelineItem } from '../lib';
@@ -379,6 +380,14 @@ export function buildPipeline(activity: ActivityDetails): PipelineItem[] {
             timer: item.timer,
             conditionalLogic: item.conditionalLogic,
           } satisfies PipelineItem;
+        }
+
+        default: {
+          Logger.warn(
+            `[buildPipeline] unknown activity item type found: ${(item as ActivityItem).inputType}`,
+          );
+
+          return null as unknown as PipelineItem;
         }
       }
     })


### PR DESCRIPTION
### 📝 Description

<!-- Contributions are welcome! If there is a corresponding      -->
<!-- JIRA ticket, link to it by replacing `#` with ticket number -->

🔗 [Jira Ticket M2-7538](https://mindlogger.atlassian.net/browse/M2-7538)

There is a dead simple filtering logic that filters out activity items that are not supported in the current version of the mobile app. This is the case when, for instance, the Admin Panel rolls out the release featuring new activity item types but the Mobile App is still in the testing/review phase: admins can start adding news items right away and the mobile app should just those items.
