### PR TITLE
Fix/setting unix time stamp to input tap detection

### DIFF
--- a/ios/FlankerNativeComponents/GameManager.swift
+++ b/ios/FlankerNativeComponents/GameManager.swift
@@ -132,7 +132,7 @@ class GameManager {
   func checkedAnswer(button: SelectedButton) {
     guard !hasRespondedInCurrentTrial else { return }
     hasRespondedInCurrentTrial = true
-    respondTouchButton = CACurrentMediaTime()
+    respondTouchButton = Date().timeIntervalSince1970
     invalidateTimers()
 
     delegate?.setEnableButton(isEnable: false)
@@ -144,9 +144,9 @@ class GameManager {
     arrayTimes.append(Int(resultTime))
     delegate?.updateTime(time: String(format: "%.3f", resultTime))
 
-    endTrialTimestamp = respondTouchButton
+    endTrialTimestamp = Date().timeIntervalSince1970
 
-    startFeedbackTimestamp = CACurrentMediaTime()
+    startFeedbackTimestamp = Date().timeIntervalSince1970
 
     let correctChoice = gameParameters.trials[countTest].correctChoice
     let isCorrect = (button == .left && correctChoice == 0) || (button == .right && correctChoice == 1)
@@ -187,7 +187,7 @@ class GameManager {
     delegate?.setEnableButton(isEnable: false)
 
     if !isFirst {
-      endFeedbackTimestamp = CACurrentMediaTime()
+      endFeedbackTimestamp = Date().timeIntervalSince1970
       countTest += 1
     } else {
       countTest = 0
@@ -201,7 +201,7 @@ class GameManager {
     updateButtonTitle()
 
     if gameParameters.showFixation {
-      startFixationsTimestamp = CACurrentMediaTime()
+      startFixationsTimestamp = Date().timeIntervalSince1970
       if let image = URL(string: gameParameters.fixation), gameParameters.fixation.contains("https") {
         delegate?.updateFixations(image: image, isStart: true, typeTime: .fixations)
       } else {
@@ -221,9 +221,9 @@ class GameManager {
         return
     }
 
-    endFixationsTimestamp = CACurrentMediaTime()
+    endFixationsTimestamp = Date().timeIntervalSince1970
 
-    startTrialTimestamp = CACurrentMediaTime()
+    startTrialTimestamp = Date().timeIntervalSince1970
 
     text = gameParameters.trials[countTest].stimulus.en
 
@@ -245,9 +245,9 @@ class GameManager {
 
     delegate?.setEnableButton(isEnable: false)
 
-    endTrialTimestamp = CACurrentMediaTime()
+    endTrialTimestamp = Date().timeIntervalSince1970
 
-    startFeedbackTimestamp = CACurrentMediaTime()
+    startFeedbackTimestamp = Date().timeIntervalSince1970
 
     if gameParameters.showFeedback {
       delegate?.updateText(text: Constants.timeRespondText, color: .black, font: Constants.smallFont, isStart: false, typeTime: .feedback)

--- a/ios/FlankerNativeComponents/GameManager.swift
+++ b/ios/FlankerNativeComponents/GameManager.swift
@@ -77,6 +77,12 @@ class GameManager {
 
   weak var delegate: GameManagerProtocol?
 
+  private let bootTime: Double = {
+        let uptime = CACurrentMediaTime()
+        let nowTime = Date().timeIntervalSince1970
+        return nowTime - uptime
+    }()
+    
   func startGame(timeSpeed: Float, isShowAnswers: Bool, countGame: Int) {
     countAllGame = countGame
     timeSpeedGame = TimeInterval(timeSpeed)
@@ -132,7 +138,7 @@ class GameManager {
   func checkedAnswer(button: SelectedButton) {
     guard !hasRespondedInCurrentTrial else { return }
     hasRespondedInCurrentTrial = true
-    respondTouchButton = Date().timeIntervalSince1970
+    respondTouchButton = bootTime + CACurrentMediaTime()
     invalidateTimers()
 
     delegate?.setEnableButton(isEnable: false)
@@ -144,9 +150,9 @@ class GameManager {
     arrayTimes.append(Int(resultTime))
     delegate?.updateTime(time: String(format: "%.3f", resultTime))
 
-    endTrialTimestamp = Date().timeIntervalSince1970
+    endTrialTimestamp = respondTouchButton
 
-    startFeedbackTimestamp = Date().timeIntervalSince1970
+    startFeedbackTimestamp = bootTime + CACurrentMediaTime()
 
     let correctChoice = gameParameters.trials[countTest].correctChoice
     let isCorrect = (button == .left && correctChoice == 0) || (button == .right && correctChoice == 1)
@@ -187,7 +193,7 @@ class GameManager {
     delegate?.setEnableButton(isEnable: false)
 
     if !isFirst {
-      endFeedbackTimestamp = Date().timeIntervalSince1970
+      endFeedbackTimestamp = bootTime + CACurrentMediaTime()
       countTest += 1
     } else {
       countTest = 0
@@ -201,7 +207,7 @@ class GameManager {
     updateButtonTitle()
 
     if gameParameters.showFixation {
-      startFixationsTimestamp = Date().timeIntervalSince1970
+      startFixationsTimestamp = bootTime + CACurrentMediaTime()
       if let image = URL(string: gameParameters.fixation), gameParameters.fixation.contains("https") {
         delegate?.updateFixations(image: image, isStart: true, typeTime: .fixations)
       } else {
@@ -221,9 +227,9 @@ class GameManager {
         return
     }
 
-    endFixationsTimestamp = Date().timeIntervalSince1970
+    endFixationsTimestamp = bootTime + CACurrentMediaTime()
 
-    startTrialTimestamp = Date().timeIntervalSince1970
+    startTrialTimestamp = bootTime + CACurrentMediaTime()
 
     text = gameParameters.trials[countTest].stimulus.en
 
@@ -245,9 +251,9 @@ class GameManager {
 
     delegate?.setEnableButton(isEnable: false)
 
-    endTrialTimestamp = Date().timeIntervalSince1970
+    endTrialTimestamp = bootTime + CACurrentMediaTime()
 
-    startFeedbackTimestamp = Date().timeIntervalSince1970
+    startFeedbackTimestamp = bootTime + CACurrentMediaTime()
 
     if gameParameters.showFeedback {
       delegate?.updateText(text: Constants.timeRespondText, color: .black, font: Constants.smallFont, isStart: false, typeTime: .feedback)


### PR DESCRIPTION
### 📝 Description
🔗 [Jira Ticket M2-7967](https://mindlogger.atlassian.net/browse/M2-7967)

This pull request fixes an issue with how timestamps were being calculated using CACurrentMediaTime() in our native Swift component. Initially, CACurrentMediaTime() was used directly, but it was being misinterpreted as a UNIX timestamp, leading to incorrect results. This change adds a method to generate a correct UNIX timestamps.

CACurrentMediaTime() returns the elapsed time since the system's boot (in seconds), but it does not correspond to an absolute timestamp or the UNIX epoch (1970-01-01). Using it directly caused several issues such as incorrect date format.

To address this, I added a new method called bootTime. This method calculates the system's boot time offset by subtracting the CACurrentMediaTime() from the current time (Date().timeIntervalSince1970). This ensures that we can correctly adjust the time provided by CACurrentMediaTime() and treat it as an accurate UNIX timestamp.

The new bootTime value is used to adjust the CACurrentMediaTime() result, so that the calculated timestamps are now consistent with actual calendar dates and times.


### 📸 Screenshots
Comparison:
![Screenshot 2024-11-15 at 4 18 11 PM](https://github.com/user-attachments/assets/ea9afec2-f624-44d6-bd87-1f86469f7e64)

sample of new unix date:
![Screenshot 2024-11-15 at 4 14 44 PM](https://github.com/user-attachments/assets/9ebe02d5-01aa-4d61-aa9d-1e20a55a3634)

![Screenshot 2024-11-15 at 4 21 01 PM](https://github.com/user-attachments/assets/db6efd74-7b74-460b-8962-000289b2efda)

Code hight lights:
![Screenshot 2024-11-15 at 4 28 07 PM](https://github.com/user-attachments/assets/41fcf319-061c-4d36-aa69-5ec9646d56b1)
![Screenshot 2024-11-15 at 4 29 32 PM](https://github.com/user-attachments/assets/4900d7a3-287e-497f-82fc-f5bc87dbde4a)

### 🪤 Peer Testing
* lauch the app
* Create a Serial Reaction Time performance task
* Set time between screens to more than 1000ms (Show each stimulus for)
* Run task on an iOS device
* When the button is presented, wait at least 500ms and then attempt to tap the button
Before:
Input will be ignored the longer you wait to tap the button (disabled state)
Expected:
now you will be able to click all the times.
* go to admin app, and select the applet that responding for your task and download the CSV file, and check if the timestamp is correct.
