### PR TITLE
fixing time mismatch

### DIFF
--- a/ios/FlankerNativeComponents/GameManager.swift
+++ b/ios/FlankerNativeComponents/GameManager.swift
@@ -110,7 +110,10 @@ class GameManager {
 
   func startLogicTimer() {
     invalidateTimers()
-    setDefaultText(isFirst: true)
+    let transitionDelay: TimeInterval = 0.3
+    DispatchQueue.main.asyncAfter(deadline: .now() + transitionDelay) {
+      self.setDefaultText(isFirst: true)
+      }
   }
 
   func setEndTimeViewingImage(time: Double, isStart: Bool, type: TypeTimeStamps) {
@@ -150,7 +153,7 @@ class GameManager {
 
     guard let gameParameters = gameParameters else { return }
     guard countTest >= 0 && countTest < gameParameters.trials.count else { return }
-    var resultTime = (respondTouchButton! - startTrialTimestamp) * 1000
+    let resultTime = (respondTouchButton! - startTrialTimestamp) * 1000
 
     arrayTimes.append(Int(resultTime))
     delegate?.updateTime(time: String(format: "%.3f", resultTime))
@@ -247,8 +250,6 @@ class GameManager {
     }
 
     endFixationsTimestamp = bootTime + CACurrentMediaTime()
-    startTrialTimestamp = bootTime + CACurrentMediaTime()
-
     hasRespondedInCurrentTrial = false
 
     text = gameParameters.trials[countTest].stimulus.en
@@ -260,15 +261,20 @@ class GameManager {
         text: text, color: .black, font: Constants.bigFont, isStart: true, typeTime: .trial)
     }
 
-    delegate?.setEnableButton(isEnable: true)
+    let slightDelay = 0.016 
+    DispatchQueue.main.asyncAfter(deadline: .now() + slightDelay) { [weak self] in
+      guard let self = self else { return }
+      self.startTrialTimestamp = self.bootTime + CACurrentMediaTime()
+      self.delegate?.setEnableButton(isEnable: true)
 
-    timeResponse = Timer(
-      timeInterval: gameParameters.trialDuration / 1000,
-      target: self,
-      selector: #selector(timeResponseFailed),
-      userInfo: nil,
-      repeats: false)
-    RunLoop.main.add(timeResponse!, forMode: .common)
+      self.timeResponse = Timer(
+        timeInterval: gameParameters.trialDuration / 1000,
+        target: self,
+        selector: #selector(self.timeResponseFailed),
+        userInfo: nil,
+        repeats: false)
+      RunLoop.main.add(self.timeResponse!, forMode: .common)
+    }
   }
 
   @objc func timeResponseFailed() {


### PR DESCRIPTION
### 📝 Description
🔗 [Jira Ticket M2-8255](https://mindlogger.atlassian.net/browse/M2-8255)

In this PR I created a way to deal with animation and time mismatch, after some time debugging the application, I noticed the timer of start logic was counting at the moment in the "start click button", so until the transition gets completed, I've lost about 0.3 ms, it was causing some problems mainly in the first block of practice and test.

So I added a delay to the start the logic, and a slight Delay to Instead of immediately enabling the button and setting 'startTrialTimestamp' I introduce a short delay ( that respondint to a frame in 60hz) to  allow the UI time to render

### 📸 Screenshots

Time is set for 500 ms:
https://github.com/user-attachments/assets/524901a0-6dba-4e8c-9603-abb5d7113074

as you can see, the second image start at 4.97 and finish at 5.47

I tested on my physical phone with diferent types of SRT configuration and the result was the same,

### 🪤 Peer Testing

1 - create  a SRT activity
2 - launch the app
3 - open the activity and check if all blocks is taking the correct amount of time (mainly the first one of practice of test)

