### PR TITLE
fix: issue with invalidation of applet base info query data (M2-8151)

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -30,6 +30,26 @@ jobs:
           prettier: true
           prettier_extensions: js,jsx,ts,tsx
           continue_on_error: false
+  tsc:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+
+      - name: Install deps
+        run: yarn install --frozen-lockfile
+
+      - uses: actions/cache@v4
+        with:
+          path: |
+            ~/node_modules
+          key: ${{ runner.os }}-node-modules-${{ hashFiles('**/yarn.lock') }}
+
+      - name: Running tsc
+        run: yarn tsc
   tests:
     runs-on: ubuntu-latest
     steps:

--- a/src/entities/applet/model/services/RefreshAppletService.ts
+++ b/src/entities/applet/model/services/RefreshAppletService.ts
@@ -17,6 +17,7 @@ import { ILogger } from '@app/shared/lib/types/logger';
 import { ImageUrl } from '@app/shared/lib/types/url';
 import {
   getActivityDetailsKey,
+  getAppletBaseInfoKey,
   getAppletDetailsKey,
   getAssignmentsKey,
   getDataFromQuery,
@@ -80,6 +81,13 @@ export class RefreshAppletService implements IRefreshAppletService {
     }
   }
 
+  private resetAppletBaseInfoQuery(appletId: string) {
+    this.queryClient.removeQueries({
+      exact: true,
+      queryKey: getAppletBaseInfoKey(appletId),
+    });
+  }
+
   private resetAppletDetailsQuery(appletId: string) {
     this.queryClient.removeQueries({
       exact: true,
@@ -113,6 +121,7 @@ export class RefreshAppletService implements IRefreshAppletService {
   private refreshAppletCaches(
     appletInternalDtos: CollectAppletInternalsResult,
   ) {
+    this.resetAppletBaseInfoQuery(appletInternalDtos.appletId);
     this.resetAppletDetailsQuery(appletInternalDtos.appletId);
 
     for (const activityDto of appletInternalDtos.activities) {
@@ -194,6 +203,8 @@ export class RefreshAppletService implements IRefreshAppletService {
     this.logger.log(
       `[RefreshAppletService.partialRefresh]: Skip refresh for Applet "${appletDto.displayName}|${appletDto.id}" as to versions are the same`,
     );
+
+    this.resetAppletBaseInfoQuery(appletDto.id);
 
     const assignmentsResponse =
       allAppletAssignments.appletAssignments[appletDto.id];

--- a/src/shared/api/services/appletsService.ts
+++ b/src/shared/api/services/appletsService.ts
@@ -10,6 +10,8 @@ import {
   AppletAndActivitiesDetailsResponse,
   AppletAssignmentsRequest,
   AppletAssignmentsResponse,
+  AppletBaseInfoRequest,
+  AppletBaseInfoResponse,
   AppletDetailsRequest,
   AppletDetailsResponse,
   AppletsResponse,
@@ -20,7 +22,7 @@ export function appletsService(): IAppletService {
   return {
     async getAppletBaseInfo(request: AppletBaseInfoRequest) {
       const apiCall = () => {
-        return httpService.get<AppletAndActivitiesDetailsResponse>(
+        return httpService.get<AppletBaseInfoResponse>(
           `/applets/${request.appletId}/base_info`,
         );
       };

--- a/src/shared/lib/utils/reactQueryHelpers.ts
+++ b/src/shared/lib/utils/reactQueryHelpers.ts
@@ -25,6 +25,9 @@ export const hasPendingMutations = (queryClient: QueryClient): boolean => {
 
 export const getAppletsKey = () => ['applets'] as AppQueryKey;
 
+export const getAppletBaseInfoKey = (appletId: string) =>
+  ['base-info', { appletId }] as AppQueryKey;
+
 export const getAppletDetailsKey = (appletId: string) =>
   ['applets', { appletId }] as AppQueryKey;
 

--- a/src/widgets/activity-group/model/hooks/useBaseInfo.ts
+++ b/src/widgets/activity-group/model/hooks/useBaseInfo.ts
@@ -1,6 +1,7 @@
 import { useBaseQuery } from '@app/shared/api/hooks/useBaseQuery';
 import { ResponseType } from '@app/shared/api/services/ActivityItemDto';
 import { getDefaultAppletsService } from '@app/shared/api/services/appletsServiceInstance';
+import { getAppletBaseInfoKey } from '@shared/lib/utils/reactQueryHelpers.ts';
 
 import { useTimer } from './useTimer';
 
@@ -8,7 +9,7 @@ export const useBaseInfo = (appletId: string) => {
   useTimer();
 
   return useBaseQuery(
-    ['base-info', { appletId }],
+    getAppletBaseInfoKey(appletId),
     () => getDefaultAppletsService().getAppletBaseInfo({ appletId }),
     {
       select: data => {


### PR DESCRIPTION
### 📝 Description

🔗 [Jira Ticket M2-8151](https://mindlogger.atlassian.net/browse/M2-8151)

This PR fixes an issue introduced in https://github.com/ChildMindInstitute/mindlogger-app-refactor/pull/873 where the "base info" query data cache is not invalidated, leading to the app crashing after an activity/flow is added to an existing applet.

### 📸 Screenshots

N/A

### 🪤 Peer Testing

1. Create an applet
2. Create an activity
3. Log into the mobile app
4. Go into the activity listing screen
5. Create another activity
6. In the mobile app, go back to the applet listing screen and refresh
7. Go into the activity listing screen

At this point, the app should not crash.

### ✏️ Notes

N/A