### PR TITLE
fix: Rebrand regressions (M2-9438, M2-9440)

### DIFF
--- a/src/screens/config/theme.tsx
+++ b/src/screens/config/theme.tsx
@@ -6,6 +6,7 @@ import { NativeStackNavigationOptions } from '@react-navigation/native-stack';
 
 import { IS_TABLET } from '@app/shared/lib/constants';
 import { palette } from '@app/shared/lib/constants/palette';
+import { BackButton } from '@app/shared/ui/BackButton';
 import { CloseIcon } from '@app/shared/ui/icons';
 import { AboutIcon } from '@app/shared/ui/icons/About';
 import { DataIcon } from '@app/shared/ui/icons/Data';
@@ -13,18 +14,12 @@ import { SurveyIcon } from '@app/shared/ui/icons/Survey';
 import { Text } from '@app/shared/ui/Text';
 import { DEFAULT_BG } from '@entities/banner/lib/constants.tsx';
 
-import { AppletDetailsParamList, RootStackNavigationProps } from './types';
+import { AppletDetailsParamList } from './types';
 import { HeaderTitle } from '../ui/HeaderTitle';
-
-type ScreenOptions = {
-  navigation: RootStackNavigationProps;
-};
 
 type BottomScreenOptions = BottomTabScreenProps<AppletDetailsParamList>;
 
