### PR TITLE
M2-8103: fixing practice repetitions when threshold is equal 0

### DIFF
--- a/src/features/pass-survey/model/flankerNextStepEvaluator.ts
+++ b/src/features/pass-survey/model/flankerNextStepEvaluator.ts
@@ -48,7 +48,7 @@ export const evaluateFlankerNextStep = (
   }
 
   const minimumAccuracy = itemConfiguration.minimumAccuracy;
-  
+
   if (!minimumAccuracy && minimumAccuracy !== 0) {
     return currentIndex + 1;
   }

--- a/src/features/pass-survey/model/flankerNextStepEvaluator.ts
+++ b/src/features/pass-survey/model/flankerNextStepEvaluator.ts
@@ -48,7 +48,7 @@ export const evaluateFlankerNextStep = (
   }
 
   const minimumAccuracy = itemConfiguration.minimumAccuracy;
-  if (!minimumAccuracy && minimumAccuracy !== 0 ) {
+  if (!minimumAccuracy && minimumAccuracy !== 0) {
     return currentIndex + 1;
   }
 

--- a/src/features/pass-survey/model/flankerNextStepEvaluator.ts
+++ b/src/features/pass-survey/model/flankerNextStepEvaluator.ts
@@ -47,11 +47,7 @@ export const evaluateFlankerNextStep = (
     }
   }
 
-  const minimumAccuracy = itemConfiguration.minimumAccuracy;
-
-  if (!minimumAccuracy && minimumAccuracy !== 0) {
-    return currentIndex + 1;
-  }
+  const minimumAccuracy = itemConfiguration.minimumAccuracy ?? 0;
 
   if (correctCount * 100 >= totalCount * minimumAccuracy) {
     const lastPracticeIndex = items.findIndex(

--- a/src/features/pass-survey/model/flankerNextStepEvaluator.ts
+++ b/src/features/pass-survey/model/flankerNextStepEvaluator.ts
@@ -48,6 +48,7 @@ export const evaluateFlankerNextStep = (
   }
 
   const minimumAccuracy = itemConfiguration.minimumAccuracy;
+  
   if (!minimumAccuracy && minimumAccuracy !== 0) {
     return currentIndex + 1;
   }

--- a/src/features/pass-survey/model/flankerNextStepEvaluator.ts
+++ b/src/features/pass-survey/model/flankerNextStepEvaluator.ts
@@ -48,8 +48,7 @@ export const evaluateFlankerNextStep = (
   }
 
   const minimumAccuracy = itemConfiguration.minimumAccuracy;
-
-  if (!minimumAccuracy) {
+  if (!minimumAccuracy && minimumAccuracy !== 0 ) {
     return currentIndex + 1;
   }
 


### PR DESCRIPTION
### 📝 Description
🔗 [Jira Ticket M2-8103](https://mindlogger.atlassian.net/browse/M2-8103)

When the accuracy or threshold is set to 0, the system continues to repeat the activity even when the user's accuracy is 100%. The issue was caused by a validation check that verifies if a minimum accuracy is specified in the activity configuration. If it's not present, the system proceeds to repeat the practice at the next index. The problem occurs because a minimum accuracy of 0 was being incorrectly interpreted as a lack of minimum accuracy (as if no minimum accuracy was set).

OBSERVATION:
I tested with 1% threshold, 2% ... every other threshold is working properly, that is, its will only repeat in case user accuracy is less than threshold.
Somehow the admin seems to block setup like 0%, but the  accuracy settings is coming from backend as 0% in the ticket's activity.

I tried to replicate the 0% setup on admin but I didnt manage to save as a 0%.
example of the minimum a manage to get:
![Screenshot 2024-11-21 at 9 27 38 PM](https://github.com/user-attachments/assets/1d4b5f9c-9ca6-418f-ae68-8aa620e37d35)
<img width="569" alt="Screenshot 2024-11-21 at 9 39 21 PM" src="https://github.com/user-attachments/assets/e2bd9a06-f85b-45d1-bb5f-6f82ebdf7239">

the activity that QA mentioned is:
Applet: Crypto Library Retest
activity: Simple & Choice Reaction Time Task Builder

and the setting is comming as 0 (Observation, this is the accuracy settings, not the user accuracy)
<img width="563" alt="Screenshot 2024-11-21 at 9 29 42 PM" src="https://github.com/user-attachments/assets/39ca1b6d-5d89-465c-89fb-6d76f8bd4c56">


### 📸 Screenshots

OBSERVATION, HERE THE TRESHOLD IS 0

BEFORE:

https://github.com/user-attachments/assets/bab596fb-de83-4fc8-8058-fa0187e3191c

AFTER:

https://github.com/user-attachments/assets/9c0c4971-bee6-471b-8e3d-574de6177d2c


### 🪤 Peer Testing

1- lauch the app
2-  point to the UAT environment (API_URL= https://api-uat.cmiml.net)
3 - use this account [geria.test+1300@gmail.com](mailto:geria.test+1300@gmail.com) / 123456
4 - test the app Simple & Choice Reaction Time Task Builder in the applet Crypto Library Retest

