### PR TITLE
fix: use local state in survey text inputs (M2-10771)

### DIFF
--- a/src/features/pass-survey/ui/AdditionalText.tsx
+++ b/src/features/pass-survey/ui/AdditionalText.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 
 import { useTranslation } from 'react-i18next';
 
@@ -19,6 +19,17 @@ export function AdditionalText({ value, onChange, required }: Props) {
   const { t } = useTranslation();
   const [height, setHeight] = useState(MIN_FIELD_HEIGHT);
 
+  // Local state prevents MMKV v4 sync re-renders from breaking Android IME composition.
+  const [localValue, setLocalValue] = useState(value ?? '');
+  useEffect(() => {
+    setLocalValue(value ?? '');
+  }, [value]);
+
+  const onChangeText = (text: string) => {
+    setLocalValue(text);
+    onChange(text);
+  };
+
   const placeholder = t(
     required ? 'optional_text:required' : 'optional_text:enter_text',
   );
@@ -27,8 +38,8 @@ export function AdditionalText({ value, onChange, required }: Props) {
     <Input
       placeholder={placeholder}
       aria-label="additional_text-input"
-      value={value}
-      onChangeText={onChange}
+      value={localValue}
+      onChangeText={onChangeText}
       onContentSizeChange={e => {
         const contentHeight = e.nativeEvent.contentSize.height;
 

--- a/src/shared/ui/survey/ParagraphText.tsx
+++ b/src/shared/ui/survey/ParagraphText.tsx
@@ -1,4 +1,4 @@
-import React, { FC, useState } from 'react';
+import React, { FC, useEffect, useState } from 'react';
 import { StyleSheet, TextInputProps, View } from 'react-native';
 
 import { useTranslation } from 'react-i18next';
@@ -24,7 +24,14 @@ export const ParagraphText: FC<Props> = ({
   const { maxLength = 50 } = config;
   const { t } = useTranslation();
 
+  // Local state prevents MMKV v4 sync re-renders from breaking Android IME composition.
+  const [localValue, setLocalValue] = useState(value);
+  useEffect(() => {
+    setLocalValue(value);
+  }, [value]);
+
   const onChangeText = (text: string) => {
+    setLocalValue(text);
     onChange(text);
   };
 
@@ -34,7 +41,7 @@ export const ParagraphText: FC<Props> = ({
         aria-label="paragraph-item"
         placeholder={t('text_entry:paragraph_placeholder')}
         onChangeText={onChangeText}
-        value={value}
+        value={localValue}
         autoCorrect={false}
         multiline={true}
         keyboardType={'default'}
@@ -45,7 +52,7 @@ export const ParagraphText: FC<Props> = ({
       <CharacterCounter
         focused={paragraphOnFocus}
         limit={maxLength}
-        numberOfCharacters={value.length}
+        numberOfCharacters={localValue.length}
       />
     </View>
   );

--- a/src/shared/ui/survey/SimpleTextInput.tsx
+++ b/src/shared/ui/survey/SimpleTextInput.tsx
@@ -1,4 +1,4 @@
-import { FC } from 'react';
+import { FC, useEffect, useState } from 'react';
 import { TextInputProps } from 'react-native';
 
 import { useTranslation } from 'react-i18next';
@@ -24,7 +24,14 @@ export const SimpleTextInput: FC<Props> = ({
 
   const { t } = useTranslation();
 
+  // Local state prevents MMKV v4 sync re-renders from breaking Android IME composition.
+  const [localValue, setLocalValue] = useState(value);
+  useEffect(() => {
+    setLocalValue(value);
+  }, [value]);
+
   const onChangeText = (text: string) => {
+    setLocalValue(text);
     onChange(text);
   };
 
@@ -34,7 +41,7 @@ export const SimpleTextInput: FC<Props> = ({
       placeholder={t('text_entry:type_placeholder')}
       onChangeText={onChangeText}
       maxLength={Number(maxLength)}
-      value={value}
+      value={localValue}
       autoCorrect={false}
       multiline={false}
       mode="survey"


### PR DESCRIPTION
- [ ] Tests for the changes have been added
- [ ] Related documentation has been added / updated
- [ ] OSS packages added to Curious open source credit page

### 📝 Description

🔗 [Jira Ticket M2-10771](https://mindlogger.atlassian.net/browse/M2-10771)

Fix where typing a character in a survey text field and then selecting a word from the keyboard's suggestion bar produced duplicated text

**Root cause:** `react-native-mmkv` v4 now writes to storage synchronously, which immediately triggers a React re-render on every keystroke. On Android, this re-render interrupted the keyboard's autocomplete flow, causing the suggestion to append to the typed character instead of replacing it.

**Fix:** Each survey text input now keeps its own local copy of the value. The displayed text updates instantly from local state, while MMKV still gets updated on every keystroke. This way MMKV's re-render no longer interferes with the keyboard's autocomplete mid-typing.

Changes include:

- `SimpleTextInput`: local state mirror of `value`
- `ParagraphText`: local state mirror of `value`; `CharacterCounter` reads from local state
- `AdditionalText`: local state mirror of `value`


### ✏️ Notes

Builds on top of `fix/16kb-page-size` (MMKV v4 upgrade). 