### PR TITLE
fix: Survey Exit Button Visibility (M2-9412) (M2-9419)

### DIFF
--- a/src/features/pass-survey/ui/Header.tsx
+++ b/src/features/pass-survey/ui/Header.tsx
@@ -45,14 +45,12 @@ export function Header({
             />
           </Box>
         )}
-        <Text fontSize={16} numberOfLines={2} marginRight={100}>
+        <Text fontSize={16} numberOfLines={2} flex={1} mr={10}>
           {activityName}
         </Text>
-        <XStack ml="auto">
-          <BackButton accessibilityLabel="close-button">
-            <Text color={colors.blue3}>{t('activity_navigation:exit')}</Text>
-          </BackButton>
-        </XStack>
+        <BackButton aria-label="close-button">
+          <Text color={colors.blue3}>{t('activity_navigation:exit')}</Text>
+        </BackButton>
       </XStack>
       <HeaderProgress
         appletId={appletId}


### PR DESCRIPTION
### 📝 Description

🔗 [Jira Ticket M2-9412](https://mindlogger.atlassian.net/browse/M2-9412)
🔗 [Jira Ticket M2-9419](https://mindlogger.atlassian.net/browse/M2-9419)

This PR makes a slight change to the way the survey header is laid out to make room for all the elements. Specifically, when an applet has a watermark and/or a long title, it tends to push the exit button off screen. This change fixes that.

### 📸 Screenshots

| Before                      | After                                 |
| -------------------------------------- | ------------------------------------- |
| <img width="240px" alt="image" src="https://github.com/user-attachments/assets/d760a3e3-4675-431b-8200-45e5f502076d" /> | <img width="240px" src="https://github.com/user-attachments/assets/4c9540d9-d672-4226-bc66-16571fa70e95"> |
| <img width="240px" alt="image" src="https://github.com/user-attachments/assets/1e0b1df0-708d-4e12-adfd-08751919606d" /> | <img width="240px" src="https://github.com/user-attachments/assets/93098fbf-8309-4ba2-8779-a2b2054d09fe"> |


### 🪤 Peer Testing

1. Create an applet with a watermark image
2. Create an activity with a long name
3. Build and run the app on iOS using the iPhone 13
4. Complete the activity and confirm the exit button remains visible
5. Repeat for Android with a device of similar width

### ✏️ Notes

N/A
