### PR TITLE
fix: include additional ItemTypes in ConditionalLogic (M2-8320)

### DIFF
--- a/src/features/pass-survey/model/hooks/useActivityStepper.ts
+++ b/src/features/pass-survey/model/hooks/useActivityStepper.ts
@@ -7,6 +7,10 @@ const ConditionalLogicItems: ActivityItemType[] = [
   'Radio',
   'Checkbox',
   'Slider',
+  'NumberSelect',
+  'Date',
+  'Time',
+  'TimeRange',
 ];
 
 export function useActivityStepper(state: ActivityState | undefined) {
@@ -28,9 +32,9 @@ export function useActivityStepper(state: ActivityState | undefined) {
     currentPipelineItem?.additionalText?.required;
 
   const hasAnswer =
-    answers[step]?.answer != null && answers[step]?.answer !== '';
+    answers[step]?.answer !== null && answers[step]?.answer !== '';
   const hasAdditionalAnswer =
-    answers[step]?.additionalAnswer != null &&
+    answers[step]?.additionalAnswer !== null &&
     answers[step]?.additionalAnswer !== '';
 
   const canSkip =

--- a/src/features/pass-survey/model/hooks/useActivityStepper.ts
+++ b/src/features/pass-survey/model/hooks/useActivityStepper.ts
@@ -31,11 +31,8 @@ export function useActivityStepper(state: ActivityState | undefined) {
   const additionalAnswerRequired =
     currentPipelineItem?.additionalText?.required;
 
-  const hasAnswer =
-    answers[step]?.answer !== null && answers[step]?.answer !== '';
-  const hasAdditionalAnswer =
-    answers[step]?.additionalAnswer !== null &&
-    answers[step]?.additionalAnswer !== '';
+  const hasAnswer = !!answers[step]?.answer;
+  const hasAdditionalAnswer = !!answers[step]?.additionalAnswer;
 
   const canSkip =
     !!currentPipelineItem?.isSkippable && !hasAnswer && !isSplashStep;


### PR DESCRIPTION
### 📝 Description

Adds Group 1 and Group 2 item types to list of valid `ConditionalLogicItems` types

🔗 [Jira Ticket M2-8320](https://mindlogger.atlassian.net/browse/M2-8320)

<!-- Replace this with a high-level description of the features/functionality proposed in the pull request. -->

### 📸 Screenshots

<!--
If your work here contains visual changes, provide before (optional) and after screenshots, GIFs, or videos.

If not, then delete this section
-->
**Before** - Text item is displayed even when conditional logic shouldn't pass

https://github.com/user-attachments/assets/61285cb6-2335-4f85-b32f-0419f18feea6

**After** - Activity is submitted after conditional logic determines there are no more items available

https://github.com/user-attachments/assets/5cd84c75-0d1a-4f5a-8bab-5bbfab2506a3


### 🪤 Peer Testing

- Create an Activity as instructed in the Jira ticket
  - Include 3 items: Number Select and 2 others, e.g. Single Select and Text
  - Create Conditional logic using Number Select to show Single Select, and Single Select to show Text
  - Save
- Start activity in the mobile app
- Answer NumberSelect so that first condition passes
- Answer SingleSelect so that second condition passes
- Tap Back twice to go to the first item (NumberSelect)
- Change answer so that first condition fails
- Tap Next
  - **Before:** Text item will appear (error)
  - **After:** Activity will be submitted as there are no more items

Steps apply to: `NumberSelect`, `Date`, `Time` and `TimeRange` item types.

**Full** testing and configuration is available in the linked Jira ticket.

### ✏️ Notes

FeatureFlag is not configured in mobile apps, the admin app is the source of truth for item configuration. 