### PR TITLE
feat(M2-8781): add Portuguese language support to mobile app

### DIFF
--- a/assets/translations/el.json
+++ b/assets/translations/el.json
@@ -239,7 +239,8 @@
     "en": "English",
     "fr": "Français",
     "el": "Ελληνικά",
-    "es": "Español"
+    "es": "Español",
+    "pt": "Português"
   },
   "application_logs_screen": {
     "upload_button": "Μεταφόρτωση αρχείων καταγραφής",

--- a/assets/translations/en.json
+++ b/assets/translations/en.json
@@ -239,7 +239,8 @@
     "en": "English",
     "fr": "Français",
     "el": "Ελληνικά",
-    "es": "Español"
+    "es": "Español",
+    "pt": "Português"
   },
   "application_logs_screen": {
     "upload_button": "Upload logs",

--- a/assets/translations/es.json
+++ b/assets/translations/es.json
@@ -239,7 +239,8 @@
     "en": "English",
     "fr": "Français",
     "el": "Ελληνικά",
-    "es": "Español"
+    "es": "Español",
+    "pt": "Português"
   },
   "application_logs_screen": {
     "upload_button": "Cargar registros",

--- a/assets/translations/fr.json
+++ b/assets/translations/fr.json
@@ -416,7 +416,8 @@
     "en": "English",
     "fr": "Français",
     "el": "Ελληνικά",
-    "es": "Español"
+    "es": "Español",
+    "pt": "Português"
   },
   "application_logs_screen": {
     "upload_button": "Télécharger les journaux",

--- a/assets/translations/pt-br.json
+++ b/assets/translations/pt-br.json
@@ -1,0 +1,526 @@
+{
+  "auth": {
+    "email": "E-mail",
+    "email_address": "Endereço de e-mail",
+    "password": "Senha",
+    "i_agree": "Eu concordo com os",
+    "terms_of_service": "Termos de Serviço",
+    "terms": "Termos",
+    "privacy": "Privacidade",
+    "privacy_policy": "Política de privacidade",
+    "password_updated": "Senha atualizada"
+  },
+  "activity": {
+    "completeOnWeb": "Preencha o formulário no aplicativo web do Curious",
+    "incorrect_answer": "Resposta incorreta. Tente novamente",
+    "failed": "Falha",
+    "flanker_accuracy_warn": "*Os registros de data e hora coletados em um dispositivo Android não são tão precisos quanto os dos dispositivos iOS.",
+    "please_wait": "Aguarde",
+    "activity_all_items_hidden": "Não foi possível iniciar \"{{entityName}} \" porque todos os itens dentro da atividade estão ocultos",
+    "flow_all_items_hidden": "Não foi possível iniciar \"{{entityName}} \" porque contém uma atividade na qual todos os itens estão ocultos",
+    "progress": {
+      "upload_files": "Carregando seus arquivos...",
+      "encrypt_answers": "Criptografando suas respostas...",
+      "upload_answers": "Carregando suas respostas...",
+      "completed": "Atividade carregada"
+    },
+    "step": "Etapa",
+    "flowStep": "({{activityPositionInFlow}} de {{numberOfActivitiesInFlow}}) {{activityFlowName}}",
+    "stepCounter": "{{currentStep}} de {{totalSteps}}",
+    "activityCounter": "Atividade {{currentStep}} de {{totalSteps}}"
+  },
+  "activity_time": {
+    "time_remaining": "restante(s) para este item"
+  },
+  "timed_activity": {
+    "time_to_complete": "Tempo para conclusão",
+    "time_to_complete_hm": "Tempo para conclusão: {{hours}} horas e {{minutes}} minutos",
+    "hours": "horas"
+  },
+  "activity_summary": {
+    "terms_text": "Entendo que as informações fornecidas por este questionário não se destinam a substituir a orientação, o diagnóstico ou o tratamento oferecido por um médico ou profissional de saúde mental, e que minhas respostas anônimas podem ser usadas e compartilhadas para pesquisas gerais sobre saúde mental infantil.",
+    "footer_text": "O CHILD MIND INSTITUTE, INC. E O CHILD MIND MEDICAL PRACTICE, PLLC (JUNTOS DENOMINADOS \"CMI\") NÃO PRATICAM, DIRETA OU INDIRETAMENTE, A MEDICINA OU FORNECEM ACONSELHAMENTO MÉDICO COMO PARTE DESTE QUESTIONÁRIO. O CMI NÃO ASSUME NENHUMA RESPONSABILIDADE POR QUALQUER DIAGNÓSTICO, TRATAMENTO, DECISÃO OU AÇÃO TOMADA COM BASE NAS INFORMAÇÕES FORNECIDAS POR ESTE QUESTIONÁRIO E NÃO ASSUME NENHUMA RESPONSABILIDADE PELO USO DESTE QUESTIONÁRIO.",
+    "score_on_subscale": "The score on the {{name}} subscale was",
+    "save": "Salvar",
+    "summary": "Resumo",
+    "alerts": "Alertas",
+    "report_summary": "Resumo do relatório",
+    "not_yet_completed": "Ainda não concluído",
+    "last_completed": "Last completed",
+    "unscheduled": "Unscheduled",
+    "due": "Due",
+    "scheduled_for": "Scheduled for",
+    "category_suicide": "Suicide",
+    "category_suicide_message": "Critical Level: Parent indicated possible bullying. Bring to immediate attention of clinician due to potential emergency situation.",
+    "category_emotional": "Emotional",
+    "category_emotional_message": "Within normal limits: No further screening or assessment required.",
+    "category_sport": "Sport",
+    "category_sport_message": "Clinical Range: Make clinician aware; Perform follow up assessment (Recommended); Generate referral.",
+    "share_report": "Compartilhar relatório",
+    "share_all_reports": "Share All Reports"
+  },
+  "activity_chart": {
+    "title": "Faça a avaliação para que os dados sejam exibidos.",
+    "monday": "S",
+    "tuesday": "T",
+    "wednesday": "Q",
+    "thursday": "Q",
+    "friday": "S",
+    "saturday": "S",
+    "sunday": "D"
+  },
+  "calendar": {
+    "months": "Janeiro_Fevereiro_Março_Abril_Maio_Junho_Julho_Agosto_Setembro_Outubro_Novembro_Dezembro",
+    "weekdays": "Dom_Seg_Ter_Qua_Qui_Sex_Sáb",
+    "x_days": "S_T_Q_Q_S_S_D"
+  },
+  "applet_data": {
+    "title": "Faça a avaliação para que os dados sejam exibidos."
+  },
+  "widget_error": {
+    "error_text": "Ocorreu um problema ao carregar esta tela.",
+    "error_description": "Verifique se a versão mais recente do Curious está instalada e entre em contato com o administrador da atividade se o problema persistir."
+  },
+  "about": {
+    "about": "Sobre",
+    "applets_title": "Saiba mais sobre cada um de seus applets e sobre a plataforma Curious.",
+    "data_title": "Saiba mais sobre a plataforma de coleta de dados Curious clicando em \"Sobre o\nCurious\" a seguir.",
+    "about_curious": "Sobre o Curious",
+    "icons_title": "Os ícones do NounProject foram criados por Alina Oleynik (pesquisa), Beth Bolton (livro) e\nShakeel (gráfico)",
+    "device_id": "ID do dispositivo"
+  },
+  "about_app": {
+    "title_with_version": "O que é o Curious? v.{{version}}",
+    "title": "A menos que indicado em outro lugar, os ícones são extraídos do OpenMoji e do NounProject.",
+    "subtitle": "A menos que indicado em outro lugar, os ícones são extraídos do OpenMoji e do NounProject.",
+    "curious_about": "## \n ### O que é o Curious? \n\n Esse aplicativo faz parte da plataforma de código aberto de coleta e análise de dados Curious, projetada pelo MATTER Lab no Child Mind Institute ([https://matter.childmind.org](https://matter.childmind.org)). \n # \n ### O que o Curious pode fazer? \n\n O conjunto de recursos do Curious está crescendo e atualmente aceita uma ampla variedade de tipos de entrada. Cada tela em uma atividade do Curious pode incluir qualquer um dos seguintes itens: \n  - Texto, imagem e áudio \n  - Pergunta seguida de opções de resposta em imagem e/ou texto \n  - Barra deslizante \n  - Entrada de texto \n  - Entrada em uma tabela \n  - Gravação de áudio \n  - Captura de foto/vídeo \n  - Desenhar ou tocar \n  - Geolocalização atual \n  - Tarefa cognitiva simples \n  - Atraso antes da resposta \n  - Temporizador \n  - Lógica condicional para determinar o próximo passo \n\n #### Onde posso obter mais informações? \n Acesse [https://mindlogger.org](https://mindlogger.org) para obter mais informações.  \n ## [Suporte]({{credits_link}} ) \n ## [Termos de serviço](https://mindlogger.org/terms-of-service) \n ## [Política de privacidade](https://mindlogger.org/privacy-policy) \n\n ##### Abraços, \n\n ##### Equipe do Curious \n\n ##### Child Mind Institute"
+  },
+  "applet_footer": {
+    "surveys": "Pesquisas",
+    "data": "Dados",
+    "about": "Sobre",
+    "activities": "Atividades",
+    "activity": "Atividade"
+  },
+  "applet_invite_flow": {
+    "back": "Voltar",
+    "next": "Avançar"
+  },
+  "live_connection": {
+    "disconnect": "DESCONECTAR",
+    "connect": "ENVIAR",
+    "connect_to_server": "Conectar ao servidor",
+    "remember": "Lembrar",
+    "ip": "Endereço IP",
+    "port": "Porta",
+    "connection_closed": "A conexão TCP foi encerrada",
+    "connection_error": "Falha na conexão. Verifique novamente o IP e a porta",
+    "connection_set_error": "Não é possível estabelecer a conexão",
+    "live_connection": "Conexão em tempo real",
+    "not_available": "não disponível"
+  },
+  "join_invite": {
+    "click_below": "Clique no botão a seguir se você estiver pronto(a) para participar desse estudo. Você pode se retirar deste estudo e/ou excluir seus dados a qualquer momento, sem consequências.",
+    "decline": "Caso você não se sinta confortável em compartilhar seus dados fornecidos para este estudo, você pode recusar este convite. ",
+    "decline_title": "Recusar"
+  },
+  "applet_list_component": {
+    "about_title": "Sobre o Curious",
+    "no_applets_yet": "Você não tem applets.",
+    "noon": "Meio-dia",
+    "midnight": "Meia-noite",
+    "refresh_error_header": "Erro de atualização",
+    "applets_not_refreshed": "Os seguintes applets não foram atualizados:",
+    "common_refresh_error": "A lista de applets não foi atualizada. Tente novamente."
+  },
+  "activity_list_component": {
+    "no_activities": "Não há atividades disponíveis para você concluir no momento",
+    "insufficient_data_error": "Este applet não foi atualizado. Tente atualizar novamente.",
+    "other_error": "Ocorreu um erro indefinido"
+  },
+  "applet_settings": {
+    "applet_not_defined": "Nenhum applet foi definido.",
+    "want_remove": "Se você deseja remover esse applet, mas manter seus dados, clique no botão a seguir",
+    "remove": "Remover",
+    "want_delete": "Se você deseja excluir seus dados desse applet e removê-lo, clique no botão a seguir.",
+    "remove_delete": "Remover e excluir dados",
+    "alert_title": "Tem certeza de que deseja excluir seus dados?",
+    "alert_message": "Não será possível recuperá-los",
+    "cancel_text": "Não, cancelar",
+    "confirm_text": "Sim, excluir"
+  },
+  "change_pass_form": {
+    "update": "Atualização",
+    "cur_pass_placeholder": "Senha atual",
+    "new_pass_placeholder": "Nova senha",
+    "error": "Não foi possível atualizar as informações do usuário.",
+    "submission_error": "A senha atual que você inseriu está incorreta.",
+    "change_pass": "Alterar senha",
+    "password_at_least_characters": "A senha deve ter pelo menos {{min}} caracteres"
+  },
+  "password_recovery_form": {
+    "password_at_least_characters": "A senha deve ter pelo menos {{min}} caracteres",
+    "password_no_spaces": "A senha não deve conter espaços",
+    "passwords_do_not_match": "As senhas não correspondem",
+    "password_confirmation_required": "Confirme sua senha",
+    "new_password_placeholder": "Nova senha",
+    "confirm_password_placeholder": "Confirmar senha",
+    "submit": "Enviar",
+    "invalid_password_reset_link": "Este link é inválido ou expirou.",
+    "click_to_reset_password": "Clique no botão a seguir para redefinir sua senha.",
+    "forgot_password": "Esqueci minha senha",
+    "success": "Sua senha foi redefinida com sucesso. Faça login com sua nova senha.",
+    "error": "Erro ao redefinir sua senha"
+  },
+  "change_study": {
+    "reset": "Reset",
+    "submit": "Enviar",
+    "enter_url_manually": "Enter URL Manually",
+    "scan_qr": "Scan QR",
+    "successfully_changed": "Server Url was changed successfully.",
+    "successfully_reset": "Server Url was reset successfully.",
+    "change_server": "Change Server",
+    "http_confirm": "Are you sure you want to connect to server which doesn't support ssl?",
+    "set_by_qr": "Study has been set by QR.",
+    "yes": "Yes",
+    "no": "No"
+  },
+  "consent": {
+    "this_app_provides": "Esse aplicativo oferece uma maneira fácil de coletar atividades de pesquisa, voz e desenho.",
+    "i_understand": "Entendo que a visualização de determinadas imagens pode ser desconfortável durante o uso deste aplicativo",
+    "i_will_allow": "Autorizo o Child Mind Institute a armazenar os dados do uso deste aplicativo em um\nservidor em nuvem seguro e a acessar essas informações para fins clínicos e de pesquisa",
+    "i_premit": "Autorizo o Child Mind Institute a entrar em contato comigo a respeito de informações coletadas por\neste aplicativo para fins clínicos ou de pesquisa.",
+    "next": "Avançar"
+  },
+  "forgot_pass_form": {
+    "reset_pass": "Redefinir senha",
+    "enter_email_mess": "Digite seu endereço de e-mail",
+    "invalid_email": "Endereço de e-mail inválido",
+    "email_address": "Endereço de e-mail",
+    "email_send_success": "O e-mail de redefinição foi enviado para <strong>{{email}}</strong> se a conta existir.",
+    "email_send_error": "Não é possível enviar um e-mail de redefinição no momento.",
+    "forgot_password": "Esqueceu a senha?"
+  },
+  "login": {
+    "new_user": "Novo usuário",
+    "account_create": "Criar uma conta",
+    "forgot_password": "Esqueceu a senha?",
+    "what_is": "What is",
+    "login_error": "Falha no login.",
+    "password_at_least_characters": "A senha deve ter pelo menos 6 caracteres"
+  },
+  "login_form": {
+    "login": "Fazer login",
+    "email_placeholder": "E-mail",
+    "password": "Senha"
+  },
+  "logout_warning": {
+    "warning": "Aviso de logout",
+    "uploads_in_progress": "Uploads em andamento",
+    "currently_uploading": "Há respostas sendo carregadas no momento. Se você fizer o logout agora e depois fizer login como um usuário diferente, suas respostas serão perdidas.",
+    "not_uploaded": "Você não carregou respostas. Se você fizer o logout agora e depois fizer login como um usuário diferente, suas respostas serão perdidas.",
+    "sure_logout": "Tem certeza de que deseja fazer logout?",
+    "cancel": "Cancelar",
+    "logout": "Fazer logout"
+  },
+  "settings": {
+    "logged_out": "Você fez o logout.",
+    "change_pass": "Alterar senha",
+    "use_cellular_data": "Usar dados móveis",
+    "logout": "Fazer logout",
+    "permanently_delete_account": "Excluir conta permanentemente",
+    "user_settings": "Configurações do usuário",
+    "upload_logs": "Carregar registros",
+    "create_new_password": "Criar uma nova senha"
+  },
+  "language_screen": {
+    "app_language": "Idioma do aplicativo",
+    "change_app_language": "Alterar idioma",
+    "en": "English",
+    "fr": "Français",
+    "el": "Grego",
+    "es": "Español",
+    "pt": "Português"
+  },
+  "application_logs_screen": {
+    "upload_button": "Carregar registros",
+    "title": "Está tendo problemas técnicos? Seus arquivos de registro ajudarão nossa equipe a solucionar problemas.",
+    "subTitle": "Faça o upload desses arquivos usando o botão a seguir.",
+    "success": "Sucesso - recebemos seus registros.",
+    "error": "Erro - os registros não foram enviados. Tente novamente."
+  },
+  "sign_up_form": {
+    "sign_up": "Inscrever-se",
+    "error": "Falha na inscrição: o nome de usuário já pode estar em uso.",
+    "new_user": "Novo usuário",
+    "username_validation_error": "O nome de usuário deve ter pelo menos 4 caracteres, começar com uma letra e conter apenas letras, números, traços e pontos.",
+    "email_validation_error": "Parece que este e-mail está incompleto",
+    "email_placeholder": "E-mail",
+    "first_name": "Nome",
+    "last_name": "Sobrenome",
+    "password_placeholder": "Senha",
+    "please_accept_terms": "Aceite os termos de serviço.",
+    "email_looks_incomplete": "Parece que este e-mail está incompleto",
+    "sign_up_agree": "Ao se inscrever, você concorda com a política de privacidade do Curious",
+    "and": "e"
+  },
+  "password_requirements": {
+    "at_least_characters": "6 caracteres",
+    "no_blank_spaces": "nenhum espaço em branco",
+    "must_include": "A senha deve incluir:"
+  },
+  "geolocation": {
+    "get_location": "OBTER LOCALIZAÇÃO",
+    "must_enable_location": "Você deve ativar os serviços de localização para concluir essa tarefa. Conceda permissão ao Curious nas Configurações do iOS e pressione o botão novamente.",
+    "must_enable_location_subtitle": "Você deve ativar os serviços de localização para concluir essa tarefa. Pressione o botão novamente e conceda ao Curious permissão para usar sua localização.",
+    "location_saved": "Localização salva.",
+    "service_not_available": "O serviço de localização não está disponível."
+  },
+  "select": {
+    "select_one": "Selecione um",
+    "no_items": "No items"
+  },
+  "permissions": {
+    "alert_button_cancel": "Rejeitar",
+    "alert_button_ok": "Abrir configurações",
+    "alarm_permission_warning": "Solicitação de permissões de alarme",
+    "alarm_permission_disabled": "Ative as permissões de alarme em seu dispositivo para receber os lembretes do Curious na hora certa. Lembre-se de que o aplicativo será fechado automaticamente quando você ativar as permissões de alarme.",
+    "gallery": "O \"Curious\" gostaria de acessar sua galeria para concluir esta tarefa",
+    "camera": "O \"Curious\" gostaria de acessar a câmera para concluir esta tarefa"
+  },
+  "media": {
+    "alert_message": "Isso pode ser configurado em Configurações",
+    "media_found_title": "Você está off-line",
+    "media_found_body": "Esta atividade contém itens que exigem conexão com a Internet. Ative a Internet para continuar."
+  },
+  "audio_recorder": {
+    "permission": "Você deve conceder permissão para usar seu microfone para concluir essa tarefa.",
+    "alert_title": "O \"Curious\" gostaria de acessar seu microfone para concluir essa tarefa.",
+    "alert_message": "Isso pode ser configurado em Configurações.",
+    "record_error": "Houve um erro ao iniciar o gravador.",
+    "stop": "PARAR",
+    "record": "GRAVAR",
+    "recording": "Gravando...",
+    "seconds": "segundos",
+    "file_saved": "Arquivo salvo."
+  },
+  "audio_player": {
+    "stop": "PARAR",
+    "playing": "REPRODUZINDO...",
+    "play": "REPRODUZIR",
+    "done": "CONCLUIR",
+    "loading": "CARREGANDO"
+  },
+  "optional_text": {
+    "required": "Esse é um campo obrigatório.",
+    "enter_text": "Insira o texto."
+  },
+  "date_picker": {
+    "ok": "OK"
+  },
+  "table_input": {
+    "short_press_detail": "* Um toque curto aumenta o contador",
+    "long_press_detail": "* Um toque longo diminui o contador"
+  },
+  "activity_due_date": {
+    "available_all_day": "Disponível: O dia todo",
+    "scheduled_at": "Scheduled At",
+    "available": "Disponível de",
+    "to": "Até",
+    "day": "day",
+    "days": "days",
+    "am": "AM",
+    "the_following_day": "o dia seguinte"
+  },
+  "form_item": {
+    "required": "Obrigatório",
+    "must_be": "Must be",
+    "characters_or_less": "characters or less",
+    "must_be_a_number": "Must be a number"
+  },
+  "applet_about": {
+    "loading": "carregando",
+    "no_info": "Os autores deste applet não forneceram nenhuma informação!"
+  },
+  "firebase_messaging": {
+    "alert_title": "O \"Curious\" gostaria de enviar notificações",
+    "alert_message": "Isso pode ser configurado em Configurações",
+    "alert_text": "Abrir configurações",
+    "response_refresh_request": "Solicitação de atualização de resposta",
+    "refresh_request_details": "Como sua senha foi redefinida, as respostas anteriores precisam ser atualizadas. Você deseja fazer essa solicitação?",
+    "refresh_request_text": "Seus gerentes iniciarão a atualização em breve.",
+    "applet_not_found_1": "O applet não foi encontrado",
+    "applet_not_found_2": "Não há applets para o ID fornecido.",
+    "activity_not_found": "A atividade \"{{entityName}} \" não está disponível agora.",
+    "already_completed": "Você já concluiu",
+    "app_killed_on_redux_persist": "Essa atividade não pode ser iniciada. Entre em contato com o suporte.",
+    "activity_was_due_at": "This activity was due at",
+    "if_progress_was_made_on_the": "If progress was made on the",
+    "it_was_saved_but_it_can_no_longer_be_taken": "it was saved but it can no longer be taken",
+    "today": "de hoje.",
+    "today2": "Programado para hoje",
+    "activity_not_ready": "Atividade não está pronta",
+    "not_able_to_start": "Você ainda não pode iniciar a atividade",
+    "is": "está",
+    "scheduled_to_start_at": "programada para começar às",
+    "postponed_notification": "Assim que as respostas forem carregadas, tentaremos abrir a atividade"
+  },
+  "local_notifications": {
+    "complete_activity": "Conclua esta atividade."
+  },
+  "join_demo_applets": {
+    "healthy_brain_network": "Healthy Brain Network (Rede do Cérebro Saudável): Avaliação Momentânea Ecológica",
+    "cognitive_tasks": "Tarefas cognitivas",
+    "mind_logger_demos": "Demonstrações do Curious"
+  },
+  "data_invite": {
+    "message": "Consideramos importante que você saiba quem terá acesso aos seus dados caso você aceite esse convite.\n\nAs seguintes pessoas terão acesso aos seus dados se você aceitar este convite:"
+  },
+  "sidebar": {
+    "home": "Início",
+    "settings": "Configurações",
+    "about": "Sobre",
+    "logout": "Fazer logout"
+  },
+  "navigator": {
+    "exit_title": "Sair do aplicativo",
+    "exit_subtitle": "Saindo do aplicativo?",
+    "cancel": "Cancelar"
+  },
+  "activity_navigation": {
+    "next": "Avançar",
+    "skip": "Pular",
+    "done": "Concluir",
+    "back": "Voltar",
+    "return": "Retornar",
+    "undo": "Desfazer",
+    "exit": "Salvar e sair"
+  },
+  "network_alerts": {
+    "no_internet_title": "Sem conexão com a Internet",
+    "no_internet_subtitle": "Conecte-se à Internet",
+    "no_internet_text": "Rejeitar",
+    "cellular_data_title": "Os dados móveis estão desativados",
+    "cellular_data_subtitle": "Conecte-se a uma rede wi-fi ou permita o uso de dados móveis",
+    "cellular_data_text": "Rejeitar",
+    "use_cellular_data": "Usar dados móveis"
+  },
+  "timing": {
+    "provide_option": "You must provide the \"after\" or \"every\" option",
+    "to_be_number": "Expected options.after to be a number",
+    "every_number": "Expected options.every to be a number"
+  },
+  "camera": {
+    "choose_photo": "Escolha uma foto",
+    "choose_video": "Escolha um vídeo",
+    "take_a_photo": "Tire uma nova foto ou escolha uma de sua biblioteca",
+    "take_a_video": "Grave um novo vídeo ou escolha um de sua biblioteca",
+    "camera": "Câmera",
+    "library": "Biblioteca"
+  },
+  "text_entry": {
+    "type_placeholder": "Insira o texto",
+    "paragraph_placeholder": "Insira sua resposta aqui."
+  },
+  "character_counter": {
+    "characters": "{{numberOfCharacters}}/{{limit}} caracteres"
+  },
+  "additional": {
+    "server-error": "Ocorreu um erro no servidor",
+    "time-end": "O tempo acabou!",
+    "time-end-tap": "O tempo acabou. Toque para concluir",
+    "thanks": "Obrigado!",
+    "sorry": "Desculpe",
+    "saved_answers": "Salvamos suas respostas!",
+    "submit_flow_answers": "Toque no botão",
+    "submit": "Enviar",
+    "submit_flow_answers_ex": "para salvar suas respostas e continuar:",
+    "close": "Fechar",
+    "resume_activity": "Retomar a atividade",
+    "activity_resume_restart": "Você gostaria de retomar essa atividade em andamento ou reiniciá-la?",
+    "restart": "Reiniciar",
+    "resume": "Retomar",
+    "retry": "Repetir",
+    "send": "Enviar",
+    "later": "Mais tarde",
+    "in_progress": "Em andamento",
+    "unscheduled": "Não programada",
+    "scheduled": "Programada",
+    "past_due": "Atrasada",
+    "available": "Disponível",
+    "sure_delete_account_data": "Tem certeza de que deseja excluir sua conta e seus dados?",
+    "no_cancel": "Não, cancelar",
+    "yes_delete": "Sim, excluir",
+    "hi": "Olá",
+    "enter_old_password": "Digite sua senha antiga",
+    "enter_new_password": "Digite uma nova senha",
+    "data_not_sent": "Clique em Enviar para carregar os dados coletados anteriormente",
+    "data_is_sending": "Carregando os dados coletados anteriormente",
+    "upload_error": "Erro de upload",
+    "want_to_retry": "Sua Internet pode estar instável. Não foi possível enviar seus dados."
+  },
+  "prize": {
+    "lack_tokens_title": "Tente novamente",
+    "lack_tokens_subtitle": "You don't have enough tokens.\nSelecione outro prêmio"
+  },
+  "cognitive": {
+    "incorrect_start_point": "Ponto de partida incorreto!",
+    "incorrect_line": "Linha incorreta!",
+    "finished_continue": "Concluído. Clique em Avançar para continuar.",
+    "finished_complete": "Concluído. Clique em Concluído para finalizar.",
+    "begin": "Início",
+    "end": "Fim"
+  },
+  "system": {
+    "migration_not_applied_text": "A migração de dados não foi aplicada com sucesso. Entre em contato com o suporte.",
+    "ok": "OK"
+  },
+  "activity_skip_popup": {
+    "popup_title": "Pular para a próxima avaliação?",
+    "popup_description": "Essa avaliação está incompleta. Se você pular para a próxima avaliação, seu progresso será salvo. Você não poderá concluir essa avaliação mais tarde.",
+    "keep_working": "Continuar avaliação",
+    "skip": "Pular"
+  },
+  "autocompletion": {
+    "done": "Concluir",
+    "time_limit_reached": "Limite de tempo atingido",
+    "time_expired": "O tempo para concluir {{activityNames}} expirou. Suas respostas serão enviadas automaticamente.",
+    "processing_answers": "Processando respostas",
+    "preparing_answers": "Aguarde e não feche a tela.",
+    "answers_submitted": "Respostas enviadas",
+    "thanks": "Obrigado! Nós salvamos tudo.",
+    "time_is_up_modal_description": "Não há mais tempo para realizar essa atividade. Todo o trabalho que você fez será salvo e enviado.",
+    "time_is_up_modal_title": "O tempo acabou",
+    "ok": "OK"
+  },
+  "data_sharing": {
+    "consent": "Concordo em tornar minhas respostas",
+    "media_consent": "Concordo em tornar minhas respostas com mídia",
+    "public": "públicas",
+    "dialog": {
+      "body": "Tornar as respostas públicas implica que as informações fornecidas por usuários individuais, como respostas a pesquisas ou feedback, estarão disponíveis abertamente para que outras pessoas possam visualizá-las."
+    }
+  },
+  "assignment": {
+    "badge": "Sobre {{name}}",
+    "banner": "Certifique-se de que todas as suas respostas sejam sobre<strong>{{name}}</strong>"
+  },
+  "splash": {
+    "version": "Versão"
+  },
+  "requestHealthRecordData": {
+    "title": "Solicitar dados de registros médicos",
+    "linkText": "Saiba mais sobre como o Curious acessa dados médicos com segurança.",
+    "partnershipText": "O Curious usa o Serviço de Informações Médicas da 1UpHealth para permitir que seu pesquisador acesse as informações contidas em seus registros médicos.\n\nNas telas a seguir, solicitaremos que você entre nos sistemas do seu provedor de serviços de saúde e compartilhar seus dados médicos com este estudo. Você voltará à atividade do Curious quando terminar.",
+    "enterYourHealthSystem": "Insira seu sistema de saúde:",
+    "healthSystemName": "Nome do sistema de saúde",
+    "search": "Pesquisar",
+    "additionalPromptText": "Você concluiu o login na sua conta de serviços de saúde.\n\nVocê gostaria de se inscrever em outras contas de serviços de saúde?",
+    "yes": "Yes",
+    "no": "No",
+    "noResults": "Não foram encontrados provedores de serviços de saúde que correspondam à sua pesquisa."
+  },
+  "rebrandBanner": {
+    "content": "<0>Estamos reformulando nossa marca!</0> <1>Atualizações de design estão a caminho: o mesmo excelente aplicativo, com um novo visual. Curioso?</1> <2>Toque para saber mais.</2>"
+  }
+}

--- a/src/entities/localization/lib/setupLocalization.ts
+++ b/src/entities/localization/lib/setupLocalization.ts
@@ -7,6 +7,7 @@ import el from '@assets/translations/el.json';
 import en from '@assets/translations/en.json';
 import es from '@assets/translations/es.json';
 import fr from '@assets/translations/fr.json';
+import ptBr from '@assets/translations/pt-br.json';
 
 import { getDefaultLocalizationStorage } from './localizationStorageInstance';
 
@@ -30,6 +31,7 @@ export function setupLocalization() {
       fr,
       el,
       es,
+      pt: ptBr,
     },
     returnNull: false,
   });

