### PR TITLE
fix: Displayed content and splash image blinking (M2-9387, M2-9336)

### DIFF
--- a/src/features/pass-survey/ui/ActivityItem.tsx
+++ b/src/features/pass-survey/ui/ActivityItem.tsx
@@ -5,6 +5,7 @@ import React, {
   useCallback,
   useContext,
   useMemo,
+  useRef,
   useState,
 } from 'react';
 
@@ -75,6 +76,7 @@ export function ActivityItem({
   const { appletId, activityId, flowId, targetSubjectId } = useContext(
     ActivityIdentityContext,
   );
+  const textVariableReplacerRef = useRef(textVariableReplacer);
 
   const { assignment } = useActivityAssignment({
     appletId,
@@ -306,7 +308,7 @@ export function ActivityItem({
                 config={pipelineItem.payload}
                 onChange={onResponse}
                 values={value?.answer || null}
-                textReplacer={textVariableReplacer}
+                textReplacer={textVariableReplacerRef.current}
                 tooltipsShown={pipelineItem.payload.addTooltip}
               />
             </Box>
@@ -320,7 +322,7 @@ export function ActivityItem({
                 config={pipelineItem.payload}
                 onChange={onResponse}
                 values={value?.answer || []}
-                textReplacer={textVariableReplacer}
+                textReplacer={textVariableReplacerRef.current}
                 tooltipsShown={pipelineItem.payload.addTooltip}
               />
             </Box>
@@ -334,7 +336,7 @@ export function ActivityItem({
                 config={pipelineItem.payload}
                 onChange={onResponse}
                 values={value?.answer || []}
-                textReplacer={textVariableReplacer}
+                textReplacer={textVariableReplacerRef.current}
               />
             </Box>
           ),
@@ -392,7 +394,7 @@ export function ActivityItem({
                 config={pipelineItem.payload}
                 onChange={handleRadioChange}
                 initialValue={value?.answer}
-                textReplacer={textVariableReplacer}
+                textReplacer={textVariableReplacerRef.current}
               />
             </Box>
           ),
@@ -436,7 +438,7 @@ export function ActivityItem({
               item={pipelineItem}
               onChange={onResponse}
               responseValue={value?.answer}
-              textReplacer={textVariableReplacer}
+              textReplacer={textVariableReplacerRef.current}
               assignment={assignment}
             />
           ),
@@ -459,7 +461,6 @@ export function ActivityItem({
     onResponse,
     pipelineItem,
     processLiveEvent,
-    textVariableReplacer,
     type,
     value?.answer,
   ]);
@@ -475,6 +476,21 @@ export function ActivityItem({
       );
     },
     [noScrollContainer, scrollEnabled],
+  );
+
+  const itemMarkdown = useMemo(
+    () =>
+      !!question && (
+        <ItemMarkdown
+          content={question}
+          assignment={assignment}
+          alignToLeft={alignMessageToLeft}
+          textVariableReplacer={textVariableReplacerRef.current}
+          mx={16}
+          mb={20}
+        />
+      ),
+    [alignMessageToLeft, assignment, question],
   );
 
   return (
@@ -506,16 +522,7 @@ export function ActivityItem({
           }
         }}
       >
-        {question && (
-          <ItemMarkdown
-            content={question}
-            assignment={assignment}
-            alignToLeft={alignMessageToLeft}
-            textVariableReplacer={textVariableReplacer}
-            mx={16}
-            mb={20}
-          />
-        )}
+        {itemMarkdown}
 
         {item}
 

--- a/src/features/pass-survey/ui/ActivityItem.tsx
+++ b/src/features/pass-survey/ui/ActivityItem.tsx
@@ -168,11 +168,7 @@ export function ActivityItem({
       case 'Splash':
         return {
           item: (
-            <Box
-              flex={1}
-              onPressIn={stopScrolling}
-              onPressOut={releaseScrolling}
-            >
+            <Box flex={1}>
               <SplashItem config={pipelineItem.payload} />
             </Box>
           ),


### PR DESCRIPTION
### 📝 Description

🔗 [Jira Ticket M2-9387](https://mindlogger.atlassian.net/browse/M2-9387)
🔗 [Jira Ticket M2-9336](https://mindlogger.atlassian.net/browse/M2-9336)

Implemented by @farmerpaul 

M2-9387
Fixes an issue where displayed content images were blinking/flickering when tapping on the screen in activities. The image should remain static after interaction. It addresses a performance optimization issue where the component was unnecessarily re-rendering, causing the visual flickering effect.

M2-9336
Via @farmerpaul 

> seems to be a relic from copy-paste when splash screens were introduced ... 2 years ago, but didn’t cause rendering issues until we needed to support multi-step item types (when EHR was introduced)


Changes implemented include:
- Optimized ActivityItem component to prevent unnecessary re-renders of displayed content and removed unneeded press event handlers
- Consolidated ItemMarkdown rendering logic to improve stability


### 🪤 Peer Testing

**Requires `yarn install`**

1. Create an applet, activity with displayed content and activity flow with splash screen logo
2. Start activity in mobile app
4. Click on item with displayed content
5. Start activity flow
4. Click on Splash screen image with logo

**Expected outcome:** The displayed content image and splash screen logo should remain static on the screen after tapping, with no blinking or flickering effect.

### ✏️ Notes
