### PR TITLE
fix: App freezes on open (M2-9307)

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,15 +27,15 @@
     "android:production": "react-native run-android --mode=productiondebug",
     "android:production-release": "react-native run-android --mode=productionrelease",
     "ios:dev": "react-native run-ios --scheme MindloggerMobileDev",
-    "ios:dev-release": "react-native run-ios --scheme MindloggerMobileDev --configuration Release",
+    "ios:dev-release": "react-native run-ios --scheme MindloggerMobileDev --mode Release",
     "ios:qa": "react-native run-ios --scheme MindloggerMobileQA",
-    "ios:qa-release": "react-native run-ios --scheme MindloggerMobileQA --configuration Release",
+    "ios:qa-release": "react-native run-ios --scheme MindloggerMobileQA --mode Release",
     "ios:staging": "react-native run-ios --scheme MindloggerMobileStaging",
-    "ios:staging-release": "react-native run-ios --scheme MindloggerMobileStaging --configuration Release",
+    "ios:staging-release": "react-native run-ios --scheme MindloggerMobileStaging --mode Release",
     "ios:uat": "react-native run-ios --scheme MindloggerMobileUAT",
-    "ios:uat-release": "react-native run-ios --scheme MindloggerMobileUAT --configuration Release",
+    "ios:uat-release": "react-native run-ios --scheme MindloggerMobileUAT --mode Release",
     "ios:production": "react-native run-ios --scheme MindloggerMobile",
-    "ios:production-release": "react-native run-ios --scheme MindloggerMobile --configuration Release"
+    "ios:production-release": "react-native run-ios --scheme MindloggerMobile --mode Release"
   },
   "dependencies": {
     "@georstat/react-native-image-cache": "^3.1.0",
@@ -192,7 +192,7 @@
     "braces": ">=3.0.3",
     "ws": ">=7.5.10",
     "fast-xml-parser": ">=4.4.1",
-    "ip": ">=1.1.10", 
-    "cross-spawn": "^7.0.5" 
+    "ip": ">=1.1.10",
+    "cross-spawn": "^7.0.5"
   }
 }

--- a/src/entities/defaultBanners/lib/hooks/useRebrandBanner.tsx
+++ b/src/entities/defaultBanners/lib/hooks/useRebrandBanner.tsx
@@ -1,6 +1,6 @@
 import { useEffect } from 'react';
+import { Image, StyleSheet } from 'react-native';
 
-import { Image } from '@tamagui/image';
 import { Trans } from 'react-i18next';
 
 import { useBanners } from '@app/entities/banner/lib/hooks/useBanners';
@@ -45,19 +45,22 @@ export const useRebrandBanner = (
             </Text>
             <>New look, new name, same great product.</>
             {/* TODO: Add link when available
-          https://mindlogger.atlassian.net/browse/M2-9276 */}
+            https://mindlogger.atlassian.net/browse/M2-9276 */}
             {/* Curious?{' '}
-          <Link
-            textDecorationLine="underline"
-            color="#B6DFFE"
-            whiteSpace="nowrap"
-            onPress={() => openUrl('https://mindlogger.org/brand-update')}
-          >
-            Tap to learn more.
-          </Link>*/}
+            <Link
+              textDecorationLine="underline"
+              color="#B6DFFE"
+              whiteSpace="nowrap"
+              onPress={() => openUrl('https://mindlogger.org/brand-update')}
+            >
+              Tap to learn more.
+            </Link>*/}
           </Trans>
         ),
-        icon: <Image src={curiousIcon} width={32} height={30} />,
+        // NOTE: For an unknown reason, we cannot use Tamagui's <Image> here as it causes the app
+        // to display a blank screen and become inoperable, only on release builds. It works fine
+        // in debug builds. So we resort to RN's native <Image>.
+        icon: <Image source={curiousIcon} style={styles.icon} />,
         color: '#FDFCFC',
         backgroundColor: '#0B0907',
         duration: null,
@@ -87,3 +90,10 @@ export const useRebrandBanner = (
     currentRouteName,
   ]);
 };
+
+const styles = StyleSheet.create({
+  icon: {
+    width: 32,
+    height: 30,
+  },
+});


### PR DESCRIPTION

### 📝 Description

🔗 [Jira Ticket M2-9307](https://mindlogger.atlassian.net/browse/M2-9307)

Something about using the Tamagui `<Image>` component in the rebrand banner causes the app to crash/hang on load, both on Android and iOS, but only in production builds. Debug builds are fine.

Since I had to timebox this work, rather than delve into what could be at play, I worked around it by using React Native's native `<Image>` component.

Also updated the iOS production build script commands to use `--mode` instead of the now-obsolete `--configuration`.

### 🪤 Peer Testing

1. Build the app on Android using one of the `android:*-release` scripts (ensure you have the corresponding `.env.*` file defined).
2. Run the app.
    **Expected outcome:** The app should load fine, and display the rebrand banner (if you have never dismissed it).
3. Build the app on iOS using one of the `ios:*-release` scripts (ensure you have the corresponding `.env.*` file defined).

> [!NOTE]
> I was unable to successfully build the app on iOS, I get an enormous and undecipherable stacktrace. I didn't bother investigating and assume it's yet another tedious iOS build configuration issue that I don't have time to investigate today.
    
4. Run the app.
    **Expected outcome:** The app should load fine, and display the rebrand banner (if you have never dismissed it).