### PR TITLE
M2-7745/fixing paragraph Text scroll on Android

### DIFF
--- a/src/shared/ui/survey/ParagraphText.tsx
+++ b/src/shared/ui/survey/ParagraphText.tsx
@@ -1,5 +1,11 @@
-import React, { FC, useState } from 'react';
-import { StyleSheet, TextInputProps, View } from 'react-native';
+import React, { FC, useState, useEffect } from 'react';
+import {
+  StyleSheet,
+  TextInputProps,
+  View,
+  Keyboard,
+  Platform,
+} from 'react-native';
 
 import { useTranslation } from 'react-i18next';
 
@@ -16,15 +22,38 @@ type Props = {
 
 const ParagraphText: FC<Props> = ({ value, onChange, config, ...props }) => {
   const [paragraphOnFocus, setParagraphOnFocus] = useState(false);
+  const [keyboardHeight, setKeyboardHeight] = useState(0);
   const { maxLength = 50 } = config;
   const { t } = useTranslation();
+
+  useEffect(() => {
+    if (Platform.OS != 'ios') {
+      const keyboardDidShowListener = Keyboard.addListener(
+        'keyboardDidShow',
+        event => {
+          setKeyboardHeight(event.endCoordinates.height * 0.8);
+        },
+      );
+      const keyboardDidHideListener = Keyboard.addListener(
+        'keyboardDidHide',
+        () => {
+          setKeyboardHeight(0);
+        },
+      );
+
+      return () => {
+        keyboardDidShowListener.remove();
+        keyboardDidHideListener.remove();
+      };
+    }
+  }, []);
 
   const onChangeText = (text: string) => {
     onChange(text);
   };
 
   return (
-    <View style={styles.container}>
+    <View style={[styles.container, { paddingBottom: keyboardHeight }]}>
       <LongTextInput
         accessibilityLabel="paragraph-item"
         placeholder={t('text_entry:paragraph_placeholder')}


### PR DESCRIPTION
### 📝 Description
🔗 [Jira Ticket M2-7745](https://mindlogger.atlassian.net/browse/M2-7745)
Allowing user scroll downward in Android.
I am adding a extra padding always keyboard opens to allow user scroll down.


### 📸 Screenshots

IOS (didn't change):
https://github.com/user-attachments/assets/e7f7a74d-b8e4-4f50-b510-f86a49c33192

ANDROID:
https://github.com/user-attachments/assets/3733e49f-f7b3-4717-873f-f235bb3a4631

Testing Android with long description:
https://github.com/user-attachments/assets/e723d713-0eae-47aa-baf5-73b46f8bd73c

Result:
![Screenshot 2024-09-10 at 5 00 25 PM](https://github.com/user-attachments/assets/77ae996f-b576-4895-8572-b8b59a486017)



### 🪤 Peer Testing
1 - Build application on Android
2 - Create a ParagraphText item and add it to an applet
3 - Once you open Paragraph text, check if when keyboard is open you can scroll down or not.



### ✏️ Notes
on IOS there should be no changes
