### PR TITLE
fix: Unity crash after force quit and restart (M2-10056)

### DIFF
--- a/ios/MindloggerMobile/AppDelegate.swift
+++ b/ios/MindloggerMobile/AppDelegate.swift
@@ -4,7 +4,6 @@ import React_RCTAppDelegate
 import ReactAppDependencyProvider
 import TSBackgroundFetch
 import Firebase
-import react_native_orientation_director
 
 @main
 class AppDelegate: UIResponder, UIApplicationDelegate {
@@ -42,7 +41,8 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     _ application: UIApplication,
     supportedInterfaceOrientationsFor window: UIWindow?
   ) -> UIInterfaceOrientationMask {
-    return OrientationDirector.getSupportedInterfaceOrientationsForWindow()
+    // Mask must be static option set (M2-10056)
+    return [.portrait, .landscapeLeft, .landscapeRight]
   }
 
   func application(


### PR DESCRIPTION
### 📝 Description

🔗 [Jira Ticket M2-10056](https://mindlogger.atlassian.net/browse/M2-10056)

Changes include:

- Return static option set for `application(_:supportedInterfaceOrientationsFor:)` method

### 🪤 Peer Testing

To reproduce crash:

1. Complete and save answers for landscape Unity activity.
2. Force quit Curious app.
3. Reopen landscape Unity activity in Curious app.

The crash does not occur in all environments but has been reproduced with:

- iPhone 13 / iOS 17.1.2
- iPhone 14 / iOS 18.5
- iPhone 15 / iOS 17.3

### ✏️ Notes

The exception associated with the crash appeared in device logs as:

    *** Terminating app due to uncaught exception 'UIApplicationInvalidInterfaceOrientation', reason: 'Supported orientations has no common orientation with the application, and [UnityDefaultViewController shouldAutorotate] is returning YES'

The related [`invalidInterfaceOrientationException`](https://developer.apple.com/documentation/uikit/uiapplication/invalidinterfaceorientationexception) can occur when the option set of supported orientations returned by [`application(_:supportedInterfaceOrientationsFor:)`](https://developer.apple.com/documentation/uikit/uiapplicationdelegate/application(_:supportedinterfaceorientationsfor:)) does not match up against the orientations supported by the view controller.

Previously, our implementation of `application(_:supportedInterfaceOrientationsFor:)` called `OrientationDirector.getSupportedInterfaceOrientationsForWindow()` which changes to just `[.portrait]` whenever Unity unmounts:

1.  We `lockTo` portrait in `useEffect` cleanup logic when Unity unmounts ([source](https://github.com/ChildMindInstitute/mindlogger-app-refactor/blob/2026.04.3/src/entities/unity/lib/hook/useUnityLifecycle.ts#L252)).
2. `lockTo` calls `requestInterfaceUpdateTo` ([source](https://github.com/gladiuscode/react-native-orientation-director/blob/v2.6.5/ios/implementation/OrientationDirectorImpl.swift#L69)).
3. `requestInterfaceUpdateTo` sets `supportedInterfaceOrientations` ([source](https://github.com/gladiuscode/react-native-orientation-director/blob/v2.6.5/ios/implementation/OrientationDirectorImpl.swift#L150)).
5. `getSupportedInterfaceOrientationsForWindow` returns `supportedInterfaceOrientations` ([source](https://github.com/gladiuscode/react-native-orientation-director/blob/v2.6.5/ios/OrientationDirector.mm#L46)).

When the user force quits the app and tries to reopen the activity, the Unity view controller sets landscape as the orientation which does not match up against `[.portrait]` returned by our implementation of `application(_:supportedInterfaceOrientationsFor:)`.

The issue is fixed by updating `application(_:supportedInterfaceOrientationsFor:)` to return a static option set of all supported orientations:

```swift
[.portrait, .landscapeLeft, .landscapeRight]
```