### PR TITLE
feat: Log Unity event data as Datadog `Context` (M2-10492)

### DIFF
--- a/src/entities/unity/lib/hook/useRNUnityCommBridge.ts
+++ b/src/entities/unity/lib/hook/useRNUnityCommBridge.ts
@@ -138,7 +138,13 @@ export const useRNUnityCommBridge = ({
 
         // Call registered handler before resolving promises
         if (handler) {
-          // Allow handler to log message
+          logger.log(
+            withAdditionalInfo(
+              `[RNUnityCommBridge] Handling ${message.m_sKey} message from Unity`,
+              message.m_sAdditionalInfo,
+            ),
+            message,
+          );
           handler(message);
         }
 

--- a/src/entities/unity/lib/hook/useRNUnityCommBridge.ts
+++ b/src/entities/unity/lib/hook/useRNUnityCommBridge.ts
@@ -3,6 +3,7 @@ import { RefObject, useCallback, useRef } from 'react';
 import RNUnityView from '@azesmway/react-native-unity';
 import { v4 as uuidv4 } from 'uuid';
 
+import { withAdditionalInfo } from '@app/shared/lib/services/Logger';
 import { getDefaultLogger } from '@app/shared/lib/services/loggerInstance';
 import { ILogger } from '@app/shared/lib/types/logger';
 
@@ -67,7 +68,10 @@ export const useRNUnityCommBridge = ({
         }
 
         logger.log(
-          `[RNUnityCommBridge] Sending ${message.m_sKey} message to Unity${message.m_sAdditionalInfo ? ': ' + message.m_sAdditionalInfo : ''}`,
+          withAdditionalInfo(
+            `[RNUnityCommBridge] Sending ${message.m_sKey} message to Unity`,
+            message.m_sAdditionalInfo,
+          ),
           message,
         );
         rnUnityViewRef.current.postMessage(
@@ -83,7 +87,10 @@ export const useRNUnityCommBridge = ({
         }
       } else {
         logger.warn(
-          `[RNUnityCommBridge] RNUnityView not ready. Not sending ${message.m_sKey} message to Unity${message.m_sAdditionalInfo ? ': ' + message.m_sAdditionalInfo : ''}`,
+          withAdditionalInfo(
+            `[RNUnityCommBridge] RNUnityView not ready. Not sending ${message.m_sKey} message to Unity`,
+            message.m_sAdditionalInfo,
+          ),
           message,
         );
         rejectPromise(new Error('RNUnityView not ready'));
@@ -91,7 +98,10 @@ export const useRNUnityCommBridge = ({
 
       return promise.then(response => {
         logger.log(
-          `[RNUnityCommBridge] Sent ${message.m_sKey} message to Unity${response?.m_sAdditionalInfo ? ': ' + response.m_sAdditionalInfo : ''}`,
+          withAdditionalInfo(
+            `[RNUnityCommBridge] Sent ${message.m_sKey} message to Unity`,
+            response?.m_sAdditionalInfo,
+          ),
           response ?? undefined,
         );
         return response;
@@ -145,7 +155,10 @@ export const useRNUnityCommBridge = ({
         // Log messages without handler or resolved promise
         if (!handler && !promiseFns) {
           logger.log(
-            `[RNUnityCommBridge] Received ${message.m_sKey} message from Unity${message.m_sAdditionalInfo ? ': ' + message.m_sAdditionalInfo : ''}`,
+            withAdditionalInfo(
+              `[RNUnityCommBridge] Received ${message.m_sKey} message from Unity`,
+              message.m_sAdditionalInfo,
+            ),
             message,
           );
         }

--- a/src/entities/unity/lib/hook/useRNUnityCommBridge.ts
+++ b/src/entities/unity/lib/hook/useRNUnityCommBridge.ts
@@ -67,7 +67,7 @@ export const useRNUnityCommBridge = ({
         }
 
         logger.log(
-          `[RNUnityCommBridge] Sending ${message.m_sKey} message to Unity`,
+          `[RNUnityCommBridge] Sending ${message.m_sKey} message to Unity${message.m_sAdditionalInfo ? ': ' + message.m_sAdditionalInfo : ''}`,
           message,
         );
         rnUnityViewRef.current.postMessage(
@@ -83,7 +83,7 @@ export const useRNUnityCommBridge = ({
         }
       } else {
         logger.warn(
-          `[RNUnityCommBridge] RNUnityView not ready. Not sending ${message.m_sKey} message to Unity`,
+          `[RNUnityCommBridge] RNUnityView not ready. Not sending ${message.m_sKey} message to Unity${message.m_sAdditionalInfo ? ': ' + message.m_sAdditionalInfo : ''}`,
           message,
         );
         rejectPromise(new Error('RNUnityView not ready'));
@@ -91,7 +91,7 @@ export const useRNUnityCommBridge = ({
 
       return promise.then(response => {
         logger.log(
-          `[RNUnityCommBridge] Sent ${message.m_sKey} message to Unity`,
+          `[RNUnityCommBridge] Sent ${message.m_sKey} message to Unity${response?.m_sAdditionalInfo ? ': ' + response.m_sAdditionalInfo : ''}`,
           response ?? undefined,
         );
         return response;
@@ -145,7 +145,7 @@ export const useRNUnityCommBridge = ({
         // Log messages without handler or resolved promise
         if (!handler && !promiseFns) {
           logger.log(
-            `[RNUnityCommBridge] Received ${message.m_sKey} message from Unity`,
+            `[RNUnityCommBridge] Received ${message.m_sKey} message from Unity${message.m_sAdditionalInfo ? ': ' + message.m_sAdditionalInfo : ''}`,
             message,
           );
         }

--- a/src/entities/unity/lib/hook/useRNUnityCommBridge.ts
+++ b/src/entities/unity/lib/hook/useRNUnityCommBridge.ts
@@ -109,38 +109,45 @@ export const useRNUnityCommBridge = ({
 
   const handleMessageFromUnity = useCallback(
     (messageString: string) => {
-      logger.info(
-        `[RNUnityCommBridge] Received message string from Unity: ${messageString}`,
-      );
-
       let message: U2RNMessage | null;
       try {
         message = JSON.parse(messageString) as U2RNMessage;
       } catch (err) {
+        // Log error on messages that cannot be parsed
         logger.error(
           `[RNUnityCommBridge] Error parsing message from Unity: ${(err as Error).message}`,
+          { messageString },
         );
         message = null;
       }
       if (message) {
-        // Call registered handler before resolving promises.
         const handler = eventHandlersRef.current[message.m_sKey];
+        const promiseFns = message.m_sId
+          ? inFlightMessagesRef.current[message.m_sId]
+          : null;
+
+        // Call registered handler before resolving promises
         if (handler) {
+          // Allow handler to log message
           handler(message);
         }
 
-        if (message.m_sId) {
-          // For messages with message ID (there should always be one, but we
-          // should still check just in case), attempt to resolve any pending
-          // promises.
-          const promiseFns = inFlightMessagesRef.current[message.m_sId];
-          if (promiseFns) {
-            const [resolvePromise] = promiseFns;
-            resolvePromise(message);
+        // Attempt to resolve any pending promises
+        if (promiseFns) {
+          const [resolvePromise] = promiseFns;
 
-            // Clear the saved promise resolver/rejector after use
-            delete inFlightMessagesRef.current[message.m_sId];
-          }
+          // Allow promise consumer to log message
+          resolvePromise(message);
+          // Clear the saved promise resolver/rejector after use
+          delete inFlightMessagesRef.current[message.m_sId];
+        }
+
+        // Log messages without handler or resolved promise
+        if (!handler && !promiseFns) {
+          logger.log(
+            `[RNUnityCommBridge] Received ${message.m_sKey} message from Unity`,
+            message,
+          );
         }
       }
     },

--- a/src/entities/unity/lib/hook/useRNUnityCommBridge.ts
+++ b/src/entities/unity/lib/hook/useRNUnityCommBridge.ts
@@ -66,30 +66,36 @@ export const useRNUnityCommBridge = ({
           ];
         }
 
-        const messagePayload = [
+        logger.log(
+          `[RNUnityCommBridge] Sending ${message.m_sKey} message to Unity`,
+          message,
+        );
+        rnUnityViewRef.current.postMessage(
           'ReactCommunicationBridge',
           'ReceiveReactMessage',
           JSON.stringify(message),
-        ] as [string, string, string];
-        logger.log(
-          `[RNUnityCommBridge] Sending message to Unity: ${JSON.stringify(messagePayload)}`,
         );
-        rnUnityViewRef.current.postMessage(...messagePayload);
 
-        // If there is not a message ID (there should always be one, but we
-        // should still check just in case), then immediately resolve the
-        // promise.
+        // If there is no message ID (there should always be one, but we should
+        // still check just in case), then immediately resolve the promise.
         if (!message.m_sId) {
           resolvePromise(null);
         }
       } else {
         logger.warn(
-          `[RNUnityCommBridge] RNUnityView not ready. Not sending message: ${JSON.stringify(message)}`,
+          `[RNUnityCommBridge] RNUnityView not ready. Not sending ${message.m_sKey} message to Unity`,
+          message,
         );
         rejectPromise(new Error('RNUnityView not ready'));
       }
 
-      return promise;
+      return promise.then(response => {
+        logger.log(
+          `[RNUnityCommBridge] Sent ${message.m_sKey} message to Unity`,
+          response ?? undefined,
+        );
+        return response;
+      });
     },
     [logger, rnUnityViewRef],
   );

--- a/src/entities/unity/lib/hook/useUnityLifecycle.ts
+++ b/src/entities/unity/lib/hook/useUnityLifecycle.ts
@@ -8,6 +8,7 @@ import RNOrientationDirector, {
 import { v4 as uuidv4 } from 'uuid';
 
 import { ActivityIdentityContext } from '@app/features/pass-survey/lib/contexts/ActivityIdentityContext';
+import { withAdditionalInfo } from '@app/shared/lib/services/Logger';
 import { getDefaultLogger } from '@app/shared/lib/services/loggerInstance';
 import { ILogger } from '@app/shared/lib/types/logger';
 import {
@@ -143,7 +144,10 @@ export const useUnityLifecycle = (options: UseUnityLifecycleOptions) => {
         unityReadyHandled.current = true;
         restartInProgressRef.current = false;
         logger.log(
-          `[UnityView] Handling ${UnityEventUnityStarted} message${msg.m_sAdditionalInfo ? ': ' + msg.m_sAdditionalInfo : ''}`,
+          withAdditionalInfo(
+            `[UnityView] Handling ${UnityEventUnityStarted} message`,
+            msg.m_sAdditionalInfo,
+          ),
           msg,
         );
         if (startupTimerRef.current) {
@@ -177,7 +181,10 @@ export const useUnityLifecycle = (options: UseUnityLifecycleOptions) => {
     async msg => {
       try {
         logger.log(
-          `[UnityView] Handling ${UnityEventEndUnity} message${msg.m_sAdditionalInfo ? ': ' + msg.m_sAdditionalInfo : ''}`,
+          withAdditionalInfo(
+            `[UnityView] Handling ${UnityEventEndUnity} message`,
+            msg.m_sAdditionalInfo,
+          ),
           msg,
         );
         stopHeartbeat();
@@ -221,7 +228,10 @@ export const useUnityLifecycle = (options: UseUnityLifecycleOptions) => {
     msg => {
       if (msg.m_sKey === UnityEventDataExport) {
         logger.log(
-          `[UnityView] Handling ${UnityEventDataExport} message${msg.m_sAdditionalInfo ? ': ' + msg.m_sAdditionalInfo : ''}`,
+          withAdditionalInfo(
+            `[UnityView] Handling ${UnityEventDataExport} message`,
+            msg.m_sAdditionalInfo,
+          ),
           msg,
         );
 
@@ -240,7 +250,10 @@ export const useUnityLifecycle = (options: UseUnityLifecycleOptions) => {
       if (msg.m_sKey === UnityEventSetOrientation) {
         const orientationValue = msg.m_sAdditionalInfo;
         logger.log(
-          `[UnityView] Handling ${UnityEventSetOrientation} message${msg.m_sAdditionalInfo ? ': ' + msg.m_sAdditionalInfo : ''}`,
+          withAdditionalInfo(
+            `[UnityView] Handling ${UnityEventSetOrientation} message`,
+            msg.m_sAdditionalInfo,
+          ),
           msg,
         );
 

--- a/src/entities/unity/lib/hook/useUnityLifecycle.ts
+++ b/src/entities/unity/lib/hook/useUnityLifecycle.ts
@@ -8,7 +8,6 @@ import RNOrientationDirector, {
 import { v4 as uuidv4 } from 'uuid';
 
 import { ActivityIdentityContext } from '@app/features/pass-survey/lib/contexts/ActivityIdentityContext';
-import { withAdditionalInfo } from '@app/shared/lib/services/Logger';
 import { getDefaultLogger } from '@app/shared/lib/services/loggerInstance';
 import { ILogger } from '@app/shared/lib/types/logger';
 import {
@@ -138,18 +137,11 @@ export const useUnityLifecycle = (options: UseUnityLifecycleOptions) => {
   }, [logger, resetFailureState, stopHeartbeat]);
 
   // Register Unity ready handler via the `UnityStarted` event.
-  const handleUnityStarted = useCallback<RNUnityCommBridgeUnityEventHandler>(
-    async msg => {
+  const handleUnityStarted =
+    useCallback<RNUnityCommBridgeUnityEventHandler>(async () => {
       if (!unityReadyHandled.current) {
         unityReadyHandled.current = true;
         restartInProgressRef.current = false;
-        logger.log(
-          withAdditionalInfo(
-            `[UnityView] Handling ${UnityEventUnityStarted} message`,
-            msg.m_sAdditionalInfo,
-          ),
-          msg,
-        );
         if (startupTimerRef.current) {
           clearTimeout(startupTimerRef.current);
           startupTimerRef.current = null;
@@ -170,23 +162,14 @@ export const useUnityLifecycle = (options: UseUnityLifecycleOptions) => {
 
         await handleUnityReady();
       }
-    },
-    [handleUnityReady, logger, startHeartbeat],
-  );
+    }, [handleUnityReady, logger, startHeartbeat]);
   useEffect(() => {
     registerEventHandler(UnityEventUnityStarted, handleUnityStarted);
   }, [handleUnityStarted, registerEventHandler]);
 
-  const handleEndUnity = useCallback<RNUnityCommBridgeUnityEventHandler>(
-    async msg => {
+  const handleEndUnity =
+    useCallback<RNUnityCommBridgeUnityEventHandler>(async () => {
       try {
-        logger.log(
-          withAdditionalInfo(
-            `[UnityView] Handling ${UnityEventEndUnity} message`,
-            msg.m_sAdditionalInfo,
-          ),
-          msg,
-        );
         stopHeartbeat();
         logger.log(
           `[UnityView] unityPaths: ${JSON.stringify(unityPaths.current)}`,
@@ -217,9 +200,7 @@ export const useUnityLifecycle = (options: UseUnityLifecycleOptions) => {
       } catch (err) {
         logger.error(`[UnityView] EndUnity handler failed: ${err}`);
       }
-    },
-    [logger, onResponse, sendMessageToUnity, stopHeartbeat],
-  );
+    }, [logger, onResponse, sendMessageToUnity, stopHeartbeat]);
   useEffect(() => {
     registerEventHandler(UnityEventEndUnity, handleEndUnity);
   }, [handleEndUnity, registerEventHandler]);
@@ -227,14 +208,6 @@ export const useUnityLifecycle = (options: UseUnityLifecycleOptions) => {
   const handleDataExport = useCallback<RNUnityCommBridgeUnityEventHandler>(
     msg => {
       if (msg.m_sKey === UnityEventDataExport) {
-        logger.log(
-          withAdditionalInfo(
-            `[UnityView] Handling ${UnityEventDataExport} message`,
-            msg.m_sAdditionalInfo,
-          ),
-          msg,
-        );
-
         unityPaths.current = [...unityPaths.current, ...msg.m_listDataPaths];
       }
     },
@@ -249,13 +222,6 @@ export const useUnityLifecycle = (options: UseUnityLifecycleOptions) => {
     msg => {
       if (msg.m_sKey === UnityEventSetOrientation) {
         const orientationValue = msg.m_sAdditionalInfo;
-        logger.log(
-          withAdditionalInfo(
-            `[UnityView] Handling ${UnityEventSetOrientation} message`,
-            msg.m_sAdditionalInfo,
-          ),
-          msg,
-        );
 
         const orientationMap: Record<
           string,

--- a/src/entities/unity/lib/types/unityMessage.ts
+++ b/src/entities/unity/lib/types/unityMessage.ts
@@ -18,6 +18,7 @@ export type UnityEvent =
 type U2RNMessageBase<TUnityEvent extends UnityEvent> = {
   m_sId: string;
   m_sKey: TUnityEvent;
+  m_sAdditionalInfo?: string;
   [key: string]: unknown;
 };
 

--- a/src/entities/unity/ui/UnityView.tsx
+++ b/src/entities/unity/ui/UnityView.tsx
@@ -23,6 +23,7 @@ import {
 } from '../lib/hook/useRNUnityCommBridge';
 import {
   RN2UMessage,
+  UnityEventDataExport,
   UnityEventEndUnity,
   UnityEventSetOrientation,
   UnityEventUnityStarted,
@@ -76,23 +77,31 @@ export const UnityView: FC<Props> = props => {
   }, [props.payload.file, logger, sendMessageToUnity]);
 
   // Register Unity ready handler via the `UnityStarted` event.
-  const handleUnityStarted =
-    useCallback<RNUnityCommBridgeUnityEventHandler>(async () => {
+  const handleUnityStarted = useCallback<RNUnityCommBridgeUnityEventHandler>(
+    async msg => {
       if (!unityReadyHandled.current) {
         unityReadyHandled.current = true;
-        logger.log('[UnityView] Handling Unity ready event');
+        logger.log(
+          `[UnityView] Handling ${UnityEventUnityStarted} message`,
+          msg,
+        );
         await handleUnityReady();
       } else {
-        logger.log('[UnityView] Ignoring Unity ready event');
+        logger.log(
+          `[UnityView] Ignoring ${UnityEventUnityStarted} message`,
+          msg,
+        );
       }
-    }, [logger, handleUnityReady]);
+    },
+    [logger, handleUnityReady],
+  );
   useEffect(() => {
     registerEventHandler(UnityEventUnityStarted, handleUnityStarted);
   }, [handleUnityStarted, registerEventHandler]);
 
-  const handleEndUnity =
-    useCallback<RNUnityCommBridgeUnityEventHandler>(async () => {
-      logger.log('[UnityView] Handling EndUnity event');
+  const handleEndUnity = useCallback<RNUnityCommBridgeUnityEventHandler>(
+    async msg => {
+      logger.log(`[UnityView] Handling ${UnityEventEndUnity} message`, msg);
       logger.log(
         `[UnityView] unityPaths: ${JSON.stringify(unityPaths.current)}`,
       );
@@ -123,17 +132,17 @@ export const UnityView: FC<Props> = props => {
       logger.log('[UnityView] Sending Reset message', resetMsg);
       const resp = await sendMessageToUnity(resetMsg);
       logger.log('[UnityView] Sent Reset message', resp ?? undefined);
-    }, [logger, props, sendMessageToUnity]);
+    },
+    [logger, props, sendMessageToUnity],
+  );
   useEffect(() => {
     registerEventHandler(UnityEventEndUnity, handleEndUnity);
   }, [handleEndUnity, registerEventHandler]);
 
   const handleDataExport = useCallback<RNUnityCommBridgeUnityEventHandler>(
     msg => {
-      if (msg.m_sKey === 'DataExport') {
-        logger.log(
-          `[UnityView] Received DataExport message with paths: ${msg.m_listDataPaths.join(', ')}`,
-        );
+      if (msg.m_sKey === UnityEventDataExport) {
+        logger.log(`[UnityView] Handling ${UnityEventDataExport} message`, msg);
 
         unityPaths.current = [...unityPaths.current, ...msg.m_listDataPaths];
       }
@@ -141,7 +150,7 @@ export const UnityView: FC<Props> = props => {
     [logger],
   );
   useEffect(() => {
-    registerEventHandler('DataExport', handleDataExport);
+    registerEventHandler(UnityEventDataExport, handleDataExport);
   }, [handleDataExport, registerEventHandler]);
 
   // Register a backup Unity ready handler via a `Echo` message.
@@ -156,10 +165,14 @@ export const UnityView: FC<Props> = props => {
           if (resp?.m_sAdditionalInfo === backupCheckPayload) {
             if (!unityReadyHandled.current) {
               unityReadyHandled.current = true;
-              logger.log('[UnityView] Handling Unity ready backup check');
+              logger.log(
+                `[UnityView] Handling ${UnityEventUnityStarted} backup check`,
+              );
               handleUnityReady().catch(logger.error);
             } else {
-              logger.log('[UnityView] Ignoring Unity ready backup check');
+              logger.log(
+                `[UnityView] Ignoring ${UnityEventUnityStarted} backup check`,
+              );
             }
           }
         })
@@ -178,7 +191,10 @@ export const UnityView: FC<Props> = props => {
     msg => {
       if (msg.m_sKey === 'SetOrientation') {
         const orientationValue = msg.m_sAdditionalInfo;
-        logger.log(`[UnityView] Received SetOrientation: ${orientationValue}`);
+        logger.log(
+          `[UnityView] Handling ${UnityEventSetOrientation} message`,
+          msg,
+        );
 
         const orientationMap: Record<
           string,

--- a/src/entities/unity/ui/UnityView.tsx
+++ b/src/entities/unity/ui/UnityView.tsx
@@ -74,13 +74,13 @@ export const UnityView: FC<Props> = props => {
       if (!unityReadyHandled.current) {
         unityReadyHandled.current = true;
         logger.log(
-          `[UnityView] Handling ${UnityEventUnityStarted} message`,
+          `[UnityView] Handling ${UnityEventUnityStarted} message${msg.m_sAdditionalInfo ? ': ' + msg.m_sAdditionalInfo : ''}`,
           msg,
         );
         await handleUnityReady();
       } else {
         logger.log(
-          `[UnityView] Ignoring ${UnityEventUnityStarted} message`,
+          `[UnityView] Ignoring ${UnityEventUnityStarted} message${msg.m_sAdditionalInfo ? ': ' + msg.m_sAdditionalInfo : ''}`,
           msg,
         );
       }
@@ -93,7 +93,10 @@ export const UnityView: FC<Props> = props => {
 
   const handleEndUnity = useCallback<RNUnityCommBridgeUnityEventHandler>(
     async msg => {
-      logger.log(`[UnityView] Handling ${UnityEventEndUnity} message`, msg);
+      logger.log(
+        `[UnityView] Handling ${UnityEventEndUnity} message${msg.m_sAdditionalInfo ? ': ' + msg.m_sAdditionalInfo : ''}`,
+        msg,
+      );
       logger.log(
         `[UnityView] unityPaths: ${JSON.stringify(unityPaths.current)}`,
       );
@@ -132,7 +135,10 @@ export const UnityView: FC<Props> = props => {
   const handleDataExport = useCallback<RNUnityCommBridgeUnityEventHandler>(
     msg => {
       if (msg.m_sKey === UnityEventDataExport) {
-        logger.log(`[UnityView] Handling ${UnityEventDataExport} message`, msg);
+        logger.log(
+          `[UnityView] Handling ${UnityEventDataExport} message${msg.m_sAdditionalInfo ? ': ' + msg.m_sAdditionalInfo : ''}`,
+          msg,
+        );
 
         unityPaths.current = [...unityPaths.current, ...msg.m_listDataPaths];
       }
@@ -180,7 +186,7 @@ export const UnityView: FC<Props> = props => {
       if (msg.m_sKey === UnityEventSetOrientation) {
         const orientationValue = msg.m_sAdditionalInfo;
         logger.log(
-          `[UnityView] Handling ${UnityEventSetOrientation} message`,
+          `[UnityView] Handling ${UnityEventSetOrientation} message${msg.m_sAdditionalInfo ? ': ' + msg.m_sAdditionalInfo : ''}`,
           msg,
         );
 

--- a/src/entities/unity/ui/UnityView.tsx
+++ b/src/entities/unity/ui/UnityView.tsx
@@ -189,7 +189,7 @@ export const UnityView: FC<Props> = props => {
   // Handle orientation change requests from Unity, re-lock to portrait on unmount.
   const handleSetOrientation = useCallback<RNUnityCommBridgeUnityEventHandler>(
     msg => {
-      if (msg.m_sKey === 'SetOrientation') {
+      if (msg.m_sKey === UnityEventSetOrientation) {
         const orientationValue = msg.m_sAdditionalInfo;
         logger.log(
           `[UnityView] Handling ${UnityEventSetOrientation} message`,

--- a/src/entities/unity/ui/UnityView.tsx
+++ b/src/entities/unity/ui/UnityView.tsx
@@ -64,15 +64,7 @@ export const UnityView: FC<Props> = props => {
         m_sKey: 'LoadConfigFile',
         m_sAdditionalInfo: props.payload.file ?? undefined,
       };
-      logger.log('[UnityView] Sending LoadConfigFile message', msg);
-      sendMessageToUnity(msg)
-        .then(resp => {
-          logger.log(
-            '[UnityView] Sent LoadConfigFile message',
-            resp ?? undefined,
-          );
-        })
-        .catch(logger.error);
+      sendMessageToUnity(msg).catch(logger.error);
     }, 5000);
   }, [props.payload.file, logger, sendMessageToUnity]);
 
@@ -129,9 +121,7 @@ export const UnityView: FC<Props> = props => {
         m_sId: uuidv4(),
         m_sKey: 'Reset',
       };
-      logger.log('[UnityView] Sending Reset message', resetMsg);
-      const resp = await sendMessageToUnity(resetMsg);
-      logger.log('[UnityView] Sent Reset message', resp ?? undefined);
+      await sendMessageToUnity(resetMsg);
     },
     [logger, props, sendMessageToUnity],
   );
@@ -158,10 +148,8 @@ export const UnityView: FC<Props> = props => {
     if (!!unityViewKey && !unityViewKeyWas) {
       const backupCheckPayload = `BackupUnityStartedCheck:${uuidv4()}`;
       const msg: RN2UMessage = newEchoMessage(backupCheckPayload);
-      logger.log('[UnityView] Sending Echo message', msg);
       sendMessageToUnity(msg)
         .then(resp => {
-          logger.log('[UnityView] Sent Echo message', resp ?? undefined);
           if (resp?.m_sAdditionalInfo === backupCheckPayload) {
             if (!unityReadyHandled.current) {
               unityReadyHandled.current = true;

--- a/src/entities/unity/ui/UnityView.tsx
+++ b/src/entities/unity/ui/UnityView.tsx
@@ -22,6 +22,7 @@ import {
   newEchoMessage,
 } from '../lib/hook/useRNUnityCommBridge';
 import {
+  RN2UMessage,
   UnityEventEndUnity,
   UnityEventSetOrientation,
   UnityEventUnityStarted,
@@ -55,15 +56,20 @@ export const UnityView: FC<Props> = props => {
     // config JSON. But for some reasons the `UnityStart` message never arrives
     // and the "backup" check below resolves too soon. So for now, to continue
     // testing we have to wait like 5 seconds for the loading screen to show.
-    logger.log('!!! Waiting before sending LoadConfigFile message ...');
+    logger.log('[UnityView] Waiting before sending LoadConfigFile message...');
     setTimeout(() => {
-      sendMessageToUnity({
+      const msg: RN2UMessage = {
         m_sId: uuidv4(),
         m_sKey: 'LoadConfigFile',
         m_sAdditionalInfo: props.payload.file ?? undefined,
-      })
+      };
+      logger.log('[UnityView] Sending LoadConfigFile message', msg);
+      sendMessageToUnity(msg)
         .then(resp => {
-          logger.log(`!!! LoadConfigFile resp: ${JSON.stringify(resp)}`);
+          logger.log(
+            '[UnityView] Sent LoadConfigFile message',
+            resp ?? undefined,
+          );
         })
         .catch(logger.error);
     }, 5000);
@@ -110,14 +116,13 @@ export const UnityView: FC<Props> = props => {
         taskData: mediaFiles,
       });
 
-      logger.log('[UnityView] Sending Reset message');
-
-      await sendMessageToUnity({
+      const resetMsg: RN2UMessage = {
         m_sId: uuidv4(),
         m_sKey: 'Reset',
-      });
-
-      logger.log('[UnityView] Sent Reset message');
+      };
+      logger.log('[UnityView] Sending Reset message', resetMsg);
+      const resp = await sendMessageToUnity(resetMsg);
+      logger.log('[UnityView] Sent Reset message', resp ?? undefined);
     }, [logger, props, sendMessageToUnity]);
   useEffect(() => {
     registerEventHandler(UnityEventEndUnity, handleEndUnity);
@@ -143,8 +148,11 @@ export const UnityView: FC<Props> = props => {
   useEffect(() => {
     if (!!unityViewKey && !unityViewKeyWas) {
       const backupCheckPayload = `BackupUnityStartedCheck:${uuidv4()}`;
-      sendMessageToUnity(newEchoMessage(backupCheckPayload))
+      const msg: RN2UMessage = newEchoMessage(backupCheckPayload);
+      logger.log('[UnityView] Sending Echo message', msg);
+      sendMessageToUnity(msg)
         .then(resp => {
+          logger.log('[UnityView] Sent Echo message', resp ?? undefined);
           if (resp?.m_sAdditionalInfo === backupCheckPayload) {
             if (!unityReadyHandled.current) {
               unityReadyHandled.current = true;

--- a/src/shared/lib/services/Logger.ts
+++ b/src/shared/lib/services/Logger.ts
@@ -24,6 +24,13 @@ import {
 } from '../utils/common';
 import { isAppOnline } from '../utils/networkHelpers';
 
+export const withAdditionalInfo = (
+  message: string,
+  additionalInfo?: string,
+): string => {
+  return additionalInfo ? `${message}: ${additionalInfo}` : message;
+};
+
 export class Logger implements ILogger {
   private mutex: IMutex;
 

--- a/src/shared/lib/services/Logger.ts
+++ b/src/shared/lib/services/Logger.ts
@@ -252,37 +252,37 @@ export class Logger implements ILogger {
     }
   }
 
-  public log(message: string) {
+  public log(message: string, context?: object) {
     if (this.consoleLogLevel <= LogLevel.Debug) {
       console.log(this.withTime(message));
-      DdLogs.info(message);
+      DdLogs.info(message, context);
     }
 
     callWithMutex(this.mutex, () => FileLogger.debug(message));
   }
 
-  public info(message: string) {
+  public info(message: string, context?: object) {
     if (this.consoleLogLevel <= LogLevel.Info) {
       console.info(this.withTime(message));
-      DdLogs.info(message);
+      DdLogs.info(message, context);
     }
 
     callWithMutex(this.mutex, () => FileLogger.info(message));
   }
 
-  public warn(message: string) {
+  public warn(message: string, context?: object) {
     if (this.consoleLogLevel <= LogLevel.Warning) {
       console.warn(this.withTime(message));
-      DdLogs.warn(message);
+      DdLogs.warn(message, context);
     }
 
     callWithMutex(this.mutex, () => FileLogger.warn(message));
   }
 
-  public error(message: string) {
+  public error(message: string, context?: object) {
     if (this.consoleLogLevel <= LogLevel.Error) {
       console.error(this.withTime(message));
-      DdLogs.error(message);
+      DdLogs.error(message, context);
     }
 
     callWithMutex(this.mutex, () => FileLogger.error(message));

--- a/src/shared/lib/types/logger.ts
+++ b/src/shared/lib/types/logger.ts
@@ -21,10 +21,10 @@ export type DeviceInfoLogObject = {
 };
 
 export interface ILogger {
-  log: (message: string) => void;
-  info: (message: string) => void;
-  warn: (message: string) => void;
-  error: (message: string) => void;
+  log: (message: string, context?: object) => void;
+  info: (message: string, context?: object) => void;
+  warn: (message: string, context?: object) => void;
+  error: (message: string, context?: object) => void;
   configure: () => void;
   send: () => Promise<boolean>;
   cancelSending: () => void;


### PR DESCRIPTION
🔗 [Jira Ticket M2-10492](https://mindlogger.atlassian.net/browse/M2-10492)

We are already successfully sending Unity logs to Datadog via:
1. @TwigAy-CMI sending Unity logs to React Native in [ChildMindInstitute/Unity-Cognitive-Task-Creator](https://github.com/ChildMindInstitute/Unity-Cognitive-Task-Creator)
2. @aweiland sending React Native logs to Datadog in #1056

However, the config file logged with the `LoadConfigFile` Unity event is backslash and comma-to-hyphen escaped and difficult to parse from Datadog logs. To allow direct access to Unity event data in Datadog, this PR adds logging of Unity events `RN2UMessage` and `U2RNMessage` as Datadog [`Context`](https://docs.datadoghq.com/logs/log_collection/javascript/?tab=npm#custom-logs). The PR also appends `m_sAdditionalInfo` to the Unity event logs to allow for easier full-text search in Datadog.

`LoadConfigFile` Datadog Log Before ([link](https://app.datadoghq.com/logs?query=env%3Adev%20service%3Amindlogger-mobile%20RNUnityCommBridge%20LoadConfigFile&agg_m=count&agg_m_source=base&agg_t=count&clustering_pattern_field_path=message&cols=host%2Cservice&messageDisplay=inline&refresh_mode=paused&storage=hot&stream_sort=desc&viz=stream&from_ts=1774972500000&to_ts=1774972800000&live=false)):

```
[RNUnityCommBridge] Received message string from Unity: {
    "m_sId": "MERITEngine-4",
    "m_sKey": "Logging",
    "m_sAdditionalInfo": "183,9.26112350401815,Log-Recieved Message from React- React Message -{\"m_sId\":\"34aed0b3-b6b9-4413-a136-dd8bf2d59b70\"-\"m_sKey\":\"LoadConfigFile\"-\"m_sAdditionalInfo\":\"New Task Data\\n{\\n    \\\"m_sTaskName\\\": \\\"ContinuousTestAbTrials\\\"-\\n    \\\"m_iTaskIndex\\\": 0-\\n    \\\"m_taskTypeCurrent\\\": 6-\\n    \\\"m_bIsGroundActive\\\": true-\\n    \\\"m_listTerrainData\\\": []-\\n    \\\"m_listObjectData\\\": []-\\n...
```

`LoadConfigFile` Datadog Log After ([link](https://app.datadoghq.com/logs?query=env%3Adev%20service%3Amindlogger-mobile%20Unity&agg_m=count&agg_m_source=base&agg_t=count&clustering_pattern_field_path=message&cols=host%2Cservice&messageDisplay=inline&refresh_mode=paused&storage=hot&stream_sort=desc&viz=stream&from_ts=1775080740000&to_ts=1775080800000&live=false)):

```
[RNUnityCommBridge] Sending LoadConfigFile message to Unity: New Task Data
{
    "m_sTaskName": "ContinuousTestAbTrials",
    "m_iTaskIndex": 0,
    "m_taskTypeCurrent": 6,
    "m_bIsGroundActive": true,
    "m_listTerrainData": [],
    "m_listObjectData": [],
    ...
```