### PR TITLE
fix: add http/https to AndroidManifest

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -45,4 +45,14 @@
         </intent-filter>
       </activity>
     </application>
+    <queries>
+        <intent>
+            <action android:name="android.intent.action.VIEW" />
+            <data android:scheme="https"/>
+        </intent>
+        <intent>
+            <action android:name="android.intent.action.VIEW" />
+            <data android:scheme="http"/>
+        </intent>
+    </queries>
 </manifest>


### PR DESCRIPTION
### 📝 Description

Adds `http` and `https` to AndroidManifest.xml according to [documentation](https://reactnative.dev/docs/linking#canopenurl)

🔗 [Jira Ticket M2-8210](https://mindlogger.atlassian.net/browse/M2-8210)

### Testing

Tested working using Android simulator

- Build app for Android
- Tap on "Terms" or "Privacy" links from Login screen
- URL should open



