### PR TITLE
fix: Fix header backgrounds & top margin on iOS (M2-9329)

### DIFF
--- a/src/app/ui/AppProvider/NavigationProvider.tsx
+++ b/src/app/ui/AppProvider/NavigationProvider.tsx
@@ -23,7 +23,13 @@ import { getDefaultLogger } from '@app/shared/lib/services/loggerInstance';
 
 const LOGGER_MODULE_NAME = 'NavigationProvider';
 
-const SCREEN_BG_COLOR_OVERRIDES: ScreenRoute[] = ['Applets', 'AppletDetails'];
+const SCREEN_BG_COLOR_OVERRIDES: ScreenRoute[] = [
+  'Applets',
+  'AppletDetails',
+  'InProgressActivity',
+  'ActivityPassedScreen',
+  'Autocompletion',
+];
 
 const theme = {
   ...DefaultTheme,

--- a/src/features/pass-survey/ui/ActivityStepper.tsx
+++ b/src/features/pass-survey/ui/ActivityStepper.tsx
@@ -2,16 +2,18 @@ import { useContext, useRef, useState } from 'react';
 import { StyleSheet } from 'react-native';
 
 import { useTranslation } from 'react-i18next';
-import DeviceInfo from 'react-native-device-info';
 import {
   SafeAreaView,
   useSafeAreaInsets,
 } from 'react-native-safe-area-context';
 
 import { useAppletDetailsQuery } from '@app/entities/applet/api/hooks/useAppletDetailsQuery';
+import { bannerActions } from '@app/entities/banner/model/slice';
 import { useActiveAssessmentLink } from '@app/screens/model/hooks/useActiveAssessmentLink';
+import { colors } from '@app/shared/lib/constants/colors';
+import { useAppDispatch } from '@app/shared/lib/hooks/redux';
+import { useOnFocus } from '@app/shared/lib/hooks/useOnFocus';
 import { HourMinute } from '@app/shared/lib/types/dateTime';
-import { isIphoneX } from '@app/shared/lib/utils/common';
 import { ActivityIndicator } from '@app/shared/ui/ActivityIndicator';
 import { Box, XStack } from '@app/shared/ui/base';
 import { Center } from '@app/shared/ui/Center';
@@ -57,17 +59,13 @@ export function ActivityStepper({
   onFinish,
   flowId,
 }: Props) {
+  const dispatch = useAppDispatch();
   const { t } = useTranslation();
 
-  const { bottom: safeAreaBottom, top: safeAreaTop } = useSafeAreaInsets();
-
-  const hasNotch = DeviceInfo.hasNotch();
-  const isNotIPhoneX = !isIphoneX();
+  const { bottom: safeAreaBottom } = useSafeAreaInsets();
 
   const [timerHeight, setTimerHeight] = useState(0);
   const [showTimeLeft, setShowTimeLeft] = useState(!!timer);
-
-  const timerMarginTop = hasNotch ? (safeAreaTop - timerHeight) / 2 : 16;
 
   // This hook handles specific logic for resuming an active assessment when called via the
   // `active-assessment` deep link. It must be called here, within the context of both the
@@ -326,6 +324,11 @@ export function ActivityStepper({
     onFinish('regular');
   };
 
+  useOnFocus(() => {
+    // Match in-progress activity background color
+    dispatch(bannerActions.setBannersBg(colors.white));
+  });
+
   if (!activityStorageRecord) {
     return (
       <Center flex={1}>
@@ -340,13 +343,11 @@ export function ActivityStepper({
 
       {showTimeLeft && (
         <TimeRemaining
-          {...(safeAreaTop ? { position: 'absolute' } : {})}
-          mt={timerMarginTop}
-          left={16}
+          ml={10}
           zIndex={1}
           entityStartedAt={entityStartedAt}
           timerSettings={timer as HourMinute}
-          clockIconShown={isNotIPhoneX}
+          clockIconShown
           opacity={timerHeight ? 1 : 0}
           onTimeElapsed={() => setShowTimeLeft(false)}
           onLayout={e => {
@@ -371,7 +372,7 @@ export function ActivityStepper({
             left: 'off',
             right: 'off',
             bottom: 'maximum',
-            top: 'maximum',
+            top: 'off',
           }}
           mode="margin"
         >

--- a/src/screens/ui/AutocompletionScreen.tsx
+++ b/src/screens/ui/AutocompletionScreen.tsx
@@ -1,12 +1,23 @@
 import { FC } from 'react';
 
+import { bannerActions } from '@app/entities/banner/model/slice';
+import { colors } from '@app/shared/lib/constants/colors';
+import { useAppDispatch } from '@app/shared/lib/hooks/redux';
+import { useOnFocus } from '@app/shared/lib/hooks/useOnFocus';
 import { Box } from '@app/shared/ui/base';
 import { ImageBackground } from '@app/shared/ui/ImageBackground';
 import { AutoCompletion } from '@app/widgets/survey/ui/completion/AutoCompletion';
 
 export const AutocompletionScreen: FC = () => {
+  const dispatch = useAppDispatch();
+
+  useOnFocus(() => {
+    // Match <ImageBackground> raster image top pixel color
+    dispatch(bannerActions.setBannersBg(colors.lightGrey4));
+  });
+
   return (
-    <Box bg="$secondary" flex={1}>
+    <Box bg="$lightGrey4" flex={1}>
       <ImageBackground>
         <Box flex={1} pt={12} pb={34}>
           <AutoCompletion />

--- a/src/screens/ui/InProgressActivityScreen.tsx
+++ b/src/screens/ui/InProgressActivityScreen.tsx
@@ -3,7 +3,11 @@ import { FC, useEffect } from 'react';
 import { NativeStackScreenProps } from '@react-navigation/native-stack';
 
 import { AutocompletionEventOptions } from '@app/abstract/lib/types/autocompletion';
+import { bannerActions } from '@app/entities/banner/model/slice';
 import { useUpcomingNotificationsObserver } from '@app/entities/notification/lib/hooks/useUpcomingNotificationsObserver';
+import { colors } from '@app/shared/lib/constants/colors';
+import { useAppDispatch } from '@app/shared/lib/hooks/redux';
+import { useOnFocus } from '@app/shared/lib/hooks/useOnFocus';
 import { Emitter } from '@app/shared/lib/services/Emitter';
 import { getSupportsMobile } from '@app/shared/lib/utils/responseTypes';
 import { ActivityIndicator } from '@app/shared/ui/ActivityIndicator';
@@ -16,6 +20,7 @@ import { RootStackParamList } from '../config/types';
 type Props = NativeStackScreenProps<RootStackParamList, 'InProgressActivity'>;
 
 export const InProgressActivityScreen: FC<Props> = ({ navigation, route }) => {
+  const dispatch = useAppDispatch();
   const { appletId, eventId, entityId, entityType, targetSubjectId } =
     route.params;
 
@@ -45,8 +50,13 @@ export const InProgressActivityScreen: FC<Props> = ({ navigation, route }) => {
     };
   }, [navigation]);
 
+  useOnFocus(() => {
+    // Match topmost container background color
+    dispatch(bannerActions.setBannersBg(colors.white));
+  });
+
   return (
-    <Box flex={1} backgroundColor="white">
+    <Box flex={1} backgroundColor="$white">
       {isLoading || !isAppSupportedEntity ? (
         <ActivityIndicator />
       ) : (

--- a/src/shared/lib/constants/colors.ts
+++ b/src/shared/lib/constants/colors.ts
@@ -42,6 +42,7 @@ export const colors = {
   lightGrey: '#00000026',
   lightGrey2: '#00000032',
   lightGrey3: '#D2E2EC4D',
+  lightGrey4: '#F3F5F4',
   outlineGrey: '#C2C7CF',
   alert: '#e63232',
   alertLight: '#FFCCCC',

--- a/src/widgets/survey/ui/Finish.tsx
+++ b/src/widgets/survey/ui/Finish.tsx
@@ -7,9 +7,12 @@ import { useQueueProcessing } from '@app/entities/activity/lib/hooks/useQueuePro
 import { useRetryUpload } from '@app/entities/activity/lib/hooks/useRetryUpload';
 import { getDefaultQueueProcessingService } from '@app/entities/activity/lib/services/queueProcessingServiceInstance';
 import { selectAppletsEntityProgressions } from '@app/entities/applet/model/selectors';
+import { bannerActions } from '@app/entities/banner/model/slice';
 import { getDefaultAlertsExtractor } from '@app/features/pass-survey/model/alertsExtractorInstance';
 import { getDefaultScoresExtractor } from '@app/features/pass-survey/model/scoresExtractorInstance';
+import { colors } from '@app/shared/lib/constants/colors';
 import { useAppDispatch, useAppSelector } from '@app/shared/lib/hooks/redux';
+import { useOnFocus } from '@app/shared/lib/hooks/useOnFocus';
 import { getDefaultUploadObservable } from '@app/shared/lib/observables/uploadObservableInstance';
 import { ReduxPersistor } from '@app/shared/lib/redux-state/store';
 import { getDefaultLogger } from '@app/shared/lib/services/loggerInstance';
@@ -168,6 +171,11 @@ export function FinishItem({
     }, 50);
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
+
+  useOnFocus(() => {
+    // Match <ImageBackground> raster image top pixel color
+    dispatch(bannerActions.setBannersBg(colors.lightGrey4));
+  });
 
   if (isRetryAlertOpened) {
     return <ImageBackground />;

--- a/src/widgets/survey/ui/Summary.tsx
+++ b/src/widgets/survey/ui/Summary.tsx
@@ -5,8 +5,12 @@ import { useTranslation } from 'react-i18next';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 
 import { AlertList } from '@app/entities/alert/ui/AlertList';
+import { bannerActions } from '@app/entities/banner/model/slice';
 import { ScoreList } from '@app/entities/score/ui/ScoreList';
 import { StaticNavigationPanel } from '@app/features/pass-survey/ui/StaticNavigationPanel';
+import { colors } from '@app/shared/lib/constants/colors';
+import { useAppDispatch } from '@app/shared/lib/hooks/redux';
+import { useOnFocus } from '@app/shared/lib/hooks/useOnFocus';
 import { Box, YStack } from '@app/shared/ui/base';
 import { ScrollView } from '@app/shared/ui/ScrollView';
 import { Text } from '@app/shared/ui/Text';
@@ -32,6 +36,7 @@ export function Summary({
   targetSubjectId,
   order,
 }: Props) {
+  const dispatch = useAppDispatch();
   const { t } = useTranslation();
   const { bottom } = useSafeAreaInsets();
 
@@ -63,6 +68,11 @@ export function Summary({
       onFinishRef.current();
     }
   }, [initialized, summaryData]);
+
+  useOnFocus(() => {
+    // Match topmost container background color
+    dispatch(bannerActions.setBannersBg(colors.white));
+  });
 
   if (!initialized) {
     return (

--- a/src/widgets/survey/ui/completion/containers.tsx
+++ b/src/widgets/survey/ui/completion/containers.tsx
@@ -2,6 +2,10 @@ import { FC, PropsWithChildren } from 'react';
 
 import { YStack } from '@tamagui/stacks';
 
+import { bannerActions } from '@app/entities/banner/model/slice';
+import { colors } from '@app/shared/lib/constants/colors';
+import { useAppDispatch } from '@app/shared/lib/hooks/redux';
+import { useOnFocus } from '@app/shared/lib/hooks/useOnFocus';
 import { BoxProps } from '@app/shared/ui/base';
 import { ImageBackground } from '@app/shared/ui/ImageBackground';
 
@@ -12,6 +16,13 @@ export type SubComponentProps = {
 };
 
 export const SubScreenContainer: FC<PropsWithChildren> = ({ children }) => {
+  const dispatch = useAppDispatch();
+
+  useOnFocus(() => {
+    // Match <ImageBackground> raster image top pixel color
+    dispatch(bannerActions.setBannersBg(colors.lightGrey4));
+  });
+
   return (
     <ImageBackground>
       <YStack flex={1} px={20} gap={20}>


### PR DESCRIPTION
### 📝 Description

<!-- Contributions are welcome! If there is a corresponding      -->
<!-- JIRA ticket, link to it by replacing `#` with ticket number -->

🔗 [Jira Ticket M2-9329](https://mindlogger.atlassian.net/browse/M2-9329)

The introduction of banners resulted in a layout & background colour issue on the assessment screens, an oversight on my part. There was both too big of a top gap, and the topmost header area behind the iPhone hardware no longer matched the background of the rest of the page. The background mismatch was happening on a handful of other screens during the assessment, including the intermediate answers submission screen during a flow, and the summary screen.

This PR fixes it. It's only relevant to iOS devices, especially iPhone.

### 📸 Screenshots

| Before                      | After                                 |
| -------------------------------------- | ------------------------------------- |
| ![Simulator Screenshot - iPhone 16 Pro - 2025-06-03 at 12 06 41](https://github.com/user-attachments/assets/df5c8e69-2ea8-4b0c-9ff7-e4c86669f694) | ![Simulator Screenshot - iPhone 16 Pro - 2025-06-03 at 12 34 18](https://github.com/user-attachments/assets/aa6e7329-42dc-4f70-90ef-758c3845f416) |

### 🪤 Peer Testing

1. On an iPhone, start an assessment.
    **Expected outcome:** The header area should look like in the "After" picture above.
2. Submit the assessment.
    **Expected outcome:** The answer submission screen's header area should match the background colour below it.
3. Start an activity flow, and submit the first activity.
    **Expected outcome:** The answer submission screen's header area should match the background colour below it.
