### PR TITLE
chore: Bump activesupport from 6.1.7.10 to 7.2.3.1

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -5,12 +5,18 @@ GEM
       base64
       nkf
       rexml
-    activesupport (6.1.7.10)
-      concurrent-ruby (~> 1.0, >= 1.0.2)
+    activesupport (7.2.3.1)
+      base64
+      benchmark (>= 0.3)
+      bigdecimal
+      concurrent-ruby (~> 1.0, >= 1.3.1)
+      connection_pool (>= 2.2.5)
+      drb
       i18n (>= 1.6, < 2)
-      minitest (>= 5.1)
-      tzinfo (~> 2.0)
-      zeitwerk (~> 2.3)
+      logger (>= 1.4.2)
+      minitest (>= 5.1, < 6)
+      securerandom (>= 0.3)
+      tzinfo (~> 2.0, >= 2.0.5)
     addressable (2.8.7)
       public_suffix (>= 2.0.2, < 7.0)
     algoliasearch (1.27.5)
@@ -80,13 +86,15 @@ GEM
     colored2 (3.1.2)
     commander (4.6.0)
       highline (~> 2.0.0)
-    concurrent-ruby (1.2.2)
+    concurrent-ruby (1.3.3)
+    connection_pool (3.0.2)
     declarative (0.0.20)
     digest-crc (0.6.5)
       rake (>= 12.0.0, < 14.0.0)
     domain_name (0.5.20190701)
       unf (>= 0.0.5, < 1.0.0)
     dotenv (2.8.1)
+    drb (2.2.3)
     emoji_regex (3.2.3)
     escape (0.0.4)
     ethon (0.16.0)
@@ -213,7 +221,7 @@ GEM
     http-cookie (1.0.6)
       domain_name (~> 0.5)
     httpclient (2.8.3)
-    i18n (1.14.1)
+    i18n (1.14.8)
       concurrent-ruby (~> 1.0)
     jmespath (1.6.2)
     json (2.7.2)
@@ -222,7 +230,7 @@ GEM
     logger (1.7.0)
     mini_magick (4.13.1)
     mini_mime (1.1.5)
-    minitest (5.20.0)
+    minitest (5.27.0)
     molinillo (0.8.0)
     multi_json (1.15.0)
     multipart-post (2.4.1)
@@ -247,6 +255,7 @@ GEM
     ruby-macho (2.5.1)
     ruby2_keywords (0.0.5)
     rubyzip (2.3.2)
+    securerandom (0.4.1)
     security (0.1.5)
     signet (0.18.0)
       addressable (~> 2.8)
@@ -285,7 +294,6 @@ GEM
       rouge (~> 2.0.7)
     xcpretty-travis-formatter (1.0.1)
       xcpretty (~> 0.2, >= 0.0.7)
-    zeitwerk (2.6.18)
 
 PLATFORMS
   ruby


### PR DESCRIPTION
### 📝 Description

Updates the ActiveSupport dependency to remediate a security vulnerability affecting versions < 7.2.3.1.

🔗 https://mindlogger.atlassian.net/browse/M2-10643

### Changes include:

Bumps activesupport from 6.1.7.10 to 7.2.3.1

###🪤 Peer Testing

- Run yarn pods
- Run yarn ios
- Verify iOS build succeeds
- Verify smoke test passes