### PR TITLE
fix: Self-report assessments started by notification (M2-8144, M2-8160)

### DIFF
--- a/src/features/tap-on-notification/model/hooks/useOnNotificationTap.ts
+++ b/src/features/tap-on-notification/model/hooks/useOnNotificationTap.ts
@@ -166,7 +166,7 @@ export function useOnNotificationTap({
             entityType,
             eventId!,
             entityName!,
-            targetSubjectId!,
+            targetSubjectId ?? null,
           );
         },
         executing ? GoBackDuration : WorkaroundDuration,


### PR DESCRIPTION
### 📝 Description

<!-- Contributions are welcome! If there is a corresponding      -->
<!-- JIRA ticket, link to it by replacing `#` with ticket number -->

🔗 [Jira Ticket M2-8144](https://mindlogger.atlassian.net/browse/M2-8144)
🔗 [Jira Ticket M2-8160](https://mindlogger.atlassian.net/browse/M2-8160)

<!-- Replace this with a high-level description of the features/functionality proposed in the pull request. -->

This change should cause self-report, one-time-completion (or daily completion) activities/flows started by a notification tap result in the refreshed activities list to properly hide that activity/flow after it has been completed.

### 🪤 Peer Testing

#### Preconditions:

- User has an applet with activity that is set to **Auto-assign: true**
- Add new scheduled event for activity: 
  - Repeats daily
  - Notification = in the next 5 minutes (or however long it takes you to refresh and force-close the applet)

#### Steps to reproduce:

1. Refresh the applets list to ensure it has the latest updates from the activity (including the notification setting)
2. Kill (close) the app
3. Wait for the notification time
4. Start the Activity by tapping the notification
5. Complete activity
    **Expected outcome:** Activity is hidden from the list of activities.