### PR TITLE
fix: unity view now shows full screen

### DIFF
--- a/src/entities/banner/model/selectors.ts
+++ b/src/entities/banner/model/selectors.ts
@@ -11,3 +11,8 @@ export const bannersBgSelector = createSelector(
   selectBanners,
   banners => banners.bannersBg,
 );
+
+export const bannersHiddenSelector = createSelector(
+  selectBanners,
+  banners => banners.bannersHidden,
+);

--- a/src/entities/banner/model/slice.ts
+++ b/src/entities/banner/model/slice.ts
@@ -20,11 +20,13 @@ type Banner = {
 type InitialState = {
   banners: Banner[];
   bannersBg?: string;
+  bannersHidden: boolean;
 };
 
 const initialState: InitialState = {
   banners: [],
   bannersBg: undefined,
+  bannersHidden: false,
 };
 
 const bannerSlice = createSlice({
@@ -45,6 +47,9 @@ const bannerSlice = createSlice({
     },
     setBannersBg: (state, action: PayloadAction<string | undefined>) => {
       state.bannersBg = action.payload;
+    },
+    setBannersHidden: (state, action: PayloadAction<boolean>) => {
+      state.bannersHidden = action.payload;
     },
   },
 });

--- a/src/entities/banner/ui/Banner.test.tsx
+++ b/src/entities/banner/ui/Banner.test.tsx
@@ -5,13 +5,38 @@ import { useAppState } from '@react-native-community/hooks';
 import { fireEvent, render } from '@testing-library/react-native';
 
 import { TamaguiProvider } from '@app/app/ui/AppProvider/TamaguiProvider';
+import { useAppDispatch } from '@app/shared/lib/hooks/redux';
+import { bannerActions } from '@entities/banner/model/slice';
 
 import { Banner } from './Banner';
+import { UnityView } from '../../unity/ui/UnityView';
 
 // Mock dependencies
 jest.mock('@react-native-community/hooks', () => ({
   useAppState: jest.fn(),
 }));
+
+jest.mock('@app/shared/lib/hooks/redux', () => ({
+  useAppDispatch: jest.fn(),
+}));
+
+jest.mock('../../unity/lib/hook/useUnityLifecycle', () => ({
+  useUnityLifecycle: () => ({
+    rnUnityViewRef: { current: null },
+    unityViewKey: 'test-key',
+    isUnityUnresponsive: false,
+    failureMode: null,
+    flowId: null,
+    showErrorModal: false,
+    isQuitBeforeMount: false,
+    handleErrorModalDismiss: jest.fn(),
+    handleRestartActivity: jest.fn(),
+    handleMessageFromUnity: jest.fn(),
+    handlePlayerUnload: jest.fn(),
+    handlePlayerQuit: jest.fn(),
+  }),
+}));
+
 
 // Mock timer
 jest.useFakeTimers();
@@ -38,6 +63,7 @@ describe('Banner', () => {
     // No close button by default since onClose is not provided
     expect(() => getByLabelText('banner-close')).toThrow();
   });
+
 
   test('renders with custom severity', () => {
     const { getByLabelText } = render(
@@ -202,5 +228,20 @@ describe('Banner', () => {
 
     // Close button should not be visible
     expect(queryByLabelText('banner-close')).toBeNull();
+  });
+
+  test('banners are hidden when UnityView is showing', () => {
+    const mockDispatch = jest.fn();
+    (useAppDispatch as jest.Mock).mockReturnValue(mockDispatch);
+
+    render(
+      <TamaguiProvider>
+        <UnityView payload={{ file: 'test.json' }} />
+      </TamaguiProvider>,
+    );
+
+    expect(mockDispatch).toHaveBeenCalledWith(
+      bannerActions.setBannersHidden(true),
+    );
   });
 });

--- a/src/entities/banner/ui/Banner.test.tsx
+++ b/src/entities/banner/ui/Banner.test.tsx
@@ -37,7 +37,6 @@ jest.mock('../../unity/lib/hook/useUnityLifecycle', () => ({
   }),
 }));
 
-
 // Mock timer
 jest.useFakeTimers();
 
@@ -63,7 +62,6 @@ describe('Banner', () => {
     // No close button by default since onClose is not provided
     expect(() => getByLabelText('banner-close')).toThrow();
   });
