### PR TITLE
feat: Downgrade Android SDK 29 → 25 (M2-10689)

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,7 +1,7 @@
 buildscript {
     ext {
         buildToolsVersion = "35.0.0"
-        minSdkVersion = 29
+        minSdkVersion = 25
         compileSdkVersion = 35
         targetSdkVersion = 35
         ndkVersion = "27.1.12297006"


### PR DESCRIPTION
### 📝 Description

🔗 [Jira Ticket M2-10689](https://mindlogger.atlassian.net/browse/M2-10689)

Changes include:

- Update `minSdkVersion` in `build.gradle`

### ✏️ Notes

We originally upgraded Android SDK 24 → 29 in commit e8b41c8 of #1086 because [Unity 6000.3 Android requirements and compatibility](https://docs.unity3d.com/6000.3/Documentation/Manual/android-requirements-and-compatibility.html) specifies Android SDK 25+:

> Unity supports Android 7.1 “Nougat” (API level 25) and above.

Android SDK 29 requires Android 10+ which would block some of our users who currently use Android 9. Downgrading to Android SDK 25 restores support for Android 7.1+.