### PR TITLE
fix(redux): Made redux-persist flush as soon as activity completed

### DIFF
--- a/src/app/ui/AppProvider/ReduxProvider.tsx
+++ b/src/app/ui/AppProvider/ReduxProvider.tsx
@@ -56,7 +56,7 @@ export const reduxStore = configureStore({
   },
 });
 
-const persistor = persistStore(reduxStore);
+export const persistor = persistStore(reduxStore);
 
 const ReduxProvider: FC<PropsWithChildren> = ({ children }) => {
   const { onModuleInitialized, initialized } = useSystemBootUp();

--- a/src/shared/lib/redux-state/store.ts
+++ b/src/shared/lib/redux-state/store.ts
@@ -1,3 +1,4 @@
-import { reduxStore } from '@app/app/ui/AppProvider/ReduxProvider';
+import { reduxStore, persistor } from '@app/app/ui/AppProvider/ReduxProvider';
 
 export const ReduxStore = reduxStore;
+export const ReduxPersistor = persistor;

--- a/src/widgets/survey/model/services/ConstructCompletionsService.ts
+++ b/src/widgets/survey/model/services/ConstructCompletionsService.ts
@@ -23,6 +23,7 @@ import {
   MixProperties,
   wait,
 } from '@app/shared/lib';
+import { ReduxPersistor } from '@app/shared/lib/redux-state/store';
 
 import { getClientInformation } from '../../lib/metaHelpers';
 import {
@@ -485,6 +486,8 @@ export class ConstructCompletionsService {
         endAt: evaluatedEndAt,
       }),
     );
+
+    await ReduxPersistor.flush();
 
     await wait(500); // M2-6153
 


### PR DESCRIPTION
### 📝 Description

🔗 [Jira Ticket M2-7646](https://mindlogger.atlassian.net/browse/M2-7646)

Changes include:

- Redux Persistor is now an exportable variable
- Flush persistor as soon as an activity is completed.

### ✏️ Notes

If a user starts an activity, submits it, and immediately kills the app while "Processing Answers" is displayed, the activity might remain in an in-progress state when the app reopens.

This behavior is likely due to how Redux Persist is configured with the following settings:
```
export const persistConfig = {
  key: 'root',
  throttle: 1000,
  storage: storage,
};
```
The `throttle` property is set to `1000`. This means that the application state is only written to disk in 1 second. This throttling is done for performance reasons, to batch updates, and to avoid overwhelming storage. [API Reference](https://github.com/rt2zz/redux-persist/blob/master/docs/api.md#type-persistconfig)

In this specific scenario, we need the state to be synced immediately after the user completes the activity, not after a 1-second delay. A 1-second delay might be too long for this particular use case.