### PR TITLE
feature: Handle `SetOrientation` events from Unity (M2-10032)

### DIFF
--- a/index.js
+++ b/index.js
@@ -9,6 +9,9 @@ import { AppRegistry } from 'react-native';
 import { Buffer } from 'buffer';
 import process from 'process';
 import PropTypes from 'prop-types';
+import RNOrientationDirector, {
+  Orientation,
+} from 'react-native-orientation-director';
 import SystemNavigationBar from 'react-native-system-navigation-bar';
 
 import { palette } from '@shared/lib/constants/palette';
@@ -51,5 +54,6 @@ HeadlessCheck.propTypes = {
 };
 
 SystemNavigationBar.setNavigationColor(palette.surface1, 'dark', 'navigation');
+RNOrientationDirector.lockTo(Orientation.portrait);
 
 AppRegistry.registerComponent(appName, () => HeadlessCheck);

--- a/ios/FlankerSandboxView/MindloggerMobile-Bridging-Header.h
+++ b/ios/FlankerSandboxView/MindloggerMobile-Bridging-Header.h
@@ -8,3 +8,4 @@
 #import <React/RCTBridgeModule.h>
 #import <React/RCTViewManager.h>
 #import <React/RCTDevLoadingView.h>
+#import <OrientationDirector.h>

--- a/ios/MindloggerMobile dev-Info.plist
+++ b/ios/MindloggerMobile dev-Info.plist
@@ -95,6 +95,8 @@
 	<key>UISupportedInterfaceOrientations</key>
 	<array>
 		<string>UIInterfaceOrientationPortrait</string>
+		<string>UIInterfaceOrientationLandscapeLeft</string>
+		<string>UIInterfaceOrientationLandscapeRight</string>
 	</array>
 	<key>UIViewControllerBasedStatusBarAppearance</key>
 	<false/>

--- a/ios/MindloggerMobile qa-Info.plist
+++ b/ios/MindloggerMobile qa-Info.plist
@@ -95,6 +95,8 @@
 	<key>UISupportedInterfaceOrientations</key>
 	<array>
 		<string>UIInterfaceOrientationPortrait</string>
+		<string>UIInterfaceOrientationLandscapeLeft</string>
+		<string>UIInterfaceOrientationLandscapeRight</string>
 	</array>
 	<key>UIViewControllerBasedStatusBarAppearance</key>
 	<false/>

--- a/ios/MindloggerMobile staging-Info.plist
+++ b/ios/MindloggerMobile staging-Info.plist
@@ -95,6 +95,8 @@
 	<key>UISupportedInterfaceOrientations</key>
 	<array>
 		<string>UIInterfaceOrientationPortrait</string>
+		<string>UIInterfaceOrientationLandscapeLeft</string>
+		<string>UIInterfaceOrientationLandscapeRight</string>
 	</array>
 	<key>UIViewControllerBasedStatusBarAppearance</key>
 	<false/>

--- a/ios/MindloggerMobile uat-Info.plist
+++ b/ios/MindloggerMobile uat-Info.plist
@@ -95,6 +95,8 @@
 	<key>UISupportedInterfaceOrientations</key>
 	<array>
 		<string>UIInterfaceOrientationPortrait</string>
+		<string>UIInterfaceOrientationLandscapeLeft</string>
+		<string>UIInterfaceOrientationLandscapeRight</string>
 	</array>
 	<key>UIViewControllerBasedStatusBarAppearance</key>
 	<false/>

--- a/ios/MindloggerMobile/AppDelegate.swift
+++ b/ios/MindloggerMobile/AppDelegate.swift
@@ -4,6 +4,7 @@ import React_RCTAppDelegate
 import ReactAppDependencyProvider
 import TSBackgroundFetch
 import Firebase
