### PR TITLE
feat: Update mobile app to send device properties on each request (M2-8664)

### DIFF
--- a/src/jobs/request-interception.ts
+++ b/src/jobs/request-interception.ts
@@ -1,9 +1,15 @@
+import { Platform, PlatformIOSStatic } from 'react-native';
+
 import i18n from 'i18next';
+import { PlatformAndroidStatic } from 'react-native/Libraries/Utilities/Platform';
 
 import { getDefaultSessionService } from '@app/entities/session/lib/sessionServiceInstance';
 import { httpService } from '@app/shared/api/services/httpService';
 import { TIMEZONE } from '@app/shared/lib/constants/dateTime';
 import { createJob } from '@app/shared/lib/services/jobManagement';
+import { APP_VERSION } from '@shared/lib/constants';
+import { getDefaultSystemRecord } from '@shared/lib/records/systemRecordInstance.ts';
+import { getDefaultLogger } from '@shared/lib/services/loggerInstance.ts';
 
 export default createJob(() => {
   httpService.interceptors.request.use(
@@ -15,8 +21,30 @@ export default createJob(() => {
         config.headers.Authorization = `${tokenType} ${accessToken}`;
       }
 
+      try {
+        const deviceId = getDefaultSystemRecord().getDeviceId();
+        if (deviceId) {
+          config.headers['Device-Id'] = deviceId;
+        }
+      } catch (e) {
+        try {
+          // Try to log the error, but if that fails, ignore it
+          const logger = getDefaultLogger();
+          logger.error(`${e}`);
+        } catch (_e) {
+          // ignored
+        }
+      }
+
       config.headers['Content-Language'] = i18n.resolvedLanguage;
       config.headers['X-Timezone'] = TIMEZONE;
+      config.headers['OS-Name'] = Platform.OS;
+      config.headers['OS-Version'] = Platform.select({
+        android: (Platform as PlatformAndroidStatic).constants.Release,
+        ios: (Platform as PlatformIOSStatic).constants.systemName,
+        default: Platform.Version.toString(),
+      });
+      config.headers['App-Version'] = APP_VERSION;
 
       return config;
     },


### PR DESCRIPTION
### 📝 Description

🔗 [Jira Ticket M2-8664](https://mindlogger.atlassian.net/browse/M2-8664)

This PR updates the Axios interceptor to add the following HTTP headers to each request:
- **Device-Id**: The device ID currently sent on sign up or login
- **OS-Name**: `android` or `ios`
- **OS-Version**: The version of the OS (e.g. 13 for Android 13)
- **App-Version**: The version of the MindLogger app currently installed.

### 📸 Screenshots

When paired with https://github.com/ChildMindInstitute/mindlogger-backend-refactor/pull/1727, the `user_devices` table will now populate these extra properties instead of leaving them blank. This happens on login, so you can use that behaviour to confirm it works

<img width="1113" alt="image" src="https://github.com/user-attachments/assets/960b368f-8656-4117-9797-3d131aa9c5e7" />

### 🪤 Peer Testing

Using https://github.com/ChildMindInstitute/mindlogger-backend-refactor/pull/1727, run the API and log into the MindLogger app. Then inspect the `user_devices` table in the database.

Alternatively you can print the headers on any random request in the API code.

### ✏️ Notes

Despite references to https://github.com/ChildMindInstitute/mindlogger-backend-refactor/pull/1727, the two PRs are not dependent on each other and can be deployed independently