### PR TITLE
fix: Fix greek login screen footer elements wrap (M2-8099)

### DIFF
--- a/src/screens/ui/LoginScreen.tsx
+++ b/src/screens/ui/LoginScreen.tsx
@@ -68,6 +68,9 @@ export const LoginScreen: FC = () => {
             jc={isTablet() ? 'space-around' : 'center'}
             mb={isTablet() ? 50 : 40}
             gap={isTablet() ? 0 : 20}
+            width="100%"
+            flexWrap="wrap"
+            ai="center"
           >
             <Link
               textDecorationLine="underline"


### PR DESCRIPTION
### 📝 Description

🔗 [Jira Ticket M2-8099](https://mindlogger.atlassian.net/browse/M2-8099)

A change to the footer's styling was added, so that in case a longer text or more items are added to the footer, the overflow/hiding problem won't be present.

This change won't be noticeable from previous instances for now, since the elements as they are right now don't present that issue:

<img width="933" alt="image" src="https://github.com/user-attachments/assets/22e3028f-a98c-40d9-b5f5-8c36fedf38a6">

Changes include:

- Updated styling for footer container (inside `LoginScreen.tsx`)

### 📸 Screenshots

| Before (Optional)                      | After                                 |
| -------------------------------------- | ------------------------------------- |
| <img width="927" alt="image" src="https://github.com/user-attachments/assets/45fefbdf-bde9-4455-851f-fdd781ffcd7f"> | <img width="951" alt="image" src="https://github.com/user-attachments/assets/3cb05d33-32dd-4ce1-808a-f07a2eb49aef"> |

**NOTE: The change won't be noticeable due to the current text for the three footer elements being different.**

### 🪤 Peer Testing

In project's current state, error can't be reproduced, so there's no validation required.