+import react_native_orientation_director
 
 @main
 class AppDelegate: UIResponder, UIApplicationDelegate {
@@ -35,6 +36,13 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     TSBackgroundFetch.sharedInstance().didFinishLaunching();
 
     return true
+  }
+
+  func application(
+    _ application: UIApplication,
+    supportedInterfaceOrientationsFor window: UIWindow?
+  ) -> UIInterfaceOrientationMask {
+    return OrientationDirector.getSupportedInterfaceOrientationsForWindow()
   }
 
   func application(

--- a/ios/MindloggerMobile/Info.plist
+++ b/ios/MindloggerMobile/Info.plist
@@ -95,6 +95,8 @@
 	<key>UISupportedInterfaceOrientations</key>
 	<array>
 		<string>UIInterfaceOrientationPortrait</string>
+		<string>UIInterfaceOrientationLandscapeLeft</string>
+		<string>UIInterfaceOrientationLandscapeRight</string>
 	</array>
 	<key>UIViewControllerBasedStatusBarAppearance</key>
 	<false/>

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -1535,6 +1535,30 @@ PODS:
     - React-Core
   - react-native-netinfo (11.5.2):
     - React-Core
+  - react-native-orientation-director (2.6.5):
+    - DoubleConversion
+    - glog
+    - hermes-engine
+    - RCT-Folly (= 2024.11.18.00)
+    - RCTRequired
+    - RCTTypeSafety
+    - React-Core
+    - React-debug
+    - React-Fabric
+    - React-featureflags
+    - React-graphics
+    - React-hermes
+    - React-ImageManager
+    - React-jsi
+    - React-NativeModulesApple
+    - React-RCTFabric
+    - React-renderercss
+    - React-rendererdebug
+    - React-utils
+    - ReactCodegen
+    - ReactCommon/turbomodule/bridging
+    - ReactCommon/turbomodule/core
+    - Yoga
   - react-native-safe-area-context (5.7.0):
     - React-Core
   - react-native-skia (2.0.2):
@@ -2270,6 +2294,7 @@ DEPENDENCIES:
   - react-native-image-picker (from `../node_modules/react-native-image-picker`)
   - react-native-mmkv (from `../node_modules/react-native-mmkv`)
   - "react-native-netinfo (from `../node_modules/@react-native-community/netinfo`)"
+  - react-native-orientation-director (from `../node_modules/react-native-orientation-director`)
   - react-native-safe-area-context (from `../node_modules/react-native-safe-area-context`)
   - "react-native-skia (from `../node_modules/@shopify/react-native-skia`)"
   - react-native-tcp-socket (from `../node_modules/react-native-tcp-socket`)
@@ -2463,6 +2488,8 @@ EXTERNAL SOURCES:
     :path: "../node_modules/react-native-mmkv"
   react-native-netinfo:
     :path: "../node_modules/@react-native-community/netinfo"
+  react-native-orientation-director:
+    :path: "../node_modules/react-native-orientation-director"
   react-native-safe-area-context:
     :path: "../node_modules/react-native-safe-area-context"
   react-native-skia:
@@ -2664,10 +2691,11 @@ SPEC CHECKSUMS:
   react-native-image-picker: 0dedb728321ef49f996619332e10603770434e5a
   react-native-mmkv: e97c0c79403fb94577e5d902ab1ebd42b0715b43
   react-native-netinfo: b72ba1bb4d9f51944311491120786aebf972d650
+  react-native-orientation-director: 6627919cbaccad44dcb904e5a07e586ea713d691
   react-native-safe-area-context: 37b720094bcaa36abcd593e08f2ad16507a94769
   react-native-skia: c80f1d06c9133aa084c979fa2c77ae3c11e45401
   react-native-tcp-socket: c9290d77fea17ee75bee93e599b604bae63166f0
-  react-native-unity: ac42fbcf438c845877ff88eea234b68631d4e58a
+  react-native-unity: 91a74c36d654fb7a7b8eff818435c28bdfdfcb24
   react-native-vector-icons-entypo: 9b3015a5b28f681c668cb3c4c7b4e18ddfac63a3
   react-native-vector-icons-feather: b669f5bc4981f53aaa25d0e0135ae9a7d5c1bbd5
   react-native-vector-icons-fontawesome6: 7464629872b702957385275b62cff2f6c28199cc

--- a/package.json
+++ b/package.json
@@ -8,7 +8,6 @@
     "build:android:dev": "echo $BUILD_WITH_UNITY",
     "build:ios:dev": "xcodebuild -workspace MindloggerMobile.xcworkspace -configuration Debug -scheme MindloggerMobileDev -destination id=00008110-000254A10E29401E",
     "clean": "npm-run-all clean:*",
-    "clean-ios": "yarn clean:ios",
     "clean:ios": "npm-run-all clean:ios:*",
     "clean:ios:build": "rimraf ./ios/build",
     "clean:ios:xcode": "cd ios && xcodebuild clean -workspace MindloggerMobile.xcworkspace -scheme MindloggerMobileDev && cd ..",

--- a/package.json
+++ b/package.json
@@ -142,6 +142,7 @@
     "react-native-mime-types": "^2.4.0",
     "react-native-mmkv": "2.11.0",
     "react-native-modal-datetime-picker": "^17.1.0",
+    "react-native-orientation-director": "^2.6.5",
     "react-native-permissions": "^4.0.1",
     "react-native-popover-view": "^6.0.1",
     "react-native-progress": "^5.0.1",

--- a/src/entities/unity/lib/types/unityMessage.ts
+++ b/src/entities/unity/lib/types/unityMessage.ts
@@ -6,12 +6,14 @@ export const UnityEventUnityStarted = 'UnityStarted';
 export const UnityEventEndUnity = 'EndUnity';
 export const UnityEventActivityCompleted = 'ActivityCompleted';
 export const UnityEventDataExport = 'DataExport';
+export const UnityEventSetOrientation = 'SetOrientation';
 
 export type UnityEvent =
   | typeof UnityEventUnityStarted
   | typeof UnityEventEndUnity
   | typeof UnityEventActivityCompleted
-  | typeof UnityEventDataExport;
+  | typeof UnityEventDataExport
+  | typeof UnityEventSetOrientation;
 
 type U2RNMessageBase<TUnityEvent extends UnityEvent> = {
   m_sId: string;
@@ -35,11 +37,18 @@ export type U2RNMessageDataExport = U2RNMessageBase<
   m_listDataPaths: Array<string>;
 };
 
+export type U2RNMessageSetOrientation = U2RNMessageBase<
+  typeof UnityEventSetOrientation
+> & {
+  m_sAdditionalInfo: 'Portrait' | 'LandscapeLeft' | 'LandscapeRight';
+};
+
 export type U2RNMessage =
   | U2RNMessageUnityStarted
   | U2RNMessageEndUnity
   | U2RNMessageActivityCompleted
-  | U2RNMessageDataExport;
+  | U2RNMessageDataExport
+  | U2RNMessageSetOrientation;
 
 // ============================================================================
 // Message from ReactNative to Unity

--- a/src/entities/unity/ui/UnityView.tsx
+++ b/src/entities/unity/ui/UnityView.tsx
@@ -166,35 +166,31 @@ export const UnityView: FC<Props> = props => {
   ]);
 
   // Handle orientation change requests from Unity, re-lock to portrait on unmount.
