### PR TITLE
fix: M2-8308 fixing isBetweenSliderRowValues logic

### DIFF
--- a/src/entities/conditional-logic/model/conditions.ts
+++ b/src/entities/conditional-logic/model/conditions.ts
@@ -357,7 +357,7 @@ export const isBetweenSliderRowValues = (
   minValue: number,
   maxValue: number,
 ) => {
-  return rowValue !== null && rowValue >= minValue && rowValue <= maxValue;
+  return rowValue !== null && rowValue > minValue && rowValue < maxValue;
 };
 
 export const isLessThanSliderRow = (rowValue: number | null, value: number) => {


### PR DESCRIPTION
### 📝 Description
🔗 [Jira Ticket M2-8308](https://mindlogger.atlassian.net/browse/M2-8308)
Fixing the logic of isBetweenSliderRow

### 📸 Screenshots
![Screenshot 2024-12-02 at 3 33 54 PM](https://github.com/user-attachments/assets/43073cb8-93ac-46aa-bd49-37a301560686)


https://github.com/user-attachments/assets/ee031336-281d-447d-9633-bc5ab0123d63


### 🪤 Peer Testing

1 - create an activity with slider per row item and  create a logic of between. ( similar to what I left on screenshots)
2 - launch the app, and check if the Boundary value is considered as a valid response ( example):
between 2 and 4,   the "2" and "4" shouldn't be a valid answer, only "3".
