### PR TITLE
fix: Mobile app fixes (M2-8800, M2-8801)

### DIFF
--- a/src/screens/config/theme.tsx
+++ b/src/screens/config/theme.tsx
@@ -34,6 +34,7 @@ export const getScreenOptions = ({
     },
     headerShadowVisible: false,
     headerTitle: HeaderTitle,
+    headerBackVisible: false,
     headerLeft: () => (
       <Text
         accessibilityLabel="close-button"

--- a/src/shared/ui/Text.tsx
+++ b/src/shared/ui/Text.tsx
@@ -1,6 +1,6 @@
 import { Text as TGUIText, TextProps } from '@tamagui/core';
 
-type Props = TextProps;
+type Props = Omit<TextProps, 'fos' | 'fow' | 'lh'>;
 
 export const Text = ({
   fontSize = 16,

--- a/src/widgets/survey/ui/UploadRetryBanner.tsx
+++ b/src/widgets/survey/ui/UploadRetryBanner.tsx
@@ -39,7 +39,7 @@ export const UploadRetryBanner: FC<Props> = () => {
   return (
     <Box h={50} px={18} bw={1} boc="$grey" bc="$alertLight">
       <Box jc="space-between" ai="center" flexDirection="row" flex={1}>
-        <Text flex={1} fos={14}>
+        <Text flex={1} fontSize={14}>
           {isUploading
             ? t('additional:data_is_sending')
             : t('additional:data_not_sent')}
@@ -53,7 +53,7 @@ export const UploadRetryBanner: FC<Props> = () => {
             isLoading={isUploading}
             onPress={onRetry}
           >
-            <Text fos={16} fontWeight="700">
+            <Text fontSize={16} fontWeight="700">
               {t('additional:send')}
             </Text>
           </Button>

--- a/src/widgets/survey/ui/completion/ActivityProgressStep.tsx
+++ b/src/widgets/survey/ui/completion/ActivityProgressStep.tsx
@@ -17,13 +17,25 @@ export const ActivityProgressStep = ({
 }: Props) => {
   return (
     <YStack>
-      <Text fos={12} fow="700" lh={27} color={colors.blue3}>
+      <Text fontSize={12} fontWeight="700" lineHeight={27} color={colors.blue3}>
         {`Activity ${currentActivity + 1} of ${totalActivities}`}
       </Text>
-      <Text fos={16} fow="700" lh={27} numberOfLines={1} col={colors.onSurface}>
+      <Text
+        fontSize={16}
+        fontWeight="700"
+        lineHeight={27}
+        numberOfLines={1}
+        color={colors.onSurface}
+      >
         {currentActivityName}
       </Text>
-      <Text fos={12} fow="400" lh={27} ls={0.1} col={colors.onSurface}>
+      <Text
+        fontSize={12}
+        fontWeight="400"
+        lineHeight={27}
+        letterSpacing={0.1}
+        color={colors.onSurface}
+      >
         {currentSecondLevelStep}
       </Text>
     </YStack>

--- a/src/widgets/survey/ui/completion/CircleProgressStep.tsx
+++ b/src/widgets/survey/ui/completion/CircleProgressStep.tsx
@@ -23,12 +23,18 @@ export const CircleProgressStep = ({
       <CircleProgress progress={currentStep / totalSteps} size={circleSize} />
 
       <Box pos="absolute">
-        <Text ta="center" tt="uppercase" fow="400" fos={10} ls={0.1}>
+        <Text
+          ta="center"
+          tt="uppercase"
+          fontWeight="400"
+          fontSize={10}
+          ls={0.1}
+        >
           {t('activity:step')}
         </Text>
         <Text
-          fow="700"
-          fos={12}
+          fontWeight="700"
+          fontSize={12}
           ls={0.1}
         >{`${currentStep} of ${totalSteps}`}</Text>
       </Box>

--- a/src/widgets/survey/ui/completion/ProcessingAnswers.tsx
+++ b/src/widgets/survey/ui/completion/ProcessingAnswers.tsx
@@ -38,11 +38,11 @@ export const ProcessingAnswers: FC = () => {
           <ActivityIndicator mb={24} size={'large'} color={colors.blue} />
         )}
 
-        <Text mb={24} als="center" fos={31} fow="600">
+        <Text mb={24} als="center" fontSize={31} fontWeight="600">
           {t('autocompletion:processing_answers')}
         </Text>
 
-        <Text mb={16} als="center" ta="center" fos={18}>
+        <Text mb={16} als="center" ta="center" fontSize={18}>
           {t('autocompletion:preparing_answers')}
         </Text>
 


### PR DESCRIPTION
### 📝 Description

<!-- Contributions are welcome! If there is a corresponding      -->
<!-- JIRA ticket, link to it by replacing `#` with ticket number -->

🔗 [Jira Ticket M2-8800](https://mindlogger.atlassian.net/browse/M2-8800)
🔗 [Jira Ticket M2-8801](https://mindlogger.atlassian.net/browse/M2-8801)

The "Processing Answers" text was being cut off after the recent line height change; this was related to shorthand prop names complicating the default line height calculation.

Also, using the `headerTitle` component affected the default value for `headerBackVisible` on Android only. Fixed by setting it explicitly to `false`.

### 📸 Screenshots

| Before                      | After                                 | |
| -------------------------------------- | ------------------------------------- | - |
| ![processing answers trim](https://github.com/user-attachments/assets/974c7b88-9541-4ebd-9726-fadeafee7d86) | ![Screenshot_1741182034](https://github.com/user-attachments/assets/92aed9e4-5174-403c-b137-97a666b87455) |  |
| ![extra back button on android](https://github.com/user-attachments/assets/9e57041d-6811-4505-9218-8e052520c073) |  ![Screenshot_1741181840](https://github.com/user-attachments/assets/53f948ef-286d-456e-9c19-0683543f5d05) | ![Screenshot_1741181884](https://github.com/user-attachments/assets/3dcf3f4f-541f-4dd6-8371-5bde46638b76) |


### 🪤 Peer Testing

1. Submit an assessment and observe the Processing Answers screen
    **Expected outcome:** "Processing Answers" should not be cut off.
2. In Android, navigate to various subscreens, including "About Mindlogger", "Create Account", "User Settings", etc.
    **Expected outcome:** There should only be 1 back button.