### PR TITLE
adding mapConditionalLogic to drawing item type

### DIFF
--- a/src/entities/activity/model/mappers.ts
+++ b/src/entities/activity/model/mappers.ts
@@ -182,6 +182,7 @@ function mapToDrawing(dto: DrawingItemDto): ActivityItem {
     hasTopNavigation: dto.config.navigationToTop,
     isHidden: dto.isHidden,
     ...mapAdditionalText(dto.config),
+    ...mapConditionalLogic(dto.conditionalLogic),
   };
 }
 


### PR DESCRIPTION
### 📝 Description
🔗 [Jira Ticket M2-8274](https://mindlogger.atlassian.net/browse/M2-8274)

the drawing item type was shown even when condition not met.
this PR adds the conditional logic mapping to the item

### 🪤 Peer Testing
1 - create an activity with some conditional logic that enable and disable Drawing item type
2 - launch the app and check if the drawing item is responding to the conditional logic.