### PR TITLE
fix: add applets refresh after answers submission (M2-8144)

### DIFF
--- a/src/entities/activity/lib/hooks/useQueueProcessing.ts
+++ b/src/entities/activity/lib/hooks/useQueueProcessing.ts
@@ -4,6 +4,7 @@ import { useForceUpdate } from '@app/shared/lib/hooks/useForceUpdate';
 import { getDefaultChangeQueueObservable } from '@app/shared/lib/observables/changeQueueObservableInstance';
 import { getDefaultUploadObservable } from '@app/shared/lib/observables/uploadObservableInstance';
 import { getDefaultLogger } from '@app/shared/lib/services/loggerInstance';
+import { useRefreshMutation } from '@entities/applet/model/hooks/useRefreshMutation.ts';
 
 import { getDefaultAnswersQueueService } from '../services/answersQueueServiceInstance';
 import { getDefaultQueueProcessingService } from '../services/queueProcessingServiceInstance';
@@ -21,6 +22,7 @@ type Result = {
 
 export const useQueueProcessing = (): Result => {
   const update = useForceUpdate();
+  const { mutateAsync: refreshApplets } = useRefreshMutation();
 
   useEffect(() => {
     const onChangeUploadState = () => {
@@ -46,7 +48,8 @@ export const useQueueProcessing = (): Result => {
 
   const processQueueWithSendingLogs = async (): Promise<boolean> => {
     const result = await queueProcessingService.process();
-    getDefaultLogger().send();
+    await refreshApplets();
+    getDefaultLogger().send().catch(console.error);
     return result;
   };
 

--- a/src/widgets/survey/model/hooks/useAutoCompletion.ts
+++ b/src/widgets/survey/model/hooks/useAutoCompletion.ts
@@ -22,6 +22,7 @@ import { ReduxPersistor } from '@app/shared/lib/redux-state/store';
 import { Emitter } from '@app/shared/lib/services/Emitter';
 import { getDefaultLogger } from '@app/shared/lib/services/loggerInstance';
 import { getMutexDefaultInstanceManager } from '@app/shared/lib/utils/mutexDefaultInstanceManagerInstance';
+import { useRefreshMutation } from '@entities/applet/model/hooks/useRefreshMutation.ts';
 import { CollectCompletionOutput } from '@widgets/survey/model/services/ICollectCompletionsService';
 
 import { CollectCompletionsService } from '../services/CollectCompletionsService';
@@ -47,6 +48,8 @@ export const useAutoCompletion = (): Result => {
   const dispatch = useAppDispatch();
 
   const queryClient = useQueryClient();
+
+  const { mutateAsync: refreshApplets } = useRefreshMutation();
 
   const hasItemsInQueue = useCallback(() => {
     return getDefaultAnswersQueueService().getLength() > 0;
@@ -180,6 +183,7 @@ export const useAutoCompletion = (): Result => {
 
       if (hasItemsInQueue()) {
         result = await getDefaultQueueProcessingService().process();
+        await refreshApplets();
       }
 
       if (forceRefreshNotifications || completionsCollected) {
@@ -188,7 +192,13 @@ export const useAutoCompletion = (): Result => {
 
       return result;
     },
-    [mutex, incompletedEntities, createConstructService, hasItemsInQueue],
+    [
+      mutex,
+      incompletedEntities,
+      createConstructService,
+      hasItemsInQueue,
+      refreshApplets,
+    ],
   );
 
   const hasExpiredEntity = useCallback((): boolean => {


### PR DESCRIPTION
### 📝 Description

🔗 [Jira Ticket M2-8144](https://mindlogger.atlassian.net/browse/M2-8144)

This PR adds an extra step to refresh applets data after answers are submitted.

This addition is meant to address the issue in [M2-8144](https://mindlogger.atlassian.net/browse/M2-8144), where when an daily activity is completed via notification, the activity does not disappear from the list of activities. In that case, the activity would disappear from the list if the user goes to refresh the applet. So this PR inserts the same refresh call to the end of the answers submission queue processor. So now, regardless if a activity is completed from the activities listing screen, or from notification, the applets will be refreshed after answers submission.

### 📸 Screenshots

N/A

### 🪤 Peer Testing

1. Create an applet
2. Create an activity
3. Set the activity as "daily", and attach a notification
4. Log into the mobile app
5. Navigate to the activities listing screen
6. Exit the mobile app ... and wait for notification to show up
7. Tap no notification
8. Complete the activity

At this point, the just completed activity should no longer appear in the activities listing screen.

### ✏️ Notes

N/A

[M2-8144]: https://mindlogger.atlassian.net/browse/M2-8144?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