### PR TITLE
feat: Handle `/ehr-complete` deep link path (M2-9433)

### DIFF
--- a/src/app/ui/AppProvider/NavigationProvider.tsx
+++ b/src/app/ui/AppProvider/NavigationProvider.tsx
@@ -53,7 +53,11 @@ const getLinking = ():
   return {
     prefixes: DEEP_LINK_PREFIXES,
     getStateFromPath: (path, options) => {
-      if (path.startsWith('/active-assessment')) {
+      // `/ehr-complete` is intentionally excluded from the AndroidManifest.xml, as it is meant to be handled on iOS only
+      if (
+        path.startsWith('/active-assessment') ||
+        path.startsWith('/ehr-complete')
+      ) {
         getDefaultLogger().info(
           `[${LOGGER_MODULE_NAME}] Found active assessment deep link, opening in app`,
         );

--- a/src/app/ui/AppProvider/NavigationProvider.tsx
+++ b/src/app/ui/AppProvider/NavigationProvider.tsx
@@ -79,6 +79,12 @@ const getLinking = ():
           };
 
           return state as unknown as PartialState<NavigationState>;
+        } else {
+          // Do nothing to prevent an infinite loop between the web browser and app
+          getDefaultLogger().warn(
+            `[${LOGGER_MODULE_NAME}] No initial navigation state found for active assessment deep link, refusing to handle deep link.`,
+          );
+          return undefined;
         }
       }
 


### PR DESCRIPTION
### 📝 Description

🔗 [Jira Ticket M2-9433](https://mindlogger.atlassian.net/browse/M2-9433)

This PR makes two changes to the mobile app deep link behaviour:
1. The path `/ehr-complete` is now handled on iOS and triggers the same behaviour that the `/active-assessment` link does
2. The logic that handles those deep link paths has been patched to prevent an infinite loop when the app is opened by one of them, but there is no in-progress assessment.

### 📸 Screenshots

Here's a video of the `/ehr-complete` deep linking handling on iOS taken from https://github.com/ChildMindInstitute/mindlogger-web-refactor/pull/640:

https://github.com/user-attachments/assets/a42d10a2-7c49-4b6a-802f-03a900523887

And now here's Android:

https://github.com/user-attachments/assets/09f2cb0e-52a5-4bc0-81dc-e7b1684531d4

### 🪤 Peer Testing

1. Edit the `ios/MindloggerMobileDevDebug.entitlements` file to add two entries for the `pr-640.d15zn9do8xbzga.amplifyapp.com` domain
2. Edit the `.env.dev` file and append `,https://pr-640.d15zn9do8xbzga.amplifyapp.com` to the `DEEP_LINK_PREFIXES` environment variable
3. Build and run the app on iOS, then sign in
4. Run this command at the terminal `npx uri-scheme open https://pr-640.d15zn9do8xbzga.amplifyapp.com/ehr-complete --ios`
5. Confirm that it opens the app to the applets screen
6. Edit the `android/app/build.gradle` file to change the dev secondary domain from `web-dev.cmiml.net` to `pr-640.d15zn9do8xbzga.amplifyapp.com`
7. Build and run the app on Android, then sign in
8. Run this command at the terminal `npx uri-scheme open https://pr-640.d15zn9do8xbzga.amplifyapp.com/ehr-complete --android`
9. Confirm that it opens the web browser
10. As a sanity check, run `npx uri-scheme open https://pr-640.d15zn9do8xbzga.amplifyapp.com/password-recovery --android` to convince yourself that deep links are working. Confirm that it opens the mobile app

### ✏️ Notes

I considered including the `/ehr-complete` deep link path for Android as well, as a form of future-proofing for when Android supports opening the app from client side redirection as iOS currently does. I ultimately decided not to pursue this, as I don't like premature optimization with a code path that we can't currently test, and the situation may be different by the time such supports is available in Android. I'm willing to have my mind changed, though
