### PR TITLE
docs: add deep-linking requirements to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,6 +177,16 @@ The above scripts run the app using Debug configuration and for Curious's `dev`
 
 For concerns related to Unity integration, see [unity/README.md](unity/README.md)
 
+## Deep Linking
+
+Testing deep linking in the simulator requires access to the organization’s Apple Developer Account and a valid provisioning profile.
+
+Also, make sure the Associated Domains contains the domains:
+`applinks:web-dev.cmiml.net?mode=developer
+webcredentials:web-dev.cmiml.net`
+
+Having mode=developer is essential to work properly in the simulator.
+
 ## License
 
 Common Public Attribution License Version 1.0 (CPAL-1.0)


### PR DESCRIPTION
### 📝 Description

For deep-linking to work in the iOS simulator, you need a valid Provisioning profile from the organization's Apple Developer account. These instructions are provided in this README.md update

[Jira Ticket #M2-10690](https://mindlogger.atlassian.net/browse/M2-10690) 

### ✏️ Notes

If there are any more instructions or notes that you feel would be meaningful to add, please do. 