### PR TITLE
[HOTFIX] fix: Alerts background color

### DIFF
--- a/src/entities/alert/ui/AlertList.tsx
+++ b/src/entities/alert/ui/AlertList.tsx
@@ -17,7 +17,7 @@ export function AlertList({ alerts }: Props) {
   }
 
   return (
-    <Box bg="$surface1" br={10} p={20} mb={20} aria-label="alerts-group">
+    <Box bg="$error_container" br={10} p={20} mb={20} aria-label="alerts-group">
       <Text fontWeight="700" fontSize={22} lineHeight={28} mb={10}>
         {t('activity_summary:alerts')}
       </Text>


### PR DESCRIPTION
### 📝 Description

Hotfix for updating the background colour of the alerts container to `error_container` on the Report Summary screen.

### 📸 Screenshots

| Before                       | After                                 |
| -------------------------------------- | ------------------------------------- |
| ![Simulator Screenshot - iPhone 16 Pro - 2025-06-26 at 08 53 23](https://github.com/user-attachments/assets/32b137e4-a3e7-468d-b305-aa51b2b9c3f1) | ![Simulator Screenshot - iPhone 16 Pro - 2025-06-26 at 08 52 12](https://github.com/user-attachments/assets/189f5938-8dc5-4e83-bac1-6e40050cf42b) |
