### PR TITLE
fix: Fix clearing of one-time-completion manual self-report assessments from notification (M2-8144, M2-8160)

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -100,7 +100,7 @@ android {
         applicationId "lab.childmindinstitute.data"
         minSdkVersion rootProject.ext.minSdkVersion
         targetSdkVersion rootProject.ext.targetSdkVersion
-        versionCode 1594
+        versionCode 1595
         versionName "2.5.0"
         resValue "string", "app_name", "Mindlogger"
         resValue "string", "build_config_package", "lab.childmindinstitute.data"

--- a/ios/MindloggerMobile.xcodeproj/project.pbxproj
+++ b/ios/MindloggerMobile.xcodeproj/project.pbxproj
@@ -1667,7 +1667,7 @@
 			buildSettings = {
 				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				BUNDLE_LOADER = "$(TEST_HOST)";
-				CURRENT_PROJECT_VERSION = 1594;
+				CURRENT_PROJECT_VERSION = 1595;
 				GCC_PREPROCESSOR_DEFINITIONS = (
 					"DEBUG=1",
 					"$(inherited)",
@@ -1698,7 +1698,7 @@
 				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				COPY_PHASE_STRIP = NO;
-				CURRENT_PROJECT_VERSION = 1594;
+				CURRENT_PROJECT_VERSION = 1595;
 				INFOPLIST_FILE = MindloggerMobileTests/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 12.4;
 				LD_RUNPATH_SEARCH_PATHS = (
@@ -1728,7 +1728,7 @@
 				CODE_SIGN_IDENTITY = "Apple Development";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
 				CODE_SIGN_STYLE = Manual;
-				CURRENT_PROJECT_VERSION = 1594;
+				CURRENT_PROJECT_VERSION = 1595;
 				DEVELOPMENT_TEAM = "";
 				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = 8RHKE85KB6;
 				ENABLE_BITCODE = NO;
@@ -1769,7 +1769,7 @@
 				CODE_SIGN_ENTITLEMENTS = MindloggerMobile/MindloggerMobileRelease.entitlements;
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Distribution";
 				CODE_SIGN_STYLE = Manual;
-				CURRENT_PROJECT_VERSION = 1594;
+				CURRENT_PROJECT_VERSION = 1595;
 				DEVELOPMENT_TEAM = "";
 				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = 8RHKE85KB6;
 				INFOPLIST_FILE = MindloggerMobile/Info.plist;
@@ -1979,7 +1979,7 @@
 				CODE_SIGN_IDENTITY = "Apple Development";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
 				CODE_SIGN_STYLE = Manual;
-				CURRENT_PROJECT_VERSION = 1594;
+				CURRENT_PROJECT_VERSION = 1595;
 				DEVELOPMENT_TEAM = "";
 				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = 8RHKE85KB6;
 				ENABLE_BITCODE = NO;
@@ -2019,7 +2019,7 @@
 				CODE_SIGN_ENTITLEMENTS = MindloggerMobileDevRelease.entitlements;
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Distribution";
 				CODE_SIGN_STYLE = Manual;
-				CURRENT_PROJECT_VERSION = 1594;
+				CURRENT_PROJECT_VERSION = 1595;
 				DEVELOPMENT_TEAM = "";
 				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = 8RHKE85KB6;
 				INFOPLIST_FILE = "MindloggerMobile dev-Info.plist";
@@ -2058,7 +2058,7 @@
 				CODE_SIGN_IDENTITY = "Apple Development";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
 				CODE_SIGN_STYLE = Manual;
-				CURRENT_PROJECT_VERSION = 1594;
+				CURRENT_PROJECT_VERSION = 1595;
 				DEVELOPMENT_TEAM = "";
 				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = 8RHKE85KB6;
 				ENABLE_BITCODE = NO;
@@ -2099,7 +2099,7 @@
 				CODE_SIGN_IDENTITY = "Apple Development";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Distribution";
 				CODE_SIGN_STYLE = Manual;
-				CURRENT_PROJECT_VERSION = 1594;
+				CURRENT_PROJECT_VERSION = 1595;
 				DEVELOPMENT_TEAM = "";
 				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = 8RHKE85KB6;
 				INFOPLIST_FILE = "MindloggerMobile qa-Info.plist";
@@ -2136,7 +2136,7 @@
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_ENTITLEMENTS = MindloggerMobileStagingDebug.entitlements;
 				CODE_SIGN_STYLE = Manual;
-				CURRENT_PROJECT_VERSION = 1594;
+				CURRENT_PROJECT_VERSION = 1595;
 				DEVELOPMENT_TEAM = "";
 				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = 8RHKE85KB6;
 				ENABLE_BITCODE = NO;
@@ -2176,7 +2176,7 @@
 				CODE_SIGN_ENTITLEMENTS = MindloggerMobileStagingRelease.entitlements;
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Distribution";
 				CODE_SIGN_STYLE = Manual;
-				CURRENT_PROJECT_VERSION = 1594;
+				CURRENT_PROJECT_VERSION = 1595;
 				DEVELOPMENT_TEAM = "";
 				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = 8RHKE85KB6;
 				INFOPLIST_FILE = "MindloggerMobile staging-Info.plist";
@@ -2215,7 +2215,7 @@
 				CODE_SIGN_IDENTITY = "Apple Development";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
 				CODE_SIGN_STYLE = Manual;
-				CURRENT_PROJECT_VERSION = 1594;
+				CURRENT_PROJECT_VERSION = 1595;
 				DEVELOPMENT_TEAM = "";
 				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = 8RHKE85KB6;
 				ENABLE_BITCODE = NO;
@@ -2256,7 +2256,7 @@
 				CODE_SIGN_IDENTITY = "Apple Development";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Distribution";
 				CODE_SIGN_STYLE = Manual;
-				CURRENT_PROJECT_VERSION = 1594;
+				CURRENT_PROJECT_VERSION = 1595;
 				DEVELOPMENT_TEAM = "";
 				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = 8RHKE85KB6;
 				INFOPLIST_FILE = "MindloggerMobile uat-Info.plist";

--- a/src/entities/notification/model/factory/NotificationBuilder.ts
+++ b/src/entities/notification/model/factory/NotificationBuilder.ts
@@ -354,10 +354,18 @@ export class NotificationBuilder implements INotificationBuilder {
 
     for (const eventEntity of this.eventEntities) {
       try {
+        const { assignment } = eventEntity;
+
+        // Normalize target subject ID to null for self-reports
+        const targetSubjectId =
+          assignment && assignment.target.id !== assignment.respondent.id
+            ? assignment.target.id
+            : null;
+
         const eventNotifications = this.processEvent(
           eventEntity.event,
           eventEntity.entity,
-          eventEntity.assignment?.target.id || null,
+          targetSubjectId,
         );
         eventNotificationsResult.push(eventNotifications);
       } catch (error) {


### PR DESCRIPTION
### 📝 Description

🔗 [Jira Ticket M2-8144](https://mindlogger.atlassian.net/browse/M2-8144)
🔗 [Jira Ticket M2-8160](https://mindlogger.atlassian.net/browse/M2-8160)

When tapping a notification to start a manual self-report assessment, the `targetSubjectId` was not being normalized to `null` as is needed to identify self-reports elsewhere in the app. Fixed this at the `NotificationBuilder` step.

### 🪤 Peer Testing

#### Preconditions:

- User has an applet with activity that is set to **Auto-assign: false** and has a **manual self-report assignment**
- Add new scheduled event for activity: 
  - Repeats daily
  - Notification = in the next 5 minutes (or however long it takes you to refresh and force-close the applet)

#### Steps to reproduce:

**Online mode:**
1. Refresh the applets list to ensure it has the latest updates from the activity (including the notification setting)
2. Kill (close) the app
3. Wait for the notification time
4. Start the Activity by tapping the notification
5. Complete activity
    **Expected outcome:** Activity is hidden from the list of activities.

**Offline mode:**
1. Refresh the applets list to ensure it has the latest updates from the activity (including the notification setting)
2. Kill (close) the app
3. Take internet offline
4. Wait for the notification time
5. Start the Activity by tapping the notification
5. Complete activity
    **Expected outcome:** Activity is hidden from the list of activities.