### PR TITLE
fix: Header cropping on Android 14 and below (M2-9402)

### DIFF
--- a/src/entities/banner/ui/Banners.tsx
+++ b/src/entities/banner/ui/Banners.tsx
@@ -9,7 +9,11 @@ import Animated, {
 } from 'react-native-reanimated';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 
-import { IS_ANDROID, IS_IOS } from '@app/shared/lib/constants';
+import {
+  IS_ANDROID,
+  IS_IOS,
+  OS_MAJOR_VERSION,
+} from '@app/shared/lib/constants';
 import { useAppSelector } from '@app/shared/lib/hooks/redux';
 import { BANNERS_DEFAULT_BG } from '@entities/banner/lib/constants.tsx';
 
@@ -52,7 +56,10 @@ export const Banners = () => {
         animatedStyles,
         {
           paddingTop: top,
-          marginBottom: IS_ANDROID ? -top : 0,
+          // There's weird white space on Android 15 and above because of the safe area insets
+          // We can remove this negative bottom margin when this issue is resolved:
+          // https://github.com/react-navigation/react-navigation/issues/12608
+          marginBottom: IS_ANDROID && OS_MAJOR_VERSION >= 15 ? -top : 0,
           zIndex: 1000,
         },
       ]}

--- a/src/screens/ui/InProgressActivityScreen.tsx
+++ b/src/screens/ui/InProgressActivityScreen.tsx
@@ -1,6 +1,7 @@
 import { FC, useEffect } from 'react';
 
 import { NativeStackScreenProps } from '@react-navigation/native-stack';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
 
 import { AutocompletionEventOptions } from '@app/abstract/lib/types/autocompletion';
 import { bannerActions } from '@app/entities/banner/model/slice';
@@ -17,7 +18,6 @@ import { FlowSurvey } from '@app/widgets/survey/ui/FlowSurvey';
 import { IS_ANDROID, OS_MAJOR_VERSION } from '@shared/lib/constants';
 
 import { RootStackParamList } from '../config/types';
-import { useSafeAreaInsets } from 'react-native-safe-area-context';
 
 type Props = NativeStackScreenProps<RootStackParamList, 'InProgressActivity'>;
 

--- a/src/screens/ui/InProgressActivityScreen.tsx
+++ b/src/screens/ui/InProgressActivityScreen.tsx
@@ -14,9 +14,10 @@ import { ActivityIndicator } from '@app/shared/ui/ActivityIndicator';
 import { Box } from '@app/shared/ui/base';
 import { useBaseInfo } from '@app/widgets/activity-group/model/hooks/useBaseInfo';
 import { FlowSurvey } from '@app/widgets/survey/ui/FlowSurvey';
-import { IS_ANDROID } from '@shared/lib/constants';
+import { IS_ANDROID, OS_MAJOR_VERSION } from '@shared/lib/constants';
 
 import { RootStackParamList } from '../config/types';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
 
 type Props = NativeStackScreenProps<RootStackParamList, 'InProgressActivity'>;
 
@@ -56,11 +57,17 @@ export const InProgressActivityScreen: FC<Props> = ({ navigation, route }) => {
     dispatch(bannerActions.setBannersBg(colors.white));
   });
 
+  const { top } = useSafeAreaInsets();
+
   return (
     // There's weird white space on Android because of the safe area insets
     // We can remove this top margin when this issue is resolved:
     // https://github.com/react-navigation/react-navigation/issues/12608
-    <Box flex={1} backgroundColor="$white" marginTop={IS_ANDROID ? 52 : 0}>
+    <Box
+      flex={1}
+      backgroundColor="$white"
+      marginTop={IS_ANDROID && OS_MAJOR_VERSION >= 15 ? top : 0}
+    >
       {isLoading || !isAppSupportedEntity ? (
         <ActivityIndicator />
       ) : (

--- a/src/shared/lib/constants/index.ts
+++ b/src/shared/lib/constants/index.ts
@@ -16,6 +16,8 @@ export const IS_ANDROID_12_OR_HIGHER =
   IS_ANDROID && (Platform.Version as number) >= 31;
 export const IS_ANDROID_13_OR_HIGHER = IS_ANDROID && +getSystemVersion() >= 13;
 
+export const OS_MAJOR_VERSION = parseInt(getSystemVersion(), 10);
+
 export const IS_SMALL_SIZE_SCREEN = VIEWPORT_WIDTH <= 375;
 
 export const IS_TABLET = isTablet();


### PR DESCRIPTION
### 📝 Description

🔗 [Jira Ticket M2-9402](https://mindlogger.atlassian.net/browse/M2-9402)

This PR fixes a bug that hides the header on several screens on Android 14 and below. The bug was introduced due to a workaround for https://github.com/react-navigation/react-navigation/issues/12608 that did not account for the bug only being present on Android 15+.

### 📸 Screenshots

> [!NOTE]
> There should be no change for Android versions 15+

#### Android 14 with banner

| Before                      | After                                 |
| -------------------------------------- | ------------------------------------- |
| <img width="240px" src="https://github.com/user-attachments/assets/0dc27de9-229d-42bd-a7d9-363f0c90ecac"> | <img width="240px" src="https://github.com/user-attachments/assets/0958a611-6dbf-4b02-9672-f942583fcc9a"> |

#### Android 14 without banner

| Before                      | After                                 |
| -------------------------------------- | ------------------------------------- |
| <img width="240px" src="https://github.com/user-attachments/assets/96047bc6-db78-4f27-9673-f9c894f57fee"> | <img width="240px" src="https://github.com/user-attachments/assets/29beb378-a330-48d4-836d-5543030bf8e6"> |

### 🪤 Peer Testing

1. Build and launch the app on an Android 14 device
2. Run through some basic flows and ensure the header remains visible throughout
3. Ensure the header is visible with and without a banner present
4. Repeat the test on Android 15

### ✏️ Notes

N/A