### PR TITLE
fix: Added password required to password recovery form validation

### DIFF
--- a/src/features/password-recovery/model/PasswordRecoveryFormSchema.ts
+++ b/src/features/password-recovery/model/PasswordRecoveryFormSchema.ts
@@ -4,7 +4,11 @@ import { passwordSuperRefine } from '@app/shared/lib/utils/passwordValidation';
 
 export const PasswordRecoveryFormSchema = z
   .object({
-    newPassword: z.string().trim().superRefine(passwordSuperRefine()),
+    newPassword: z
+      .string()
+      .trim()
+      .min(1, 'form_item:required')
+      .superRefine(passwordSuperRefine()),
     // No char-type validation needed - the passwords-must-match refine below
     // guarantees confirmPassword satisfies the same rules as newPassword.
     confirmPassword: z

--- a/src/features/password-recovery/model/PasswordRecoveryFormSchema.ts
+++ b/src/features/password-recovery/model/PasswordRecoveryFormSchema.ts
@@ -6,7 +6,6 @@ export const PasswordRecoveryFormSchema = z
   .object({
     newPassword: z
       .string()
-      .trim()
       .min(1, 'form_item:required')
       .superRefine(passwordSuperRefine()),
     // No char-type validation needed - the passwords-must-match refine below

--- a/src/shared/lib/utils/passwordValidation.ts
+++ b/src/shared/lib/utils/passwordValidation.ts
@@ -166,6 +166,10 @@ export const passwordSuperRefine = (): ((
       ctx.addIssue({
         code: z.ZodIssueCode.custom,
         message: PasswordErrorKey.MUST_INCLUDE,
+        params: {
+          minLength: PASSWORD_MIN_LENGTH,
+          types: ACCOUNT_PASSWORD_MIN_CHAR_TYPES,
+        },
       });
     }
 
@@ -173,6 +177,9 @@ export const passwordSuperRefine = (): ((
       ctx.addIssue({
         code: z.ZodIssueCode.custom,
         message: PasswordErrorKey.MIN_LENGTH,
+        params: {
+          minLength: PASSWORD_MIN_LENGTH,
+        },
       });
     }
 


### PR DESCRIPTION
### 📝 Description

<!-- JIRA ticket, link to it by replacing `#` with ticket number -->
🔗 [Bug Ticket M2-#10676](https://mindlogger.atlassian.net/browse/M2-10676)

<!-- Replace this with a high-level description of the features/functionality proposed in the pull request. -->
On the password recovery screen, when a person is creating a new password, the validation error is showing inline variables names and not the actual values.

Changes include:

- Added a minimum requirement validation so that the input error would only show the minimum requirement error, and not the Enhanced password requirements error. 

### 🪤 Peer Testing
- [ ] Open app on device or in simulator
- [ ] Click on 'Forgot Password'
- [ ] Click the link sent in the email
- [ ] Click Submit with both fields being empty
- [ ] Should see Password is required
- [ ] Enter a value in the New Password field
- [ ] Should see long password requirements error with no variable names in it.

### ✏️ Notes
These changes require testing the functionality within the app before approval.