### PR TITLE
fix (M2-9838): Portuguese grammatical fixes 

### DIFF
--- a/assets/translations/pt-br.json
+++ b/assets/translations/pt-br.json
@@ -330,7 +330,7 @@
     "day": "day",
     "days": "days",
     "am": "AM",
-    "the_following_day": "o dia seguinte"
+    "the_following_day": "do dia seguinte"
   },
   "form_item": {
     "required": "Obrigatório",
@@ -436,7 +436,7 @@
     "submit": "Enviar",
     "submit_flow_answers_ex": "para salvar suas respostas e continuar:",
     "close": "Fechar",
-    "resume_activity": "Retomar a atividade",
+    "resume_activity": "Retomar atividade",
     "activity_resume_restart": "Você gostaria de retomar essa atividade em andamento ou reiniciá-la?",
     "restart": "Reiniciar",
     "resume": "Retomar",


### PR DESCRIPTION
### 📝 Description

🔗 [Jira Ticket M2-9838](https://mindlogger.atlassian.net/browse/M2-9838)

<!-- Replace this with a high-level description of the features/functionality proposed in the pull request. -->

### 🪤 Peer Testing

Issue 2: On the "Schedule" applet, a grammar error is found. It reads "Até 7:15 PM o dia seguinte" and it should read "Até 7:15 PM do dia seguinte" 

Issue 3: “Tap restart on activity/flow”: Grammar error: it reads 'Retomar a atividade' and it should read 'Retomar atividade'