### PR TITLE
fix: Preserve in-progress state during app refresh (M2-8177)

### DIFF
--- a/src/entities/applet/model/slice.ts
+++ b/src/entities/applet/model/slice.ts
@@ -276,18 +276,16 @@ const slice = createSlice({
         }),
       );
 
-      if (existingProgression) {
-        const existingCompletion =
-          existingProgression as EntityProgressionCompleted;
-        if (existingCompletion.status !== 'completed') {
-          existingCompletion.status = 'completed';
-        }
+      const endedAtTimestamp = action.payload.endAt.getTime();
 
-        if (
-          !existingCompletion.endedAtTimestamp ||
-          action.payload.endAt.getTime() > existingCompletion.endedAtTimestamp
-        ) {
-          existingCompletion.endedAtTimestamp = action.payload.endAt.getTime();
+      if (existingProgression) {
+        if (existingProgression.status === 'completed') {
+          const existingCompletion =
+            existingProgression as EntityProgressionCompleted;
+
+          if (endedAtTimestamp > (existingCompletion.endedAtTimestamp ?? 0)) {
+            existingCompletion.endedAtTimestamp = endedAtTimestamp;
+          }
         }
       } else {
         const newCompletion: EntityProgressionCompleted = {
@@ -299,7 +297,7 @@ const slice = createSlice({
           targetSubjectId: action.payload.targetSubjectId,
           availableUntilTimestamp: null,
           startedAtTimestamp: 0,
-          endedAtTimestamp: action.payload.endAt.getTime(),
+          endedAtTimestamp,
         };
         state.entityProgressions = state.entityProgressions ?? [];
         state.entityProgressions.push(newCompletion);


### PR DESCRIPTION
### 📝 Description

<!-- Contributions are welcome! If there is a corresponding      -->
<!-- JIRA ticket, link to it by replacing `#` with ticket number -->

🔗 [Jira Ticket M2-8177](https://mindlogger.atlassian.net/browse/M2-8177)

Existing local `in-progress` state for any activity that had a previous submission that same day had fits state reset to `completed` during manual app refresh. Fixed logic to not override the `state` property for these records (previously was being set to `completed`) just because the user has previously submitted the activity that day – rather, just set the `endedAtTimestamp` property if the activity already happened to be in `completed` state, and leave `state` unchanged otherwise.

This bug was introduced when the `applet` slice was changed significantly during the refactor to support MI Assign.

### 🪤 Peer Testing

#### Preconditions:

- User is logged in to mobile app
- User has an applet with an activity (auto-assigned or manually assigned) with no customized schedule

#### Steps:

1. Start and fully complete the activity.
2. The same day, start the activity again, but tap **Exit** part-way through.
   **Expected outcome:** Activity should now have an “in progress” state.
3. Return to the home screen, and pull down to refresh the app.
4. Go back to the applet showing the list of activities
    **Expected outcome:** Activity should have its in-progress state preserved.
5. Resume the activity.
    **Expected outcome:** Activity should resume at the point where it was left off.