### PR TITLE
Fix: M2-8294 Single selection per row: The user remains on the input screen after selecting the response and tapping 'Next'

### DIFF
--- a/src/features/pass-survey/model/AnswerValidator.ts
+++ b/src/features/pass-survey/model/AnswerValidator.ts
@@ -112,6 +112,19 @@ export function AnswerValidator(
     return null;
   };
 
+  const getSelectionRowOptionValue = (rowIndex: number): string | null => {
+    const answer = currentAnswer?.answer as Maybe<
+      { id: string; text: string }[]
+    >;
+
+    if (answer && answer[rowIndex]) {
+      const optionIds = answer[rowIndex].id;
+
+      return optionIds;
+    }
+    return null;
+  };
+
   return {
     isCorrect() {
       if (!currentPipelineItem?.validationOptions) {
@@ -164,12 +177,12 @@ export function AnswerValidator(
     },
 
     isEqualToRowOption(rowIndex: number, optionValue: string) {
-      const selectedOption = getRowOptionValues(rowIndex);
+      const selectedOption = getSelectionRowOptionValue(rowIndex);
       return selectedOption !== null && selectedOption.includes(optionValue);
     },
 
     isNotEqualToRowOption(rowIndex: number, optionValue: string) {
-      const selectedOption = getRowOptionValues(rowIndex);
+      const selectedOption = getSelectionRowOptionValue(rowIndex);
       return selectedOption !== null && !selectedOption.includes(optionValue);
     },
 


### PR DESCRIPTION
### 📝 Description
🔗 [Jira Ticket M2-8294](https://mindlogger.atlassian.net/browse/M2-8294)
Fixing how singleSelectionPerRow get value

### 📸 Screenshots
![Screenshot 2024-12-02 at 11 48 13 PM](https://github.com/user-attachments/assets/d1d3250a-50cd-4c8c-b6ad-7f2ae0490397)
![Screenshot 2024-12-02 at 11 46 32 PM](https://github.com/user-attachments/assets/7a0bd5e0-7db8-4474-8d79-6f8ec251c322)
![Screenshot 2024-12-02 at 11 48 19 PM](https://github.com/user-attachments/assets/20674026-0b2e-4439-b616-6d12b4a9a5a8)

https://github.com/user-attachments/assets/1e261093-663f-4a8c-8315-dce9bd235681

### 🪤 Peer Testing

1 - create an activity with  single selection per row Item
2 - create a conditional logic (could be any conditional logic as long it is is equal or it is not equal) 
3 - launch the app 
4 - select the applet with the activity you created and check if the logic is responding right.

