### PR TITLE
Chore/M2-7771 improve encrypt and removing wait from use upload progress

### DIFF
--- a/src/shared/lib/encryption/encryption.ts
+++ b/src/shared/lib/encryption/encryption.ts
@@ -114,14 +114,17 @@ class EncryptionManager {
     const iv: Buffer = this.getRandomBytes();
     const cipher = crypto.createCipheriv('aes-256-cbc', Buffer.from(key), iv);
 
-    let encrypted: Buffer = Buffer.alloc(0);
+    const encryptedChunks: Buffer[] = [];
 
     for (let i = 0; i < text.length; i += CHUNK_SIZE) {
       const chunk = text.slice(i, i + CHUNK_SIZE);
-      encrypted = Buffer.concat([encrypted, cipher.update(chunk)]);
+      encryptedChunks.push(cipher.update(chunk));
     }
 
-    encrypted = Buffer.concat([encrypted, cipher.final()]);
+    encryptedChunks.push(cipher.final());
+
+    const encrypted = Buffer.concat(encryptedChunks);
+
     return `${iv.toString('hex')}:${encrypted.toString('hex')}`;
   };
 

--- a/src/shared/lib/encryption/encryption.ts
+++ b/src/shared/lib/encryption/encryption.ts
@@ -114,17 +114,14 @@ class EncryptionManager {
     const iv: Buffer = this.getRandomBytes();
     const cipher = crypto.createCipheriv('aes-256-cbc', Buffer.from(key), iv);
 
-    const encryptedChunks: Buffer[] = [];
+    let encrypted: Buffer = Buffer.alloc(0);
 
     for (let i = 0; i < text.length; i += CHUNK_SIZE) {
       const chunk = text.slice(i, i + CHUNK_SIZE);
-      encryptedChunks.push(cipher.update(chunk));
+      encrypted = Buffer.concat([encrypted, cipher.update(chunk)]);
     }
 
-    encryptedChunks.push(cipher.final());
-
-    const encrypted = Buffer.concat(encryptedChunks);
-
+    encrypted = Buffer.concat([encrypted, cipher.final()]);
     return `${iv.toString('hex')}:${encrypted.toString('hex')}`;
   };
 

--- a/src/shared/lib/hooks/useUploadProgress.ts
+++ b/src/shared/lib/hooks/useUploadProgress.ts
@@ -2,7 +2,7 @@ import { useEffect } from 'react';
 
 import { useTranslation } from 'react-i18next';
 
-import { UploadProgressObservable, wait } from '../';
+import { UploadProgressObservable } from '../';
 import { SecondLevelStep, UploadProgress } from '../observables/';
 
 import { useForceUpdate } from './';
@@ -100,7 +100,6 @@ const useUploadProgress = (): UseUploadProgressResult => {
   useEffect(() => {
     const onProgressChange = async (delay: number) => {
       update();
-      await wait(delay);
     };
 
     UploadProgressObservable.addObserver(onProgressChange);

--- a/src/shared/lib/hooks/useUploadProgress.ts
+++ b/src/shared/lib/hooks/useUploadProgress.ts
@@ -98,7 +98,7 @@ const useUploadProgress = (): UseUploadProgressResult => {
   }
 
   useEffect(() => {
-    const onProgressChange = async () => {
+    const onProgressChange = () => {
       update();
     };
 

--- a/src/shared/lib/hooks/useUploadProgress.ts
+++ b/src/shared/lib/hooks/useUploadProgress.ts
@@ -98,7 +98,7 @@ const useUploadProgress = (): UseUploadProgressResult => {
   }
 
   useEffect(() => {
-    const onProgressChange = async (delay: number) => {
+    const onProgressChange = async () => {
       update();
     };
 

--- a/src/shared/lib/observables/uploadProgressObservable.ts
+++ b/src/shared/lib/observables/uploadProgressObservable.ts
@@ -1,4 +1,3 @@
-/* eslint-disable no-nested-ternary */
 import { CommonObservable } from '../utils';
 
 export type SecondLevelStep =
@@ -25,10 +24,6 @@ export interface IUploadProgressObservableSetters {
   setCurrentSecondLevelStepKey(value: SecondLevelStep | null): Promise<void>;
   reset(): void;
 }
-
-const ShortDelay = 100;
-const MiddleDelay = 200;
-const LongFakeStepDelay = 500;
 
 class UploadProgressObservable
   extends CommonObservable
@@ -61,19 +56,13 @@ class UploadProgressObservable
 
   public async setTotalFilesInActivity(value: number | null) {
     this.uploadProgress.totalFilesInActivity = value;
-    await this.notifyAsync(value === 0 ? LongFakeStepDelay : 0);
+    this.notify();
   }
 
   public async setCurrentSecondLevelStepKey(value: SecondLevelStep | null) {
     this.uploadProgress.currentSecondLevelStepKey = value;
 
-    await this.notifyAsync(
-      value === 'upload_files' || value === 'encrypt_answers'
-        ? ShortDelay
-        : value === 'completed'
-          ? MiddleDelay
-          : 0,
-    );
+    this.notify();
   }
 
   public get totalActivities() {


### PR DESCRIPTION
### 📝 Description

<!-- Contributions are welcome! If there is a corresponding      -->
<!-- JIRA ticket, link to it by replacing `#` with ticket number -->

🔗 [Jira Ticket M2-7771](https://mindlogger.atlassian.net/browse/M2-7771)
in encrypt function  it was constantly using Buffer.concat.
By modifying  the function to collect encrypted chunks in an array and concatenating them once at the end we can improve the performance.
Removing the wait, we can improve even more the time.

Changes include:

- removing wait from the useUploadProgress
- improving encrypt function



### 🪤 Peer Testing

As long you already have the app properly configured, you must create an applet and test if the save flow is working properly and the time reduced for at least 1 second.


### ✏️ Notes
Before, the upload answers was taking about 1400 to 1600ms and encrypt was taking 1578 to 1650ms
