### PR TITLE
Fix/m2 7967 fix input tap detection

### DIFF
--- a/ios/FlankerNativeComponents/FlankerView.swift
+++ b/ios/FlankerNativeComponents/FlankerView.swift
@@ -318,28 +318,32 @@ class FlankerView: UIView {
 }
 
 extension FlankerView: GameManagerProtocol {
-  func setEnableButton(isEnable: Bool) {
-    leftButton.isEnabled = isEnable
-    rightButton.isEnabled = isEnable
-  }
+    func setEnableButton(isEnable: Bool) {
+        DispatchQueue.main.async {
+            self.leftButton.isEnabled = isEnable
+            self.rightButton.isEnabled = isEnable
+        }
+    }
 
   func updateTime(time: String) {
     timeLabel.text = time
   }
 
   func updateText(text: String, color: UIColor, font: UIFont, isStart: Bool, typeTime: TypeTimeStamps) {
-    typeTimeStamp = typeTime
-    textLabel.font = font
-    textLabel.text = text
-    textLabel.textColor = color
-    textLabel.setNeedsDisplay()
-    textLabel.layoutSubviews()
-    startDisplayLink()
-    let time = CACurrentMediaTime()
-    print("Marker: self.displayLink?.isPaused = false: \(time)")
-    textLabel.isHidden = false
-    fixationImage.isHidden = true
-    drawPixel()
+    DispatchQueue.main.async {
+      typeTimeStamp = typeTime
+      textLabel.font = font
+      textLabel.text = text
+      textLabel.textColor = color
+      textLabel.setNeedsDisplay()
+      textLabel.layoutSubviews()
+      startDisplayLink()
+      let time = CACurrentMediaTime()
+      print("Marker: self.displayLink?.isPaused = false: \(time)")
+      textLabel.isHidden = false
+      fixationImage.isHidden = true
+      drawPixel()
+    }
   }
 
   func updateTitleButton(left: String?, right: String?, leftImage: URL?, rightImage: URL?, countButton: Int) {

--- a/ios/FlankerNativeComponents/FlankerView.swift
+++ b/ios/FlankerNativeComponents/FlankerView.swift
@@ -331,18 +331,18 @@ extension FlankerView: GameManagerProtocol {
 
   func updateText(text: String, color: UIColor, font: UIFont, isStart: Bool, typeTime: TypeTimeStamps) {
     DispatchQueue.main.async {
-      typeTimeStamp = typeTime
-      textLabel.font = font
-      textLabel.text = text
-      textLabel.textColor = color
-      textLabel.setNeedsDisplay()
-      textLabel.layoutSubviews()
-      startDisplayLink()
-      let time = CACurrentMediaTime()
-      print("Marker: self.displayLink?.isPaused = false: \(time)")
-      textLabel.isHidden = false
-      fixationImage.isHidden = true
-      drawPixel()
+          self.typeTimeStamp = typeTime
+          self.textLabel.font = font
+          self.textLabel.text = text
+          self.textLabel.textColor = color
+          self.textLabel.setNeedsDisplay()
+          self.textLabel.layoutSubviews()
+          self.startDisplayLink()
+          let time = CACurrentMediaTime()
+          print("Marker: self.displayLink?.isPaused = false: \(time)")
+          self.textLabel.isHidden = false
+          self.fixationImage.isHidden = true
+          self.drawPixel()
     }
   }
 

--- a/ios/FlankerNativeComponents/GameManager.swift
+++ b/ios/FlankerNativeComponents/GameManager.swift
@@ -308,7 +308,7 @@ class GameManager {
     if !isFirst {
       countTest += 1
     }
-    
+
 
     if gameParameters.showFixation {
       if let image = URL(string: gameParameters.fixation), gameParameters.fixation.contains("https") {
@@ -406,7 +406,6 @@ private extension GameManager {
 
   func isEndGame() -> Bool {
     guard let gameParameters = gameParameters else { return false }
-
     if countTest == gameParameters.trials.count {
       let sumArray = arrayTimes.reduce(0, +)
       var avrgArray: Int = 0

--- a/ios/FlankerNativeComponents/GameManager.swift
+++ b/ios/FlankerNativeComponents/GameManager.swift
@@ -192,9 +192,7 @@ class GameManager {
   func checkedAnswer(button: SelectedButton) {
     invalidateTimers()
 
-    DispatchQueue.main.async {
-      self.delegate?.setEnableButton(isEnable: false)
-    }
+    delegate?.setEnableButton(isEnable: false)
 
     guard let gameParameters = gameParameters else { return }
     guard
@@ -223,9 +221,7 @@ class GameManager {
         resultManager.addStepData(data: model)
         delegate?.resultTest(avrgTime: nil, procentCorrect: nil, data: model, dataArray: nil, isShowResults: gameParameters.showResults, minAccuracy: gameParameters.minimumAccuracy)
         if gameParameters.showFeedback {
-          DispatchQueue.main.async {
-            self.delegate?.updateText(text: Constants.correctText, color: Constants.greenColor, font: Constants.smallFont, isStart: false, typeTime: .feedback)
-          }
+          delegate?.updateText(text: Constants.correctText, color: Constants.greenColor, font: Constants.smallFont, isStart: false, typeTime: .feedback)
         }
         responseText = Constants.correctText
       } else {
@@ -243,9 +239,7 @@ class GameManager {
         resultManager.addStepData(data: model)
         delegate?.resultTest(avrgTime: nil, procentCorrect: nil, data: model, dataArray: nil, isShowResults: gameParameters.showResults, minAccuracy: gameParameters.minimumAccuracy)
         if gameParameters.showFeedback {
-          DispatchQueue.main.async {
-            self.delegate?.updateText(text: Constants.inCorrectText, color: Constants.redColor, font: Constants.smallFont, isStart: false, typeTime: .feedback)
-          }
+          delegate?.updateText(text: Constants.inCorrectText, color: Constants.redColor, font: Constants.smallFont, isStart: false, typeTime: .feedback)
         }
         responseText = Constants.inCorrectText
       }
@@ -266,9 +260,7 @@ class GameManager {
         resultManager.addStepData(data: model)
         delegate?.resultTest(avrgTime: nil, procentCorrect: nil, data: model, dataArray: nil, isShowResults: gameParameters.showResults, minAccuracy: gameParameters.minimumAccuracy)
         if gameParameters.showFeedback {
-          DispatchQueue.main.async {
-            self.delegate?.updateText(text: Constants.correctText, color: Constants.greenColor, font: Constants.smallFont, isStart: false, typeTime: .feedback)
-          }
+          delegate?.updateText(text: Constants.correctText, color: Constants.greenColor, font: Constants.smallFont, isStart: false, typeTime: .feedback)
         }
         responseText = Constants.correctText
       } else {
@@ -286,9 +278,7 @@ class GameManager {
         resultManager.addStepData(data: model)
         delegate?.resultTest(avrgTime: nil, procentCorrect: nil, data: model, dataArray: nil, isShowResults: gameParameters.showResults, minAccuracy: gameParameters.minimumAccuracy)
         if gameParameters.showFeedback {
-          DispatchQueue.main.async {
-            self.delegate?.updateText(text: Constants.inCorrectText, color: Constants.redColor, font: Constants.smallFont, isStart: false, typeTime: .feedback)
-          }
+          delegate?.updateText(text: Constants.inCorrectText, color: Constants.redColor, font: Constants.smallFont, isStart: false, typeTime: .feedback)
         }
         responseText = Constants.inCorrectText
       }
@@ -333,9 +323,7 @@ class GameManager {
   @objc func setText() {
     guard let gameParameters = gameParameters else { return }
 
-    DispatchQueue.main.async {
-      self.delegate?.setEnableButton(isEnable: true)
-    }
+    delegate?.setEnableButton(isEnable: true)
 
     text = gameParameters.trials[countTest].stimulus.en
 
@@ -346,17 +334,15 @@ class GameManager {
     }
 
     timeResponse = Timer(timeInterval: gameParameters.trialDuration / 1000, target: self, selector: #selector(self.timeResponseFailed), userInfo: nil, repeats: false)
-    RunLoop.main.add(timeResponse!, forMode: .common) 
+    RunLoop.main.add(timeResponse!, forMode: .common)
   }
 
   @objc func timeResponseFailed() {
     guard let gameParameters = gameParameters else { return }
 
-    DispatchQueue.main.async {
-      self.delegate?.setEnableButton(isEnable: false)
-      if gameParameters.showFeedback {
-        self.delegate?.updateText(text: Constants.timeRespondText, color: .black, font: Constants.smallFont, isStart: false, typeTime: .feedback)
-      }
+    delegate?.setEnableButton(isEnable: false)
+    if gameParameters.showFeedback {
+      delegate?.updateText(text: Constants.timeRespondText, color: .black, font: Constants.smallFont, isStart: false, typeTime: .feedback)
     }
 
     guard

--- a/ios/FlankerNativeComponents/GameManager.swift
+++ b/ios/FlankerNativeComponents/GameManager.swift
@@ -191,7 +191,11 @@ class GameManager {
 
   func checkedAnswer(button: SelectedButton) {
     invalidateTimers()
-    delegate?.setEnableButton(isEnable: false)
+
+    DispatchQueue.main.async {
+      self.delegate?.setEnableButton(isEnable: false)
+    }
+
     guard let gameParameters = gameParameters else { return }
     guard
       let startTrialTimestamp = startTrialTimestamp,
@@ -219,7 +223,9 @@ class GameManager {
         resultManager.addStepData(data: model)
         delegate?.resultTest(avrgTime: nil, procentCorrect: nil, data: model, dataArray: nil, isShowResults: gameParameters.showResults, minAccuracy: gameParameters.minimumAccuracy)
         if gameParameters.showFeedback {
-          delegate?.updateText(text: Constants.correctText, color: Constants.greenColor, font: Constants.smallFont, isStart: false, typeTime: .feedback)
+          DispatchQueue.main.async {
+            self.delegate?.updateText(text: Constants.correctText, color: Constants.greenColor, font: Constants.smallFont, isStart: false, typeTime: .feedback)
+          }
         }
         responseText = Constants.correctText
       } else {
@@ -237,7 +243,9 @@ class GameManager {
         resultManager.addStepData(data: model)
         delegate?.resultTest(avrgTime: nil, procentCorrect: nil, data: model, dataArray: nil, isShowResults: gameParameters.showResults, minAccuracy: gameParameters.minimumAccuracy)
         if gameParameters.showFeedback {
-          delegate?.updateText(text: Constants.inCorrectText, color: Constants.redColor, font: Constants.smallFont, isStart: false, typeTime: .feedback)
+          DispatchQueue.main.async {
+            self.delegate?.updateText(text: Constants.inCorrectText, color: Constants.redColor, font: Constants.smallFont, isStart: false, typeTime: .feedback)
+          }
         }
         responseText = Constants.inCorrectText
       }
@@ -258,7 +266,9 @@ class GameManager {
         resultManager.addStepData(data: model)
         delegate?.resultTest(avrgTime: nil, procentCorrect: nil, data: model, dataArray: nil, isShowResults: gameParameters.showResults, minAccuracy: gameParameters.minimumAccuracy)
         if gameParameters.showFeedback {
-          delegate?.updateText(text: Constants.correctText, color: Constants.greenColor, font: Constants.smallFont, isStart: false, typeTime: .feedback)
+          DispatchQueue.main.async {
+            self.delegate?.updateText(text: Constants.correctText, color: Constants.greenColor, font: Constants.smallFont, isStart: false, typeTime: .feedback)
+          }
         }
         responseText = Constants.correctText
       } else {
@@ -276,15 +286,17 @@ class GameManager {
         resultManager.addStepData(data: model)
         delegate?.resultTest(avrgTime: nil, procentCorrect: nil, data: model, dataArray: nil, isShowResults: gameParameters.showResults, minAccuracy: gameParameters.minimumAccuracy)
         if gameParameters.showFeedback {
-          delegate?.updateText(text: Constants.inCorrectText, color: Constants.redColor, font: Constants.smallFont, isStart: false, typeTime: .feedback)
+          DispatchQueue.main.async {
+            self.delegate?.updateText(text: Constants.inCorrectText, color: Constants.redColor, font: Constants.smallFont, isStart: false, typeTime: .feedback)
+          }
         }
         responseText = Constants.inCorrectText
       }
     }
-    
 
     if gameParameters.showFeedback {
-      Timer.scheduledTimer(timeInterval: Constants.lowTimeInterval, target: self, selector: #selector(self.setDefaultText), userInfo: nil, repeats: false)
+      let timer = Timer(timeInterval: Constants.lowTimeInterval, target: self, selector: #selector(self.setDefaultText), userInfo: nil, repeats: false)
+      RunLoop.main.add(timer, forMode: .common)
     } else {
       setDefaultText(isFirst: false)
     }
@@ -296,7 +308,7 @@ class GameManager {
     if !isFirst {
       countTest += 1
     }
-
+    
 
     if gameParameters.showFixation {
       if let image = URL(string: gameParameters.fixation), gameParameters.fixation.contains("https") {
@@ -311,7 +323,8 @@ class GameManager {
     updateButtonTitle()
 
     if gameParameters.showFixation {
-      timerSetText = Timer.scheduledTimer(timeInterval: gameParameters.fixationDuration / 1000, target: self, selector: #selector(setText), userInfo: nil, repeats: false)
+      timerSetText = Timer(timeInterval: gameParameters.fixationDuration / 1000, target: self, selector: #selector(setText), userInfo: nil, repeats: false)
+      RunLoop.main.add(timerSetText!, forMode: .common)
     } else {
       setText()
     }
@@ -320,7 +333,10 @@ class GameManager {
   @objc func setText() {
     guard let gameParameters = gameParameters else { return }
 
-    delegate?.setEnableButton(isEnable: true)
+    DispatchQueue.main.async {
+      self.delegate?.setEnableButton(isEnable: true)
+    }
+
     text = gameParameters.trials[countTest].stimulus.en
 
     if let image = URL(string: text), text.contains("https") {
@@ -329,15 +345,18 @@ class GameManager {
       delegate?.updateText(text: text, color: .black, font: Constants.bigFont, isStart: true, typeTime: .trial)
     }
 
-    timeResponse = Timer.scheduledTimer(timeInterval: gameParameters.trialDuration / 1000, target: self, selector: #selector(self.timeResponseFailed), userInfo: nil, repeats: false)
+    timeResponse = Timer(timeInterval: gameParameters.trialDuration / 1000, target: self, selector: #selector(self.timeResponseFailed), userInfo: nil, repeats: false)
+    RunLoop.main.add(timeResponse!, forMode: .common) 
   }
 
   @objc func timeResponseFailed() {
     guard let gameParameters = gameParameters else { return }
 
-    delegate?.setEnableButton(isEnable: false)
-    if gameParameters.showFeedback {
-      delegate?.updateText(text: Constants.timeRespondText, color: .black, font: Constants.smallFont, isStart: false, typeTime: .feedback)
+    DispatchQueue.main.async {
+      self.delegate?.setEnableButton(isEnable: false)
+      if gameParameters.showFeedback {
+        self.delegate?.updateText(text: Constants.timeRespondText, color: .black, font: Constants.smallFont, isStart: false, typeTime: .feedback)
+      }
     }
 
     guard
@@ -360,7 +379,8 @@ class GameManager {
     delegate?.resultTest(avrgTime: nil, procentCorrect: nil, data: model, dataArray: nil, isShowResults: gameParameters.showResults, minAccuracy: gameParameters.minimumAccuracy)
     responseText = Constants.timeRespondText
 
-    Timer.scheduledTimer(timeInterval: Constants.lowTimeInterval, target: self, selector: #selector(self.setDefaultText), userInfo: nil, repeats: false)
+    let timer = Timer(timeInterval: Constants.lowTimeInterval, target: self, selector: #selector(self.setDefaultText), userInfo: nil, repeats: false)
+    RunLoop.main.add(timer, forMode: .common)
   }
 
   func clearData() {
@@ -386,7 +406,7 @@ private extension GameManager {
 
   func isEndGame() -> Bool {
     guard let gameParameters = gameParameters else { return false }
-    
+
     if countTest == gameParameters.trials.count {
       let sumArray = arrayTimes.reduce(0, +)
       var avrgArray: Int = 0


### PR DESCRIPTION
### 📝 Description

🔗 [Jira Ticket M2-7967](https://mindlogger.atlassian.net/browse/M2-7967)
#### Solution Explanation:
DispatchQueue:
Main Thread for UI Updates, In iOS development, all UI updates must occur on the main thread. UIKit is not thread-safe, and updating UI elements from a background thread can lead to unpredictable behavior or crashes and  Wrapping UI updates in DispatchQueue.main.async ensures that the enclosed code executes on the main thread, regardless of which thread the enclosing method was called from.
 what do we gain? By explicitly dispatching UI updates to the main thread, we eliminate the risk of UI related issues due to threading.


Timer Instead of Timer.scheduledTimer:
Using Timer Instead of Timer.scheduledTimer Timer.scheduledTimer creates a timer and automatically schedules it on the current run loop in the default mode.
If the code calling Timer.scheduledTimer is not on the main thread, the timer may be scheduled on a background run loop, leading to timing issues or the timer not firing at all and Timers scheduled in the default run loop mode may not fire during certain user interactions because the run loop switches modes during these interactions.  Timer Initialization Without Scheduling:
* Manual Scheduling: By using Timer(timeInterval: ...), its create a timer instance without automatically scheduling it on a run loop.
* Control Over Run Loop and Mode: We can then manually add the timer to the desired run loop and specify the run loop mode, giving us better control over its behavior.


  Using RunLoop.main.add:
After creating a Timer instance without scheduling it, I need to add it to a run loop to start it. 
* .default: The default mode for the main run loop. Timers in this mode may not fire during user interactions.
* .common: A set of modes that includes the default mode and modes used during user interactions. Timers added in this mode continue to fire even when the run loop switches modes due to user interactions.

### 📸 Screenshots
#### Simple Choice Reaction Time task:

https://github.com/user-attachments/assets/7b9db765-eabf-4982-91bc-e022270a618d

### 🪤 Peer Testing
* lauch the app
* Create a Serial Reaction Time performance task
* Set time between screens to more than 1000ms (Show each stimulus for)
* Run task on an iOS device
* When the button is presented, wait at least 500ms and then attempt to tap the button
Before:
Input will be ignored the longer you wait to tap the button (disabled state)
Expected:
now you will be able to click all the times.


