### PR TITLE
fix: adjust SCHEDULE_EXACT_ALARM availability (M2-8444)

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -11,7 +11,8 @@
     <uses-permission android:name="android.permission.HIGH_SAMPLING_RATE_SENSORS" />
     <uses-permission
       android:name="android.permission.SCHEDULE_EXACT_ALARM"
-      tools:ignore="UnusedPermission" />
+      android:maxSdkVersion="35"
+      tools:replace="android:maxSdkVersion" />
     <uses-permission
       android:name="android.permission.USE_FULL_SCREEN_INTENT"
       tools:node="remove" />


### PR DESCRIPTION
### 📝 Description

🔗 [Jira Ticket M2-8444](https://mindlogger.atlassian.net/browse/M2-8444)

Fixes notification permissions for Android 15 by explicitly setting`maxSdkVersion` to `35` for the `SCHEDULE_EXACT_ALARM` permission.

### 📸 Screenshots

#### Before
https://github.com/user-attachments/assets/8e82a71f-0f23-4317-a432-051810603fc0

#### After
https://github.com/user-attachments/assets/33c082a0-c187-48e6-9ac0-508621170333

### 🪤 Peer Testing

- Install the app on Android 15
- Press the "Open Settings" button when prompted for "Alarm permissions request"
- The setting should be configurable


### ✏️ Notes

This hardcoded value should be removed as part of M2-8088 Update React Native.