### PR TITLE
feat: add event history id to answer submissions (M2-8481)

### DIFF
--- a/src/entities/activity/lib/services/AnswersUploadService.ts
+++ b/src/entities/activity/lib/services/AnswersUploadService.ts
@@ -399,6 +399,10 @@ export class AnswersUploadService implements IAnswersUploadService {
 
     const identifier = data.userIdentifier && encrypt(data.userIdentifier);
 
+    const eventHistoryId =
+      data.eventVersion && data.eventId
+        ? `${data.eventId}_${data.eventVersion}`
+        : undefined;
     const userPublicKey = this.encryptionManager.getPublicKey({
       privateKey: userPrivateKey,
       appletPrime: JSON.parse(appletEncryption.prime),
@@ -430,6 +434,7 @@ export class AnswersUploadService implements IAnswersUploadService {
       createdAt: data.createdAt,
       client: data.client,
       alerts: data.alerts,
+      eventHistoryId,
     };
 
     if ('consentToShare' in data) {

--- a/src/entities/activity/lib/services/AnswersUploadService.ts
+++ b/src/entities/activity/lib/services/AnswersUploadService.ts
@@ -399,10 +399,10 @@ export class AnswersUploadService implements IAnswersUploadService {
 
     const identifier = data.userIdentifier && encrypt(data.userIdentifier);
 
-    const eventHistoryId =
-      data.eventVersion && data.eventId
-        ? `${data.eventId}_${data.eventVersion}`
-        : undefined;
+    const eventHistoryId = data.eventVersion
+      ? `${data.eventId}_${data.eventVersion}`
+      : undefined;
+
     const userPublicKey = this.encryptionManager.getPublicKey({
       privateKey: userPrivateKey,
       appletPrime: JSON.parse(appletEncryption.prime),

--- a/src/entities/activity/lib/types/uploadAnswers.ts
+++ b/src/entities/activity/lib/types/uploadAnswers.ts
@@ -34,6 +34,7 @@ export type SendAnswersInput = {
   activityName: string;
   logCompletedAt?: string;
   consentToShare?: boolean;
+  eventVersion?: string;
 };
 
 export type CheckFileUploadResult = {

--- a/src/entities/event/lib/types/event.ts
+++ b/src/entities/event/lib/types/event.ts
@@ -39,4 +39,5 @@ export type ScheduleEvent = {
   notificationSettings: NotificationSettings;
   selectedDate: Date | null;
   scheduledAt: Date | null;
+  version?: string;
 };

--- a/src/entities/event/model/mappers.ts
+++ b/src/entities/event/model/mappers.ts
@@ -40,5 +40,6 @@ export function mapEventFromDto(dto: ScheduleEventDto | null): ScheduleEvent {
       notifications: [],
       reminder: null,
     },
+    version: dto.version,
   };
 }

--- a/src/shared/api/services/IAnswerService.ts
+++ b/src/shared/api/services/IAnswerService.ts
@@ -201,6 +201,7 @@ export type ActivityAnswersRequest = {
   };
   alerts: AnswerAlertsDto;
   consentToShare?: boolean;
+  eventHistoryId?: string;
 };
 
 export type ActivityAnswersResponse = SuccessfulEmptyResponse;

--- a/src/shared/api/services/IEventsService.ts
+++ b/src/shared/api/services/IEventsService.ts
@@ -43,6 +43,7 @@ export type ScheduleEventDto = {
     timer: HourMinute | null;
     idleTimer: HourMinute | null;
   };
+  version?: string;
 };
 
 export type AppletEventsResponse = SuccessfulResponse<{

--- a/src/widgets/survey/model/services/ConstructCompletionsService.ts
+++ b/src/widgets/survey/model/services/ConstructCompletionsService.ts
@@ -342,6 +342,8 @@ export class ConstructCompletionsService {
       targetSubjectId,
     )!;
 
+    const scheduledEvent = this.queryDataUtils.getEventDto(appletId, eventId);
+
     const evaluatedEndAt = this.evaluateEndAt(
       'intermediate',
       (progression as EntityProgressionInProgress).availableUntilTimestamp,
@@ -382,6 +384,7 @@ export class ConstructCompletionsService {
       targetSubjectId,
       isFlowCompleted: false,
       tzOffset: getTimezoneOffset(),
+      eventVersion: scheduledEvent?.version,
     });
 
     clearActivityStorageRecord(
@@ -506,6 +509,8 @@ export class ConstructCompletionsService {
       targetSubjectId,
     )!;
 
+    const scheduledEvent = this.queryDataUtils.getEventDto(appletId, eventId);
+
     const itemToUpload: SendAnswersInput = {
       appletId,
       createdAt: evaluatedEndAt,
@@ -529,6 +534,7 @@ export class ConstructCompletionsService {
       targetSubjectId,
       isFlowCompleted: !!flowId,
       tzOffset: getTimezoneOffset(),
+      eventVersion: scheduledEvent?.version,
     };
 
     this.pushToQueueService.push(itemToUpload);

--- a/src/widgets/survey/model/services/tests/ConstructCompletionsService.test.ts
+++ b/src/widgets/survey/model/services/tests/ConstructCompletionsService.test.ts
@@ -109,6 +109,11 @@ describe('Test ConstructCompletionsService.constructForIntermediate', () => {
       displayName: 'mock-applet-name-1',
     });
 
+    //@ts-expect-error
+    service.queryDataUtils.getEventDto = jest.fn().mockReturnValue({
+      version: 'mock-event-version-1',
+    });
+
     await service.construct(getInputsForIntermediate());
 
     expect(getActivityRecordMock).toBeCalledTimes(1);
@@ -163,6 +168,7 @@ describe('Test ConstructCompletionsService.constructForIntermediate', () => {
       userActions: expectedUserActions,
       userIdentifier: 'mock-user-id-1',
       version: 'applet-version-mock-1',
+      eventVersion: 'mock-event-version-1',
     });
   });
 
@@ -202,6 +208,9 @@ describe('Test ConstructCompletionsService.constructForIntermediate', () => {
       encryption: 'applet-encryption-mock-1',
       displayName: 'mock-applet-name-1',
     });
+
+    //@ts-expect-error
+    service.queryDataUtils.getEventDto = jest.fn().mockReturnValue({});
 
     await service.construct(getInputsForIntermediate());
 
@@ -279,6 +288,11 @@ describe('Test ConstructCompletionsService.constructForFinish', () => {
       displayName: 'mock-applet-name-1',
     });
 
+    //@ts-expect-error
+    service.queryDataUtils.getEventDto = jest.fn().mockReturnValue({
+      version: 'mock-event-version-1',
+    });
+
     await service.construct(getInputsForFinish('flow'));
 
     expect(getActivityRecordMock).toBeCalledTimes(1);
@@ -335,6 +349,7 @@ describe('Test ConstructCompletionsService.constructForFinish', () => {
           userActions: expectedUserActions,
           userIdentifier: 'mock-user-id-1',
           version: 'applet-version-mock-1',
+          eventVersion: 'mock-event-version-1',
         },
       ],
     ]);
@@ -395,6 +410,11 @@ describe('Test ConstructCompletionsService.constructForFinish', () => {
       displayName: 'mock-applet-name-1',
     });
 
+    //@ts-expect-error
+    service.queryDataUtils.getEventDto = jest.fn().mockReturnValue({
+      version: 'mock-event-version-1',
+    });
+
     await service.construct(getInputsForFinish('regular'));
 
     expect(getActivityRecordMock).toBeCalledTimes(1);
@@ -453,6 +473,7 @@ describe('Test ConstructCompletionsService.constructForFinish', () => {
           userActions: expectedUserActions,
           userIdentifier: 'mock-user-id-1',
           version: 'applet-version-mock-1',
+          eventVersion: 'mock-event-version-1',
         },
       ],
     ]);


### PR DESCRIPTION
### 📝 Description

> [!IMPORTANT]
> For the answer submission to be accepted by the BE, it requires running it with this branch checked out: https://github.com/ChildMindInstitute/mindlogger-backend-refactor/pull/1754

🔗 [Jira Ticket M2-8481](https://mindlogger.atlassian.net/browse/M2-8481)

Adds `eventHistoryId` to new submissions, making sure to use the existing queue service.

### 🪤 Peer Testing

- Create a new Applet/Activity
- Submit the activity using the mobile app
- Validate `eventHistoryId` is included in the payload
  - You can review the `encryptedData` payload in `AnswersUploadService.uploadAnswers` or by ensuring `event_history_id` is saved in the new answer directly in the database.
