### PR TITLE
Fix: M2-8444 Allowing Alarm permission from Android manifest

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -11,8 +11,7 @@
     <uses-permission android:name="android.permission.HIGH_SAMPLING_RATE_SENSORS" />
     <uses-permission
       android:name="android.permission.SCHEDULE_EXACT_ALARM"
-      android:maxSdkVersion="${max_sdk_version}"
-      tools:replace="android:maxSdkVersion" />
+      tools:ignore="UnusedPermission" />
     <uses-permission
       android:name="android.permission.USE_FULL_SCREEN_INTENT"
       tools:node="remove" />


### PR DESCRIPTION
### 📝 Description
🔗 [Jira Ticket M2-8444](https://mindlogger.atlassian.net/browse/M2-8444)

 It was not possible to allow local notifications.

### 📸 Screenshots
ERROR:
https://github.com/user-attachments/assets/c0bab2de-2bdc-4665-932b-1ace169e5e7a

FIX:
https://github.com/user-attachments/assets/3c8d9f0f-9f89-40ca-84f1-d8af860f4bc4

### 🪤 Peer Testing

1 - Install the app on Android 15, ( it would be good test with previous versions as well)
2 - Allow to use notifications on the first pop-up