### PR TITLE
fix: Patch `react-native-unity` for Android build

### DIFF
--- a/patches/@azesmway+react-native-unity+1.0.11.patch
+++ b/patches/@azesmway+react-native-unity+1.0.11.patch
@@ -1,0 +1,23 @@
+diff --git a/node_modules/@azesmway/react-native-unity/android/src/main/java/com/azesmwayreactnativeunity/UPlayer.java b/node_modules/@azesmway/react-native-unity/android/src/main/java/com/azesmwayreactnativeunity/UPlayer.java
+index b944779..22e4bf4 100644
+--- a/node_modules/@azesmway/react-native-unity/android/src/main/java/com/azesmwayreactnativeunity/UPlayer.java
++++ b/node_modules/@azesmway/react-native-unity/android/src/main/java/com/azesmwayreactnativeunity/UPlayer.java
+@@ -93,11 +93,17 @@ public class UPlayer {
+ 
+     public FrameLayout requestFrame() throws NoSuchMethodException {
+         try {
++            // Attempt to invoke getFrameLayout() for the newer UnityPlayer class
+             Method getFrameLayout = unityPlayer.getClass().getMethod("getFrameLayout");
+ 
+             return (FrameLayout) getFrameLayout.invoke(unityPlayer);
+         } catch (NoSuchMethodException | IllegalAccessException | InvocationTargetException e) {
+-            return unityPlayer;
++            // If it is old UnityPlayer, use isInstance() and cast() to bypass incompatible type checks when compiling using newer versions of UnityPlayer
++            if (FrameLayout.class.isInstance(unityPlayer)) {
++                return FrameLayout.class.cast(unityPlayer);
++            } else {
++                return null;
++            }
+         }
+     }
+ 

--- a/patches/README.md
+++ b/patches/README.md
@@ -2,6 +2,13 @@
 
 Applied via [patch-package](https://github.com/ds300/patch-package).
 
+## @azesmway+react-native-unity+1.0.11.patch
+
+Patch `requestFrame` in UPlayer.java to fix Android build issue.
+
+- Resolves issue azesmway/react-native-unity#123.
+- Added in commit 187d7933 of pull request #1117.
+
 ## react-native+0.79.7.patch
 
 Bumps `fmt` dependency 11.0.2 → 12.1.0 to fix iOS compile errors with Xcode 26.4.


### PR DESCRIPTION
### 📝 Description

1. `yarn install --ignore-scripts` for a clean `@azesmway/react-native-unity` install.
2. Update `UPlayer.java` in `node_modules/@azesmway/react-native-unity` as described by @TwigAy-CMI.
3. Run `yarn patch-package @azesmway/react-native-unity`

### ✏️ Notes

The patch addresses an Android build issue that @TwigAy-CMI investigated.

See related discussion in azesmway/react-native-unity#123.