-
 
   test('renders with custom severity', () => {
     const { getByLabelText } = render(

--- a/src/entities/banner/ui/Banners.tsx
+++ b/src/entities/banner/ui/Banners.tsx
@@ -19,7 +19,11 @@ import { DEFAULT_BG } from '@entities/banner/lib/constants';
 
 import { Banner, BannerProps } from './Banner';
 import { useBanners } from '../lib/hooks/useBanners';
-import { bannersBgSelector, bannersSelector } from '../model/selectors';
+import {
+  bannersBgSelector,
+  bannersHiddenSelector,
+  bannersSelector,
+} from '../model/selectors';
 import { BannerType } from '../model/slice';
 
 const handleClose = (
@@ -35,6 +39,7 @@ export const Banners = () => {
   const { removeBanner } = useBanners();
   const banners = useAppSelector(bannersSelector);
   const bannersBg = useAppSelector(bannersBgSelector) ?? DEFAULT_BG;
+  const isHidden = useAppSelector(bannersHiddenSelector);
   const { top } = useSafeAreaInsets();
 
   // Animate top safe area background color to match native header background color transition
@@ -47,6 +52,10 @@ export const Banners = () => {
       easing: Easing.out(Easing.ease),
     }),
   }));
+
+  if (isHidden) {
+    return null;
+  }
 
   const sortedBanners = [...banners].sort((a, b) => a.order - b.order);
 

--- a/src/entities/unity/ui/UnityView.tsx
+++ b/src/entities/unity/ui/UnityView.tsx
@@ -3,15 +3,15 @@ import { UIManager } from 'react-native';
 
 import RNUnityView from '@azesmway/react-native-unity';
 
+import { bannerActions } from '@app/entities/banner/model/slice';
 import { UnityPipelineItem } from '@app/features/pass-survey/lib/types/payload';
+import { useAppDispatch } from '@app/shared/lib/hooks/redux';
 import { Spinner } from '@app/shared/ui/Spinner';
 import { Text } from '@app/shared/ui/Text';
 import { UnityResult } from '@entities/unity/lib/types/unityType.ts';
 
 import { UnityErrorModal } from './UnityErrorModal';
 import { useUnityLifecycle } from '../lib/hook/useUnityLifecycle';
-import { useAppDispatch } from '@app/shared/lib/hooks/redux';
-import { bannerActions } from '@app/entities/banner/model/slice';
 
 type Props = {
   payload: UnityPipelineItem['payload'];

--- a/src/entities/unity/ui/UnityView.tsx
+++ b/src/entities/unity/ui/UnityView.tsx
@@ -1,4 +1,4 @@
-import { FC } from 'react';
+import { FC, useEffect } from 'react';
 import { UIManager } from 'react-native';
 
 import RNUnityView from '@azesmway/react-native-unity';
@@ -10,6 +10,8 @@ import { UnityResult } from '@entities/unity/lib/types/unityType.ts';
 
 import { UnityErrorModal } from './UnityErrorModal';
 import { useUnityLifecycle } from '../lib/hook/useUnityLifecycle';
+import { useAppDispatch } from '@app/shared/lib/hooks/redux';
+import { bannerActions } from '@app/entities/banner/model/slice';
 
 type Props = {
   payload: UnityPipelineItem['payload'];
@@ -53,6 +55,15 @@ export const UnityView: FC<Props> = props => {
     />
   );
 
+  const dispatch = useAppDispatch();
+
+  useEffect(() => {
+    dispatch(bannerActions.setBannersHidden(true));
+    return () => {
+      dispatch(bannerActions.setBannersHidden(false));
+    };
+  }, [dispatch]);
+
   if (!compiledWithRNUnityView) {
     // TODO: Render some dummy/placeholder UI to bypass the activity
     return (
@@ -82,6 +93,7 @@ export const UnityView: FC<Props> = props => {
     <>
       <RNUnityView
         key={unityViewKey}
+        testID="merit-unity-view"
         ref={rnUnityViewRef}
         // eslint-disable-next-line react-native/no-inline-styles
         style={{ flex: 1 }}

--- a/src/screens/ui/InProgressActivityScreen.tsx
+++ b/src/screens/ui/InProgressActivityScreen.tsx
@@ -5,7 +5,6 @@ import { useSafeAreaInsets } from 'react-native-safe-area-context';
 
 import { AutocompletionEventOptions } from '@app/abstract/lib/types/autocompletion';
 import { useUpcomingNotificationsObserver } from '@app/entities/notification/lib/hooks/useUpcomingNotificationsObserver';
-import { useAppDispatch } from '@app/shared/lib/hooks/redux';
 import { Emitter } from '@app/shared/lib/services/Emitter';
 import { getSupportsMobile } from '@app/shared/lib/utils/responseTypes';
 import { Box } from '@app/shared/ui/base';

--- a/src/screens/ui/InProgressActivityScreen.tsx
+++ b/src/screens/ui/InProgressActivityScreen.tsx
@@ -5,6 +5,7 @@ import { useSafeAreaInsets } from 'react-native-safe-area-context';
 
 import { AutocompletionEventOptions } from '@app/abstract/lib/types/autocompletion';
 import { useUpcomingNotificationsObserver } from '@app/entities/notification/lib/hooks/useUpcomingNotificationsObserver';
+import { useAppDispatch } from '@app/shared/lib/hooks/redux';
 import { Emitter } from '@app/shared/lib/services/Emitter';
 import { getSupportsMobile } from '@app/shared/lib/utils/responseTypes';
 import { Box } from '@app/shared/ui/base';


### PR DESCRIPTION
### Description
The Banner component was rendered at the top of the screen at all times and when rendered it does not allow any UI components to be visible at the top of the screen. Added a bannersHidden flag to the banner Redux slice so screens can hide it. UnityView now dispatches setBannersHidden on mount/unmount to remove the bar and allow full-screen rendering

🔗 [Jira Ticket M2-#10635](https://mindlogger.atlassian.net/browse/M2-10635)

Changes include
- Added `bannersHidden` state to the banner Redux slice so any component can request the banner bar be removed from the view tree
- `UnityView` dispatches `setBannersHidden(true)` on mount and `setBannersHidden(false)` on unmount, allowing it to render edge-to-edge on iOS

## Peer testing
- [ ] Open a Unity activity on a physical phone device
- [ ] Verify the Unity view renders into the notch area with no bar covering it
- [ ] Navigate back from the Unity activity and verify the banner bar returns on other screens

<!-- Replace this with a high-level description of the features/functionality proposed in the pull request. -->

### 📸 Screenshots

<img width="645" height="1398" alt="Screenshot 2026-04-30 at 1 31 38 PM" src="https://github.com/user-attachments/assets/270b96b9-0290-4bc6-8f45-fc3aa97bd635" />

### ✏️ Notes
Changes still need to be tested on Android.
