### PR TITLE
fix: (M2-9713) Greek selection should be in Greek, not in Portuguese 

### DIFF
--- a/assets/translations/pt-br.json
+++ b/assets/translations/pt-br.json
@@ -238,7 +238,7 @@
     "change_app_language": "Alterar idioma",
     "en": "English",
     "fr": "Français",
-    "el": "Grego",
+    "el": "Ελληνικά",
     "es": "Español",
     "pt": "Português"
   },


### PR DESCRIPTION
### 📝 Description


🔗 [Jira Ticket M2-9713](https://mindlogger.atlassian.net/browse/M2-9713)

Changed "Grego" to "Ελληνικά" when you are looking at the language selections after changing to Portuguese