### PR TITLE
M2-7646: performance optimisation

### DIFF
--- a/src/entities/applet/model/slice.ts
+++ b/src/entities/applet/model/slice.ts
@@ -149,29 +149,33 @@ const slice = createSlice({
     ) => {
       const { appletId, entityId, eventId, endAt } = action.payload;
 
-      const { availableTo } = state.inProgress[appletId][entityId][eventId];
+      const entityState = state.inProgress[appletId]?.[entityId]?.[eventId];
 
+      if (!entityState) return;
+
+      const { availableTo } = entityState;
       const isExpired = isEntityExpired(availableTo);
 
-      state.inProgress[appletId][entityId][eventId].endAt = isExpired
-        ? availableTo
-        : endAt;
+      entityState.endAt = isExpired ? availableTo : endAt;
 
-      const completedEntities = state.completedEntities ?? {};
-
-      const completions = state.completions ?? {};
-
-      completedEntities[entityId] = endAt;
-
-      if (!completions[entityId]) {
-        completions[entityId] = {};
+      if (!state.completedEntities) {
+        state.completedEntities = {};
       }
 
-      const entityCompletions = completions[entityId];
+      state.completedEntities[entityId] = endAt;
+
+      if (!state.completions) {
+        state.completions = {};
+      }
+
+      const entityCompletions = state.completions[entityId] ?? {};
+
+      state.completions[entityId] = entityCompletions;
 
       if (!entityCompletions[eventId]) {
         entityCompletions[eventId] = [];
       }
+
       entityCompletions[eventId].push(endAt);
     },
 


### PR DESCRIPTION
### 📝 Description

🔗 [Jira Ticket M2-7646](https://mindlogger.atlassian.net/browse/M2-7646)

Changes include:

- Slightly improved performance of `entityCompleted` reducer by reducing accessing and mutations of deeply nested properties. Redux Toolkit uses the `immer` library under the hood, which allows for direct state mutation but comes with some performance overhead.
- Moved the invocation of `entityCompleted` action up to the top of `constructForFinish` method. Previously, it was called after a set of mapper functions that contain some medium-heavy computations. That, in turn, caused a ~ 400ms delay in 1-item activity and up to ~700ms in 14-item activity. Now, after optimizations applied, it's ~150 ms in 14-item activity. Screenshot and performance measuring strategy described below.


### Screenshots

Activity with 14 items:

| Before optimizations |
![image](https://github.com/user-attachments/assets/89a37e90-6685-47e8-8a76-b2b7c4057b21)

| After optimizations |
![image](https://github.com/user-attachments/assets/06eaa98a-6832-4679-bed4-2ac70dfe2bc4)



### 🪤 Peer Testing
- Add a variable at the very top of the `constructForFinish` method and assign a `Date` instance: 
<img width="517" alt="Screenshot 2024-08-23 at 2 13 02 PM" src="https://github.com/user-attachments/assets/cb795f9c-6656-49ee-8561-97a6fb992cd2">

- Put some before the `entityCompleted` action, after it, and after Persistor's `flush` action. For each log, add the difference between the current `Date` and the date that you store in the variable described above:
![image](https://github.com/user-attachments/assets/4fed087f-f1ed-4b07-8a79-c154b2510e12)

- Build and run Android release variant. For instance, `yarn android:dev-release`
- Observe the logs using the `npx react-native log-android` command.