### PR TITLE
fix: retaining local data on log out (M2-8113)

### DIFF
--- a/src/features/auth/model/cleanupData.ts
+++ b/src/features/auth/model/cleanupData.ts
@@ -2,6 +2,13 @@ import { clearEntityRecordStorages } from '@features/auth/lib/clearEntityRecordS
 import { clearUploadQueueStorage } from '@features/auth/lib/clearUploadQueueStorage';
 import { getDefaultLogger } from '@shared/lib/services/loggerInstance';
 
+// Clear entity record and progression data.
+// This function should only be called upon successful login, and that the
+// just logged-in user's ID is not the same as the previously logged-in user's
+// ID.
+// This function should not be called upon log out. This way, previously stored
+// entity record and progression data can be preserved for the same user over
+// multiple sessions. This is an intended behaviour.
 export async function cleanupData() {
   getDefaultLogger().info(
     '[cleanupData] Processing cleanup upon another user login',

--- a/src/features/login/ui/LoginForm.tsx
+++ b/src/features/login/ui/LoginForm.tsx
@@ -59,6 +59,11 @@ export const LoginForm: FC<Props> = props => {
         password: variables.password,
       };
 
+      // If the previously logged-in user's ID is not the same as the just
+      // logged-in user's ID, then clear previously stored data.
+      // We are able to make this determination because previously stored data
+      // is not cleared on log out (only session info is cleared on log out),
+      // and this is an intended behaviour.
       if (userParams.userId !== userId) {
         await cleanupData();
         dispatch(cleanUpAction());

--- a/src/features/logout/model/hooks.ts
+++ b/src/features/logout/model/hooks.ts
@@ -16,7 +16,6 @@ import { getDefaultLogger } from '@app/shared/lib/services/loggerInstance';
 import { useTCPSocket } from '@app/shared/lib/tcp/useTCPSocket';
 import { isAppOnline } from '@app/shared/lib/utils/networkHelpers';
 import { hasPendingMutations } from '@app/shared/lib/utils/reactQueryHelpers';
-import { cleanupData } from '@features/auth/model/cleanupData';
 
 export function useLogout() {
   const queryClient = useQueryClient();
@@ -57,8 +56,6 @@ export function useLogout() {
     await queryClient.removeQueries(['activities']);
 
     queryClient.clear();
-
-    await cleanupData();
 
     getDefaultSessionService().clearSession();
 


### PR DESCRIPTION
### 📝 Description

🔗 [Jira Ticket M2-8113](https://mindlogger.atlassian.net/browse/M2-8113)

This PR removes the `await cleanupData()` from the "log out" hook.

The call was previously erroneously added by me. I thought it was an oversight that entity record/progression data were not cleared upon log out. I didn't realize retaining those data was an intended behaviour. So this PR removes the call to restore the previously intentional behaviour of not clearing entity record/progression data on log out.

### 📸 Screenshots

N/A

### 🪤 Peer Testing

1. Log into the mobile app
2. Start an activity but do not complete it
3. Exit the activity
4. Log out
5. Re-log into the mobile app
6. Resume the activity

... at this point, the activity should resume from where it was left off before existing and logging out.

### ✏️ Notes

N/A
