### PR TITLE
fix: Revert "chore: add applets refresh after answers submission" (M2-8144)

### DIFF
--- a/src/entities/activity/lib/hooks/useQueueProcessing.ts
+++ b/src/entities/activity/lib/hooks/useQueueProcessing.ts
@@ -4,7 +4,6 @@ import { useForceUpdate } from '@app/shared/lib/hooks/useForceUpdate';
 import { getDefaultChangeQueueObservable } from '@app/shared/lib/observables/changeQueueObservableInstance';
 import { getDefaultUploadObservable } from '@app/shared/lib/observables/uploadObservableInstance';
 import { getDefaultLogger } from '@app/shared/lib/services/loggerInstance';
-import { useRefreshMutation } from '@entities/applet/model/hooks/useRefreshMutation.ts';
 
 import { getDefaultAnswersQueueService } from '../services/answersQueueServiceInstance';
 import { getDefaultQueueProcessingService } from '../services/queueProcessingServiceInstance';
@@ -22,7 +21,6 @@ type Result = {
 
 export const useQueueProcessing = (): Result => {
   const update = useForceUpdate();
-  const { mutateAsync: refreshApplets } = useRefreshMutation();
 
   useEffect(() => {
     const onChangeUploadState = () => {
@@ -48,8 +46,7 @@ export const useQueueProcessing = (): Result => {
 
   const processQueueWithSendingLogs = async (): Promise<boolean> => {
     const result = await queueProcessingService.process();
-    await refreshApplets();
-    getDefaultLogger().send().catch(console.error);
+    getDefaultLogger().send();
     return result;
   };
 

--- a/src/widgets/survey/model/hooks/useAutoCompletion.ts
+++ b/src/widgets/survey/model/hooks/useAutoCompletion.ts
@@ -22,7 +22,6 @@ import { ReduxPersistor } from '@app/shared/lib/redux-state/store';
 import { Emitter } from '@app/shared/lib/services/Emitter';
 import { getDefaultLogger } from '@app/shared/lib/services/loggerInstance';
 import { getMutexDefaultInstanceManager } from '@app/shared/lib/utils/mutexDefaultInstanceManagerInstance';
-import { useRefreshMutation } from '@entities/applet/model/hooks/useRefreshMutation.ts';
 import { CollectCompletionOutput } from '@widgets/survey/model/services/ICollectCompletionsService';
 
 import { CollectCompletionsService } from '../services/CollectCompletionsService';
@@ -48,8 +47,6 @@ export const useAutoCompletion = (): Result => {
   const dispatch = useAppDispatch();
 
   const queryClient = useQueryClient();
-
-  const { mutateAsync: refreshApplets } = useRefreshMutation();
 
   const hasItemsInQueue = useCallback(() => {
     return getDefaultAnswersQueueService().getLength() > 0;
@@ -183,7 +180,6 @@ export const useAutoCompletion = (): Result => {
 
       if (hasItemsInQueue()) {
         result = await getDefaultQueueProcessingService().process();
-        await refreshApplets();
       }
 
       if (forceRefreshNotifications || completionsCollected) {
@@ -192,13 +188,7 @@ export const useAutoCompletion = (): Result => {
 
       return result;
     },
-    [
-      mutex,
-      incompletedEntities,
-      createConstructService,
-      hasItemsInQueue,
-      refreshApplets,
-    ],
+    [mutex, incompletedEntities, createConstructService, hasItemsInQueue],
   );
 
   const hasExpiredEntity = useCallback((): boolean => {


### PR DESCRIPTION
### 📝 Description

This PR is the same as https://github.com/ChildMindInstitute/mindlogger-app-refactor/pull/887 which was hotfixed into `release/2.5.0` but git did not merge into `dev` even with this [PR](https://github.com/ChildMindInstitute/mindlogger-app-refactor/pull/892). 

This re-applies the fix to revert this change https://github.com/ChildMindInstitute/mindlogger-app-refactor/commit/34b9471acb91b26eea684d2722bd7c5670a0d89c. 

🔗 [Jira Ticket M2-8144](https://mindlogger.atlassian.net/browse/M2-8144)

### 🪤 Peer Testing
N/A
