### PR TITLE
fix: Remove createdAt filtering from existence check (M2-9658)

### DIFF
--- a/src/entities/activity/lib/services/AnswersUploadService.ts
+++ b/src/entities/activity/lib/services/AnswersUploadService.ts
@@ -24,14 +24,14 @@ import {
 import { isLocalFileUrl } from '@app/shared/lib/utils/file';
 import { MediaFile } from '@app/shared/ui/survey/MediaItems/types';
 import { IAnswersUploadService } from '@entities/activity/lib/services/IAnswersUploadService';
-
-import { IMediaFilesCleaner } from './IMediaFilesCleaner';
 import {
   CheckAnswersInput,
   CheckFilesUploadResults,
   CheckFileUploadResult,
   SendAnswersInput,
-} from '../types/uploadAnswers';
+} from '@entities/activity/lib/types/uploadAnswers';
+
+import { IMediaFilesCleaner } from './IMediaFilesCleaner';
 
 export class AnswersUploadService implements IAnswersUploadService {
   private createdAt: number | null;
@@ -97,7 +97,6 @@ export class AnswersUploadService implements IAnswersUploadService {
     const response = await this.answerService.checkIfAnswersExist({
       activityId: checkInput.activityId,
       appletId: checkInput.appletId,
-      createdAt: checkInput.createdAt,
       submitId: checkInput.submitId,
     });
 
@@ -321,14 +320,12 @@ export class AnswersUploadService implements IAnswersUploadService {
     let uploaded: boolean;
 
     try {
-      const { activityId, appletId, flowId, createdAt, submitId } =
-        encryptedData;
+      const { activityId, appletId, flowId, submitId } = encryptedData;
 
       uploaded = await this.checkIfAnswersUploaded({
         activityId,
         appletId,
         flowId,
-        createdAt,
         submitId,
       });
     } catch (error) {
@@ -361,7 +358,6 @@ export class AnswersUploadService implements IAnswersUploadService {
         activityId: encryptedData.activityId,
         appletId: encryptedData.appletId,
         flowId: encryptedData.flowId,
-        createdAt: encryptedData.createdAt,
         submitId: encryptedData.submitId,
       });
     } catch (error) {

--- a/src/entities/activity/lib/services/tests/AnswersUploadService.test.ts
+++ b/src/entities/activity/lib/services/tests/AnswersUploadService.test.ts
@@ -349,7 +349,6 @@ describe('AnswersUploadService', () => {
       activityId: 'activity123',
       appletId: 'applet123',
       flowId: 'flow123',
-      createdAt: 1234567890,
     } as ActivityAnswersRequest;
 
     const mockCheckIfAnswersUploaded = jest.fn().mockResolvedValueOnce(false);
@@ -372,7 +371,6 @@ describe('AnswersUploadService', () => {
       activityId: 'activity123',
       appletId: 'applet123',
       flowId: 'flow123',
-      createdAt: 1234567890,
     });
     expect(mockSendActivityAnswers).toHaveBeenCalledWith(encryptedData);
   });
@@ -382,7 +380,6 @@ describe('AnswersUploadService', () => {
       activityId: 'activity123',
       appletId: 'applet123',
       flowId: 'flow123',
-      createdAt: 1234567890,
     } as ActivityAnswersRequest;
 
     const mockCheckIfAnswersUploaded = jest.fn().mockResolvedValueOnce(false);
@@ -404,7 +401,6 @@ describe('AnswersUploadService', () => {
       activityId: 'activity123',
       appletId: 'applet123',
       flowId: 'flow123',
-      createdAt: 1234567890,
     });
 
     expect(mockSendActivityAnswers).toHaveBeenCalledWith(encryptedData);
@@ -415,7 +411,6 @@ describe('AnswersUploadService', () => {
       activityId: 'activity123',
       appletId: 'applet123',
       flowId: 'flow123',
-      createdAt: 1234567890,
     } as ActivityAnswersRequest;
 
     const mockCheckIfAnswersUploaded = jest.fn().mockResolvedValueOnce(true);
@@ -434,7 +429,6 @@ describe('AnswersUploadService', () => {
       activityId: 'activity123',
       appletId: 'applet123',
       flowId: 'flow123',
-      createdAt: 1234567890,
     });
     expect(mockSendActivityAnswers).not.toHaveBeenCalled();
   });

--- a/src/entities/activity/lib/types/uploadAnswers.ts
+++ b/src/entities/activity/lib/types/uploadAnswers.ts
@@ -49,7 +49,6 @@ export type CheckFilesUploadResults = Array<CheckFileUploadResult>;
 
 export type CheckAnswersInput = {
   appletId: string;
-  createdAt: number;
   activityId: string;
   flowId: string | null;
   submitId: string;

--- a/src/shared/api/services/IAnswerService.ts
+++ b/src/shared/api/services/IAnswerService.ts
@@ -209,7 +209,6 @@ export type ActivityAnswersResponse = SuccessfulEmptyResponse;
 
 export type CheckIfAnswersExistRequest = {
   appletId: string;
-  createdAt: number;
   activityId: string;
   submitId: string;
 };


### PR DESCRIPTION
- [X] Tests for the changes have been added

### 📝 Description

🔗 [Jira Ticket M2-9658](https://mindlogger.atlassian.net/browse/M2-9658)

This PR builds on top of the work done in the matching [BE PR](https://github.com/ChildMindInstitute/mindlogger-backend-refactor/pull/1931) by removing the requirement of a `createdAt` parameter from the answers existence check endpoint. This gets rid of the issue on local dev environments where mobile apps were unable to submit answers successfully.

After the BE PR is merged, this can be merged as well.

### 🪤 Peer Testing

If the BE PR hasn't been merged, point local BE to the `fix/M2-9658-remove-created-at-filtering` branch.

Attempt any activity submissions. They should fulfill successfully.
