### PR TITLE
fix: target subject ID normalization issue (M2-7407)

### DIFF
--- a/src/entities/applet/model/slice.ts
+++ b/src/entities/applet/model/slice.ts
@@ -239,6 +239,7 @@ const slice = createSlice({
 
       const completedProgression =
         existingProgression as EntityProgressionCompleted;
+      completedProgression.status = 'completed';
       if (isExpired) {
         if (availableUntilTimestamp && availableUntilTimestamp > 0) {
           completedProgression.endedAtTimestamp = availableUntilTimestamp;


### PR DESCRIPTION
### 📝 Description

🔗 [Jira Ticket M2-7407](https://mindlogger.atlassian.net/browse/M2-7407)

This PR fixed an issue with missing normalization of `targetSubjectId` when the mobile app consumes entity completion records.

Currently, if an activity is auto-assign, or has a manual assignment to the respondent themselves, the mobile app internally treats that activity has having `targetSubjectId: null`.

However, for those activities, the `/answers/applet/completions` endpoint would return completion records that has the respondent's subject ID as the record's `targetSubjectId`.

Previously, these completion records were consumed without modification, and the presence of the respondent's `targetSubjectId` in completion records would cause a mismatch with the app's internal representation of `targetSubjectId: null`, thus 'cause the mobile app to not realized an activity is already completed.

This issue causes one-time activities to continue to be available after completion.

This PR adds a normalization step which nullifies the `targetSubjectId` on completion records, if the particular `targetSubjectId` is the respondent's. This brings the completion records `targetSubjectId` into alignment with the mobile app's internal representation, thus preventing one-time activities from becoming available again after completion.

### 📸 Screenshots

N/A

### 🪤 Peer Testing

I completed an extensive suite of manual testing that compares the behaviour of the web app and the mobile app under different scenarios. Please see the report here: https://www.notion.so/metalab/Web-Mobile-Assignment-Test-Report-11a9460132f7807fa688cecb70ef3401

**!!! IMPORTANT !!!** The above report identified -- what I believe to be -- some inconsistencies with the web app; while the mobile app's behaviour seems to be consistently correct. So when testing, please take into account those inconsistencies in the web app.

### ✏️ Notes

N/A