### PR TITLE
fix: Accept only alphanumeric characters in search (M2-9267)

### DIFF
--- a/src/shared/ui/survey/RequestHealthRecordDataItem/OneUpHealthStep.tsx
+++ b/src/shared/ui/survey/RequestHealthRecordDataItem/OneUpHealthStep.tsx
@@ -63,6 +63,13 @@ export const OneUpHealthStep: FC = () => {
     error: _error,
   } = useOneUpHealthSystemSearchApi({ appletId, submitId, activityId });
 
+  const handleChangeText = (text: string) => {
+    // Filter out symbols, as the 1UpHealth API fails to handle them properly.
+    // This mimics the 1UpHealth proprietary iframe behaviour.
+    const filteredText = text.replace(/[^a-zA-Z0-9 ]/g, '');
+    setSearchQuery(filteredText);
+  };
+
   const handleSearch = (query = searchQuery) => {
     setSearchQuery(query);
     search(query);
@@ -102,8 +109,9 @@ export const OneUpHealthStep: FC = () => {
             >
               <Box position="relative" flex={1}>
                 <Input
+                  aria-label="health-system-search-input"
                   value={searchQuery}
-                  onChangeText={setSearchQuery}
+                  onChangeText={handleChangeText}
                   onSubmitEditing={() => handleSearch()}
                   blurOnSubmit={false}
                   returnKeyType="search"
@@ -115,6 +123,7 @@ export const OneUpHealthStep: FC = () => {
                 />
                 {searchQuery && (
                   <Box
+                    aria-label="health-system-search-clear-button"
                     position="absolute"
                     right="$1"
                     top="50%"
@@ -131,7 +140,11 @@ export const OneUpHealthStep: FC = () => {
                   </Box>
                 )}
               </Box>
-              <SubmitButton onPress={() => handleSearch()} mode="tonal">
+              <SubmitButton
+                aria-label="health-system-search-button"
+                onPress={() => handleSearch()}
+                mode="tonal"
+              >
                 {t('requestHealthRecordData:search')}
               </SubmitButton>
             </XStack>


### PR DESCRIPTION
### 📝 Description

<!-- Contributions are welcome! If there is a corresponding      -->
<!-- JIRA ticket, link to it by replacing `#` with ticket number -->

🔗 [Jira Ticket M2-9267](https://mindlogger.atlassian.net/browse/M2-9267)

This change prevents users from entering symbols in the EHR health system search field, mimicking the behaviour of the Web App iframe. Symbols are not handled properly by the 1UpHealth search API.

### 🪤 Peer Testing

1. Start an activity containing an EHR item type
2. Consent to sharing EHRs and proceed to the health system search screen.
3. Try to enter "20/20" into the search field, or another string containing symbols.
    **Expected outcome:** The symbols is excluded from the input – only letters, digits and spaces are allowed.