### PR TITLE
fix: Use the correct constant for the iOS version number (M2-8843)

### DIFF
--- a/src/jobs/request-interception.ts
+++ b/src/jobs/request-interception.ts
@@ -41,7 +41,7 @@ export default createJob(() => {
       config.headers['OS-Name'] = Platform.OS;
       config.headers['OS-Version'] = Platform.select({
         android: (Platform as PlatformAndroidStatic).constants.Release,
-        ios: (Platform as PlatformIOSStatic).constants.systemName,
+        ios: (Platform as PlatformIOSStatic).constants.osVersion,
         default: Platform.Version.toString(),
       });
       config.headers['App-Version'] = APP_VERSION;


### PR DESCRIPTION
### 📝 Description

🔗 [Jira Ticket M2-8443](https://mindlogger.atlassian.net/browse/M2-8443)

This PR fixes the iOS version being sent to the backend from the mobile app in the `OS-Version` http header.

### 📸 Screenshots

Pay attention to the `os_version` column

| Before (Optional)                      | After                                 |
| -------------------------------------- | ------------------------------------- |
| <img width="521" alt="image" src="https://github.com/user-attachments/assets/92144f75-12e8-4130-bddb-5a276e4cc816" /> | <img width="502" alt="image" src="https://github.com/user-attachments/assets/8ad24676-b882-43a5-ae39-3b59bba303c7" /> |

### 🪤 Peer Testing

1. Build and run the mobile app on an iOS device, and log in
2. Check the `user_device_events_history` table in the database and look for rows with `ios` as the `os_name`
3. Confirm that the `os_version` is the correct version of iOS running on the device, and **not** the string `iOS`

### ✏️ Notes

N/A