-export const getScreenOptions = ({
-  navigation,
-}: ScreenOptions): NativeStackNavigationOptions => {
+export const getScreenOptions = (): NativeStackNavigationOptions => {
   return {
     headerStyle: {
       backgroundColor: DEFAULT_BG,
@@ -34,9 +29,9 @@ export const getScreenOptions = ({
     headerTitleAlign: 'center',
     headerBackVisible: false,
     headerLeft: () => (
-      <Text aria-label="close-button" onPress={navigation.goBack} p={12}>
+      <BackButton aria-label="close-button" p={12}>
         <CloseIcon color={palette.on_surface} size={20} />
-      </Text>
+      </BackButton>
     ),
   };
 };

--- a/src/shared/ui/BackButton.tsx
+++ b/src/shared/ui/BackButton.tsx
@@ -37,7 +37,9 @@ export function BackButton<TRouteName extends keyof RootParamList>(
 
   return (
     <Box {...styledProps}>
-      <TouchableOpacity onPress={back}>{children}</TouchableOpacity>
+      <TouchableOpacity onPress={back} hitSlop={40}>
+        {children}
+      </TouchableOpacity>
     </Box>
   );
 }

--- a/src/shared/ui/icons/index.tsx
+++ b/src/shared/ui/icons/index.tsx
@@ -43,10 +43,6 @@ export const ChevronRightIcon: FC<IconProps> = props => (
   <FontAwesome6 name="angle-right" iconStyle="solid" {...props} />
 );
 
-export const QuestionTooltipIcon: FC<IconProps> = props => (
-  <FontAwesome6 name="circle-question" iconStyle="solid" {...props} />
-);
-
 export const LeftArrowIcon: FC<IconProps> = props => (
   <FontAwesome6 name="arrow-left" iconStyle="solid" {...props} />
 );

--- a/src/shared/ui/survey/CheckBox/CheckBox.item.tsx
+++ b/src/shared/ui/survey/CheckBox/CheckBox.item.tsx
@@ -2,21 +2,15 @@ import { FC, useMemo } from 'react';
 import { Platform, StyleSheet } from 'react-native';
 
 import { CachedImage } from '@georstat/react-native-image-cache';
-import { styled } from '@tamagui/core';
 import { XStack } from '@tamagui/stacks';
 
 import { getSelectorColors } from '@app/shared/lib/utils/survey/survey';
 
 import { Item } from './types';
 import { CheckBox } from '../../CheckBox';
-import { QuestionTooltipIcon } from '../../icons';
+import { QuestionIcon } from '../../icons/QuestionIcon';
 import { Text } from '../../Text';
 import { Tooltip } from '../../Tooltip';
-
-const CheckboxTooltipContainer = styled(XStack, {
-  marginRight: 10,
-  width: '8%',
-});
 
 type Props = {
   setPalette: boolean;
@@ -65,7 +59,7 @@ export const CheckBoxItem: FC<Props> = ({
       my={8}
       gap={10}
       ai="center"
-      jc="center"
+      jc="space-between"
       br={12}
       borderWidth={2}
       borderColor={borderColor}
@@ -105,24 +99,17 @@ export const CheckBoxItem: FC<Props> = ({
         </XStack>
       )}
 
-      <Text
-        aria-label="option_text"
-        color={textColor}
-        fontSize={18}
-        flexGrow={1}
-      >
+      <Text aria-label="option_text" color={textColor} fontSize={18} flex={1}>
         {name}
       </Text>
 
       {tooltipAvailable && tooltipContainerVisible && !!tooltip && (
-        <CheckboxTooltipContainer>
-          <Tooltip
-            markdown={tooltipText}
-            aria-label={`checkbox-tooltip-view-${tooltipText}`}
-          >
-            <QuestionTooltipIcon color={tooltipColor} size={25} />
-          </Tooltip>
-        </CheckboxTooltipContainer>
+        <Tooltip
+          markdown={tooltipText}
+          aria-label={`checkbox-tooltip-view-${tooltipText}`}
+        >
+          <QuestionIcon color={tooltipColor} />
+        </Tooltip>
       )}
     </XStack>
   );

--- a/src/shared/ui/survey/RadioActivityItem/RadioItem.tsx
+++ b/src/shared/ui/survey/RadioActivityItem/RadioItem.tsx
@@ -7,7 +7,7 @@ import { getSelectorColors } from '@app/shared/lib/utils/survey/survey';
 
 import { RadioOption } from './types';
 import { Box, RadioGroup, XStack } from '../../base';
-import { QuestionTooltipIcon } from '../../icons';
+import { QuestionIcon } from '../../icons/QuestionIcon';
 import { Text } from '../../Text';
 import { Tooltip } from '../../Tooltip';
 
@@ -55,9 +55,8 @@ export const RadioItem: FC<RadioLabelProps & AccessibilityProps> = ({
       p={16}
       my={8}
       gap={10}
-      jc="center"
+      jc="space-between"
       ai="center"
-      ac="center"
       borderRadius={12}
       borderWidth={2}
       borderColor={borderColor}
@@ -89,7 +88,7 @@ export const RadioItem: FC<RadioLabelProps & AccessibilityProps> = ({
         aria-label={'radio-option-text'}
         fontSize={18}
         color={textColor}
-        flexGrow={1}
+        flex={1}
       >
         {name}
       </Text>
@@ -99,7 +98,7 @@ export const RadioItem: FC<RadioLabelProps & AccessibilityProps> = ({
           aria-label={'tooltip_view-' + tooltipText}
           markdown={tooltipText}
         >
-          <QuestionTooltipIcon color={tooltipColor} size={22} />
+          <QuestionIcon color={tooltipColor} />
         </Tooltip>
       )}
     </XStack>


### PR DESCRIPTION
### 📝 Description

<!-- Contributions are welcome! If there is a corresponding      -->
<!-- JIRA ticket, link to it by replacing `#` with ticket number -->

🔗 [Jira Ticket M2-9438](https://mindlogger.atlassian.net/browse/M2-9438)
🔗 [Jira Ticket M2-9440](https://mindlogger.atlassian.net/browse/M2-9440)

Fixes layout of single selection and multiple selection item types when the option label is really long and wraps to the next line.

### 📸 Screenshots

| Before                      | After                                 |
| -------------------------------------- | ------------------------------------- |
| ![Simulator Screenshot - iPhone 16 Pro - 2025-06-24 at 16 49 06](https://github.com/user-attachments/assets/acbb3c30-7d5c-43d0-b95e-edadf337d1aa) | ![Simulator Screenshot - iPhone 16 Pro - 2025-06-24 at 16 47 52](https://github.com/user-attachments/assets/29ba9c75-b505-446b-b0d5-f4b4ede56a64) |
| ![Simulator Screenshot - iPhone 16 Pro - 2025-06-24 at 16 49 11](https://github.com/user-attachments/assets/55b71db5-abc4-4a48-9075-addf02fccb55) | ![Simulator Screenshot - iPhone 16 Pro - 2025-06-24 at 16 46 49](https://github.com/user-attachments/assets/38bd3579-c98c-478d-98ad-6cdd11a195a1) |

### 🪤 Peer Testing

Test activities containing single selection/multiple selection items with long text labels (> 75 characters). Try different options like enabling tooltips or adding images. Text should wrap correctly with no overlapping, and preserve container padding.