### PR TITLE
fix: React Native Upgrade Bug Fixes (M2-9405) (M2-9409) (M2-9418)

### DIFF
--- a/src/shared/lib/markdown/rules.tsx
+++ b/src/shared/lib/markdown/rules.tsx
@@ -253,21 +253,21 @@ const AlignmentStyles = {
 export const markDownRules: RenderRules = {
   'container_hljs-left': (node, children) => {
     return (
-      <Box key={node.key} style={localStyles.alignLeftContainer} space={20}>
+      <Box key={node.key} style={localStyles.alignLeftContainer} gap={20}>
         {children}
       </Box>
     );
   },
   'container_hljs-center': (node, children) => {
     return (
-      <Box key={node.key} style={localStyles.alignCenterContainer} space={20}>
+      <Box key={node.key} style={localStyles.alignCenterContainer} gap={20}>
         {children}
       </Box>
     );
   },
   'container_hljs-right': (node, children) => {
     return (
-      <Box key={node.key} style={localStyles.alignRightContainer} space={20}>
+      <Box key={node.key} style={localStyles.alignRightContainer} gap={20}>
         {children}
       </Box>
     );

--- a/src/shared/ui/LongTextInput.tsx
+++ b/src/shared/ui/LongTextInput.tsx
@@ -13,6 +13,7 @@ const LongTextInputView = styled(
     alignItems: 'flex-start',
     alignSelf: 'stretch',
     flex: 1,
+    textAlignVertical: 'top',
 
     minHeight: 176,
     maxHeight: isTablet() ? 350 : null,

--- a/src/shared/ui/MarkdownView.tsx
+++ b/src/shared/ui/MarkdownView.tsx
@@ -41,9 +41,11 @@ export const MarkdownView: FC<Props> = ({ content, markdownStyle, rules }) => {
     ...markdownStyle,
     text: {
       fontFamily: fontLanguage === 'el' ? elFont.family : defaultFont.family,
+      ...markdownStyle.text,
+    },
+    body: {
       fontSize: 16,
       lineHeight: 20,
-      ...markdownStyle.text,
     },
     ...(fontLanguage === 'el'
       ? {

--- a/src/widgets/survey/ui/TimeIsUpModal.tsx
+++ b/src/widgets/survey/ui/TimeIsUpModal.tsx
@@ -42,6 +42,9 @@ export function TimeIsUpModal({ onSubmit }: Props) {
                 textProps={{
                   fontSize: 14,
                   fontWeight: 'bold',
+                  width: 70,
+                  paddingHorizontal: 3,
+                  textAlign: 'center',
                 }}
               >
                 {t('autocompletion:ok')}


### PR DESCRIPTION
### 📝 Description

🔗 [Jira Ticket M2-9405](https://mindlogger.atlassian.net/browse/M2-9405)
🔗 [Jira Ticket M2-9409](https://mindlogger.atlassian.net/browse/M2-9409)
🔗 [Jira Ticket M2-9418](https://mindlogger.atlassian.net/browse/M2-9418)

This PR fixes several bugs identified during QA testing of #986. They are:

- M2-9405: [Mobile] Drawing is flashing (draw with finger or apple pencil)
- M2-9409: [Mobile] Markdown heading smaller after upgrading to React Native 0.79
- M2-9418: [Mobile] “Time’s up” pop-up does not display button text after React Native update

It also fixes a vertical align issue with paragraph text items on Android, where the text was center aligned vertically (vs iOS where it is top aligned).

#### Flashing drawing

This was fixed using a suggestion from @farmerpaul to replace the path array state variable with a reanimated shared variable. I refactored the way the canvas keeps track of paths to use a single variable, and I'm surprised it worked with no issues.

I was hesitant to do this refactoring at first because the `MAX_POINTS_PER_LINE` variable (set to 50) seemed intentional. However, I did some digging and was unable to find any reasoning behind it. I tested this on Android versions 13 through 16, as well as iOS 18.3, and it seems to work even for really long paths

#### Markdown headings

I didn't upgrade the `react-native-markdown-display` library as part of #986, so this bug is probably due to the newer react native version itself. Because of the way the markdown tree is laid out, headings contain text nodes. Therefore, style rules defined in the `text` property will seem to "override" rules defined in a more specific property (e.g. `heading1`). However, what's happening is just the rules applying as intended.

I have moved the explicit fontSize and lineHeight rules to the `body` property, as this is probably what we want instead

#### Time's up dialog

The OK button on the time's up dialog was not visible, due to missing explicit style rules. I believe this is due to how newer versions of Tamagui implement text styling. The fix was just adding explicit style rules to the text within the button.

### 📸 Screenshots

#### Flashing drawing

https://github.com/user-attachments/assets/37556d18-f2c5-4ca7-88ea-96c3bbf14bb1

#### Markdown headings

| Before                                                                                                    | After                                                                                                     |
|-----------------------------------------------------------------------------------------------------------|-----------------------------------------------------------------------------------------------------------|
| <img width="240px" src="https://github.com/user-attachments/assets/335ac34a-e7c3-4cc1-868a-e6500d1dab37"> | <img width="240px" src="https://github.com/user-attachments/assets/8c9d15de-f486-4370-8d87-44e58f9ca3b0"> |

#### Time's up dialog

| Before                                                                                                    | After                                                                                                     |
|-----------------------------------------------------------------------------------------------------------|-----------------------------------------------------------------------------------------------------------|
| <img width="240px" src="https://github.com/user-attachments/assets/e7449d17-998f-4da6-8718-9fec19cbfca1"> | <img width="240px" src="https://github.com/user-attachments/assets/b826b560-d8dd-4dc4-8459-db0b27334efd"> |

#### Paragraph item vertical align

| Before                                                                                                    | After                                                                                                     |
|-----------------------------------------------------------------------------------------------------------|-----------------------------------------------------------------------------------------------------------|
| <img width="240px" src="https://github.com/user-attachments/assets/4065b429-27e2-4b94-a7c5-55b484fcd6e9"> | <img width="240px" src="https://github.com/user-attachments/assets/b098c8d5-61f5-4709-a981-d6b55424a7f2"> |

### 🪤 Peer Testing

Here are the markdown headings for your convenience:

```md
# Heading 1

## Heading 2

### Heading 3

#### Heading 4

##### Heading 5

###### Heading 6

Body text
```

1. Create an activity with the following items: paragraph text, drawing, message (with markdown headings)
2. Edit the event for the activity (in the schedules tab) and set a one minute timer (00:01)
3. Build and launch the app on Android (versions 12-16)
4. Complete the activity, and verify each item's functionality as described above
5. Repeat the test on iOS

### ✏️ Notes

N/A
