### PR TITLE
fix: Treat `0` as valid number answer (M2-8842)

### DIFF
--- a/src/features/pass-survey/model/hooks/useActivityStepper.ts
+++ b/src/features/pass-survey/model/hooks/useActivityStepper.ts
@@ -31,8 +31,14 @@ export function useActivityStepper(state: ActivityState | undefined) {
   const additionalAnswerRequired =
     currentPipelineItem?.additionalText?.required;
 
-  const hasAnswer = !!answers[step]?.answer;
-  const hasAdditionalAnswer = !!answers[step]?.additionalAnswer;
+  const hasAnswer =
+    answers[step]?.answer !== undefined &&
+    answers[step]?.answer !== null &&
+    answers[step]?.answer !== '';
+  const hasAdditionalAnswer =
+    answers[step]?.additionalAnswer !== undefined &&
+    answers[step]?.additionalAnswer !== null &&
+    answers[step]?.additionalAnswer !== '';
 
   const canSkip =
     !!currentPipelineItem?.isSkippable && !hasAnswer && !isSplashStep;


### PR DESCRIPTION
### 📝 Description

🔗 [Jira Ticket M2-8842](https://mindlogger.atlassian.net/browse/M2-8842)

This fixes a regression introduced by #943 that caused `0` values for Slider items to be interpreted as "no answer", preventing the respondent from being able to proceed to the next step.

### 🪤 Peer Testing

1. Create an activity with a Slider item that can accept 0 as a minimum value
2. Log into the mobile app as a respondent.
3. Start the activity.
4. Tap on the min value (0) on the slider range.
    - **Before:** It is impossible to proceed with the selected min value ‘0' on slider, and the "Undo" and "Next" buttons don’t appear.
    - **After:** It is possible to proceed with the selected min value ‘0' on slider, and the "Undo" and "Next" buttons appear.

**Confirm original fix for #943 continues to work:**

1. Create an Activity as instructed in the Jira ticket
    - Include 3 items: Number Select and 2 others, e.g. Single Select and Text
    - Create Conditional logic using Number Select to show Single Select, and Single Select to show Text
4. Start activity in the mobile app
5. Answer NumberSelect so that first condition passes
6. Answer SingleSelect so that second condition passes
7. Tap Back twice to go to the first item (NumberSelect)
8. Change answer so that first condition fails
9. Tap Next
    - **Before:** Text item will appear (error)
    - **After:** Activity will be submitted as there are no more items