--- a/src/shared/lib/types/language.ts
+++ b/src/shared/lib/types/language.ts
@@ -1,1 +1,1 @@
-export type Language = 'en' | 'fr' | 'el' | 'es';
+export type Language = 'en' | 'fr' | 'el' | 'es' | 'pt';

--- a/src/shared/lib/utils/dateTime.ts
+++ b/src/shared/lib/utils/dateTime.ts
@@ -5,7 +5,7 @@ import {
   getUnixTime,
   subMonths,
 } from 'date-fns';
-import { enGB, fr, el, es } from 'date-fns/locale';
+import { enGB, fr, el, es, ptBR } from 'date-fns/locale';
 import i18n from 'i18next';
 
 import { getTwoDigits, range } from './common';
@@ -17,7 +17,7 @@ import {
 import { DayMonthYear, HourMinute } from '../types/dateTime';
 import { Language } from '../types/language';
 
-const dateFnsLocales = { fr, en: enGB, el, es };
+const dateFnsLocales = { fr, en: enGB, el, es, pt: ptBR };
 
 export const getMsFromHours = (hours: number): number => {
   return hours * (MINUTES_IN_HOUR * MS_IN_MINUTE);


### PR DESCRIPTION
## ✅ PR Checklist
- [ ] Tests for the changes have been added
- [ ] Related documentation has been added / updated
- [ ] OSS packages added to Curious [open source credit page](https://mindlogger.atlassian.net/jira/servicedesk/projects/MLA/knowledge/articles/340623543?spaceKey=MLA)

---

## 📝 Description

🔗 [Jira Ticket M2-8805](https://mindlogger.atlassian.net/browse/M2-8805)

This PR adds **Portuguese language support** to the mobile app, allowing users to select Portuguese as their preferred application language.

### Changes
- Added Portuguese translation file (`pt-br.json`) with all translated strings  
- Added `pt` to Language type definition  
- Imported and configured `pt-br.json` in i18n setup  
- Added Portuguese option to the language selection screen  
- Language selection persists in local storage (existing functionality)  

No feature flag required per requirements. Translation provided by a third-party vendor.  

---

## 📸 Screenshots

| Before | After |
| ------ | ----- |
| Language options: English, Français, ελληνικά, Español | Language options: English, Français, ελληνικά, Español, Português |

| <img width="300" alt="Simulator Screenshot - iPhone 16 Pro - 2025-08-27 at 22 41 53" src="https://github.com/user-attachments/assets/b23e7b97-ed13-44a2-a11e-8148b10def6d" /> | |<img width="300" alt="Simulator Screenshot - iPhone 16 Pro - 2025-08-27 at 22 42 22" src="https://github.com/user-attachments/assets/52d316c2-d799-4762-a8c8-897d590d6134" /> |
| <img width="300" alt="Simulator Screenshot - iPhone 16 Pro - 2025-08-27 at 22 42 15" src="https://github.com/user-attachments/assets/a990d304-c058-4fef-b3a0-815405153629" /> | <img width="300" alt="Simulator Screenshot - iPhone 16 Pro - 2025-08-27 at 22 42 17" src="https://github.com/user-attachments/assets/827afd8d-c1e9-423d-832d-4df22b4ecf6a" /> |
<img width="300" alt="Simulator Screenshot - iPhone 16 Pro - 2025-08-27 at 22 41 55" src="https://github.com/user-attachments/assets/710bd142-b7e0-40ef-9a6a-a3be4df107c0" />  |

---

## 🪤 Peer Testing

**Setup Requirements:**
- Run `yarn install`  
- Run `yarn pods`  

### Test Steps
1. Navigate to **Settings → Change Language**  
   - **Expected:** Language selection screen displays 5 language options including *Português*  

2. Tap on **Português**  
   - **Expected:** App UI updates to Portuguese and returns to Settings  

3. Close and restart the app  
   - **Expected:** App remains in Portuguese (persisted in local storage)  

4. While in Portuguese, navigate back to **Change Language**  
   - **Expected:** All options are displayed in their native languages (English, Français, ελληνικά, Español, Português)  

---

## ✏️ Notes
- Translation content is provided by a third-party vendor.  
- Review is limited to confirming that the option is available and functional.  
- Any translation accuracy/content issues will be addressed in a separate ticket.  