-  const handleSetOrientation =
-    useCallback<RNUnityCommBridgeUnityEventHandler>(
-      msg => {
-        if (msg.m_sKey === 'SetOrientation') {
-          const orientationValue = (
-            msg as { m_sAdditionalInfo: string }
-          ).m_sAdditionalInfo;
-          logger.log(
-            `[UnityView] Received SetOrientation: ${orientationValue}`,
+  const handleSetOrientation = useCallback<RNUnityCommBridgeUnityEventHandler>(
+    msg => {
+      if (msg.m_sKey === 'SetOrientation') {
+        const orientationValue = (msg as { m_sAdditionalInfo: string })
+          .m_sAdditionalInfo;
+        logger.log(`[UnityView] Received SetOrientation: ${orientationValue}`);
+
+        const orientationMap: Record<string, Orientation> = {
+          Portrait: Orientation.portrait,
+          LandscapeLeft: Orientation.landscapeLeft,
+          LandscapeRight: Orientation.landscapeRight,
+        };
+
+        const orientation = orientationMap[orientationValue];
+        if (orientation !== undefined) {
+          RNOrientationDirector.lockTo(orientation);
+        } else {
+          logger.warn(
+            `[UnityView] Unknown orientation value: ${orientationValue}`,
           );
-
-          const orientationMap: Record<string, Orientation> = {
-            Portrait: Orientation.portrait,
-            LandscapeLeft: Orientation.landscapeLeft,
-            LandscapeRight: Orientation.landscapeRight,
-          };
-
-          const orientation = orientationMap[orientationValue];
-          if (orientation !== undefined) {
-            RNOrientationDirector.lockTo(orientation);
-          } else {
-            logger.warn(
-              `[UnityView] Unknown orientation value: ${orientationValue}`,
-            );
-          }
         }
-      },
-      [logger],
-    );
+      }
+    },
+    [logger],
+  );
   useEffect(() => {
     registerEventHandler(UnityEventSetOrientation, handleSetOrientation);
     return () => {

--- a/src/entities/unity/ui/UnityView.tsx
+++ b/src/entities/unity/ui/UnityView.tsx
@@ -23,6 +23,7 @@ import {
 } from '../lib/hook/useRNUnityCommBridge';
 import {
   UnityEventEndUnity,
+  UnityEventSetOrientation,
   UnityEventUnityStarted,
 } from '../lib/types/unityMessage';
 
@@ -164,13 +165,42 @@ export const UnityView: FC<Props> = props => {
     unityViewKeyWas,
   ]);
 
-  // Unlock orientation when Unity view mounts, re-lock to portrait on unmount.
+  // Handle orientation change requests from Unity, re-lock to portrait on unmount.
+  const handleSetOrientation =
+    useCallback<RNUnityCommBridgeUnityEventHandler>(
+      msg => {
+        if (msg.m_sKey === 'SetOrientation') {
+          const orientationValue = (
+            msg as { m_sAdditionalInfo: string }
+          ).m_sAdditionalInfo;
+          logger.log(
+            `[UnityView] Received SetOrientation: ${orientationValue}`,
+          );
+
+          const orientationMap: Record<string, Orientation> = {
+            Portrait: Orientation.portrait,
+            LandscapeLeft: Orientation.landscapeLeft,
+            LandscapeRight: Orientation.landscapeRight,
+          };
+
+          const orientation = orientationMap[orientationValue];
+          if (orientation !== undefined) {
+            RNOrientationDirector.lockTo(orientation);
+          } else {
+            logger.warn(
+              `[UnityView] Unknown orientation value: ${orientationValue}`,
+            );
+          }
+        }
+      },
+      [logger],
+    );
   useEffect(() => {
-    RNOrientationDirector.unlock();
+    registerEventHandler(UnityEventSetOrientation, handleSetOrientation);
     return () => {
       RNOrientationDirector.lockTo(Orientation.portrait);
     };
-  }, []);
+  }, [handleSetOrientation, registerEventHandler]);
 
   // IMPORTANT: DO NOT use this effect for anything else!
   useEffect(() => {

--- a/src/entities/unity/ui/UnityView.tsx
+++ b/src/entities/unity/ui/UnityView.tsx
@@ -169,8 +169,7 @@ export const UnityView: FC<Props> = props => {
   const handleSetOrientation = useCallback<RNUnityCommBridgeUnityEventHandler>(
     msg => {
       if (msg.m_sKey === 'SetOrientation') {
-        const orientationValue = (msg as { m_sAdditionalInfo: string })
-          .m_sAdditionalInfo;
+        const orientationValue = msg.m_sAdditionalInfo;
         logger.log(`[UnityView] Received SetOrientation: ${orientationValue}`);
 
         const orientationMap: Record<

--- a/src/entities/unity/ui/UnityView.tsx
+++ b/src/entities/unity/ui/UnityView.tsx
@@ -3,6 +3,9 @@ import { UIManager } from 'react-native';
 
 import RNUnityView from '@azesmway/react-native-unity';
 import * as mime from 'react-native-mime-types';
+import RNOrientationDirector, {
+  Orientation,
+} from 'react-native-orientation-director';
 import { v4 as uuidv4 } from 'uuid';
 
 import { UnityPipelineItem } from '@app/features/pass-survey/lib/types/payload';
@@ -160,6 +163,14 @@ export const UnityView: FC<Props> = props => {
     unityViewKey,
     unityViewKeyWas,
   ]);
+
+  // Unlock orientation when Unity view mounts, re-lock to portrait on unmount.
+  useEffect(() => {
+    RNOrientationDirector.unlock();
+    return () => {
+      RNOrientationDirector.lockTo(Orientation.portrait);
+    };
+  }, []);
 
   // IMPORTANT: DO NOT use this effect for anything else!
   useEffect(() => {

--- a/src/entities/unity/ui/UnityView.tsx
+++ b/src/entities/unity/ui/UnityView.tsx
@@ -173,7 +173,12 @@ export const UnityView: FC<Props> = props => {
           .m_sAdditionalInfo;
         logger.log(`[UnityView] Received SetOrientation: ${orientationValue}`);
 
-        const orientationMap: Record<string, Orientation> = {
+        const orientationMap: Record<
+          string,
+          | Orientation.portrait
+          | Orientation.landscapeLeft
+          | Orientation.landscapeRight
+        > = {
           Portrait: Orientation.portrait,
           LandscapeLeft: Orientation.landscapeLeft,
           LandscapeRight: Orientation.landscapeRight,

--- a/src/features/pass-survey/ui/ActivityItem.tsx
+++ b/src/features/pass-survey/ui/ActivityItem.tsx
@@ -462,6 +462,8 @@ export function ActivityItem({
               />
             </Box>
           ),
+          question: null,
+          noScrollContainer: true,
         };
       default:
         return {

--- a/unity/README.md
+++ b/unity/README.md
@@ -81,7 +81,7 @@ Run the follow commands to prepare the build:
 
 ```
 $ yarn
-$ yarn clean
+$ yarn clean:ios
 $ yarn unity:relink
 $ yarn pods:reinstall
 ```
@@ -100,7 +100,7 @@ Run the follow commands to prepare the build:
 
 ```
 $ yarn
-$ yarn clean
+$ yarn clean:ios
 $ yarn pods:reinstall
 ```
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -8438,6 +8438,11 @@ react-native-modal-datetime-picker@^17.1.0:
   dependencies:
     prop-types "^15.7.2"
 
+react-native-orientation-director@^2.6.5:
+  version "2.6.5"
+  resolved "https://registry.yarnpkg.com/react-native-orientation-director/-/react-native-orientation-director-2.6.5.tgz#5fb69a12fc0855ed690f143565b955067258054d"
+  integrity sha512-hTkDu5VrRqHcg/5ihPjZhikA0RQpAv1pp7qja8whvic9ROOPGsDUWMSf0+pWRdIRKhmP1R0JyWmuRpjUYvoK7w==
+
 react-native-permissions@^4.0.1:
   version "4.1.5"
   resolved "https://registry.yarnpkg.com/react-native-permissions/-/react-native-permissions-4.1.5.tgz#db4d1ddbf076570043f4fd4168f54bb6020aec92"


### PR DESCRIPTION
### 📝 Description

🔗 [Jira Ticket M2-10032](https://mindlogger.atlassian.net/browse/M2-10032)

Changes include:

- Enable landscape mode for iOS app
- Use `react-native-orientation-director` to lock orientation to portrait by default
- Handle `SetOrientation` events from Unity to lock orientation to portrait/landscape
- Remove **Upload Configurations** header bar

Depends on ChildMindInstitute/Unity-Cognitive-Task-Creator@63ab06f.

### 📸 Screenshots

#### Before handling `SetOrientation`

<img width="295" height="639" alt="2026-03-26 iOS Unity Activity Before (M2-10032)" src="https://github.com/user-attachments/assets/2df8eaac-1143-4ede-892a-efe5cb82b5bc" />

#### After handling `SetOrientation`

<img width="639" height="295" alt="2026-03-26 iOS Unity Activity After (M2-10032)" src="https://github.com/user-attachments/assets/b5858332-26ad-4c48-8e1a-1be1301a9ac3" />

#### After removing **Upload Configurations** header bar

<img width="639" height="295" alt="2026-03-27 iOS Unity Activity After (M2-10032)" src="https://github.com/user-attachments/assets/2af7a08b-39f8-4bb7-b9f4-607139ad5730" />