### PR TITLE
fix: Unity file path encoding (M2-10719)

### DIFF
--- a/src/entities/activity/lib/services/AnswersUploadService.ts
+++ b/src/entities/activity/lib/services/AnswersUploadService.ts
@@ -22,7 +22,7 @@ import {
   formatToDtoDate,
   formatToDtoTime,
 } from '@app/shared/lib/utils/dateTime';
-import { isLocalFileUrl } from '@app/shared/lib/utils/file';
+import { getFilePath, isLocalFileUrl } from '@app/shared/lib/utils/file';
 import { MediaFile } from '@app/shared/ui/survey/MediaItems/types';
 import { IAnswersUploadService } from '@entities/activity/lib/services/IAnswersUploadService';
 import {
@@ -159,7 +159,7 @@ export class AnswersUploadService implements IAnswersUploadService {
     logAnswerIndex: number,
     appletId: string,
   ): Promise<string> {
-    const localFileExists = await FileSystem.exists(mediaFile.uri);
+    const localFileExists = await FileSystem.exists(getFilePath(mediaFile.uri));
 
     const logFileInfo = `(${mediaFile.type}, from answer #${logAnswerIndex})`;
 

--- a/src/entities/activity/lib/services/MediaFilesCleaner.ts
+++ b/src/entities/activity/lib/services/MediaFilesCleaner.ts
@@ -7,6 +7,7 @@ import {
   ObjectAnswerDto,
 } from '@app/shared/api/services/IAnswerService';
 import { getDefaultLogger } from '@app/shared/lib/services/loggerInstance';
+import { getFilePath } from '@app/shared/lib/utils/file';
 import { MediaFile, MediaValue } from '@app/shared/ui/survey/MediaItems/types';
 import { getActivityRecordKey } from '@app/widgets/survey/lib/storageHelpers';
 
@@ -43,10 +44,11 @@ export const createMediaFilesCleaner = (
 
     for (const fileUrl of urlsToProcess) {
       try {
-        const fileExists = await FileSystem.exists(fileUrl);
+        const filePath = getFilePath(fileUrl);
+        const fileExists = await FileSystem.exists(filePath);
 
         if (fileExists) {
-          await FileSystem.unlink(fileUrl);
+          await FileSystem.unlink(filePath);
         }
       } catch (error) {
         getDefaultLogger().warn(
@@ -85,10 +87,11 @@ export const createMediaFilesCleaner = (
         const mediaValue = answerValue as MediaValue;
 
         if (mediaValue?.uri) {
-          const fileExists = await FileSystem.exists(mediaValue.uri);
+          const filePath = getFilePath(mediaValue.uri);
+          const fileExists = await FileSystem.exists(filePath);
 
           if (fileExists) {
-            await FileSystem.unlink(mediaValue.uri);
+            await FileSystem.unlink(filePath);
 
             console.info('[MediaFilesCleaner.cleanUp]: completed');
           }

--- a/src/shared/api/services/fileService.ts
+++ b/src/shared/api/services/fileService.ts
@@ -4,6 +4,7 @@ import { IS_ANDROID } from '@app/shared/lib/constants';
 import { getDefaultSystemRecord } from '@app/shared/lib/records/systemRecordInstance';
 import { getDefaultLogger } from '@app/shared/lib/services/loggerInstance';
 import { getStringHashCode } from '@app/shared/lib/utils/common';
+import { getFilePath } from '@app/shared/lib/utils/file';
 import {
   HttpError,
   watchForConnectionLoss,
@@ -149,9 +150,8 @@ export function fileService(): IFileService {
 
         try {
           const body = [];
-          const localUrl = request.localUrl.replace('file://', ''); // no 'file://' on both Android and iOS
-
           const fieldKeys = Object.keys(request.fields);
+          const localUrl = getFilePath(request.localUrl); // no 'file://' on both Android and iOS
 
           for (const key of fieldKeys) {
             body.push({ name: key, data: request.fields[key] });

--- a/src/shared/lib/hooks/useCachedImage.ts
+++ b/src/shared/lib/hooks/useCachedImage.ts
@@ -3,7 +3,7 @@ import { useState, useEffect } from 'react';
 import { CacheManager } from '@georstat/react-native-image-cache';
 
 import { getDefaultLogger } from '../services/loggerInstance';
-import { getFilePath } from '../utils/file';
+import { getFileUri } from '../utils/file';
 
 export function useCachedImage(uri?: string) {
   const [source, setSource] = useState<string | null>(uri ?? null);
@@ -18,7 +18,7 @@ export function useCachedImage(uri?: string) {
         const path = await CacheManager.get(uri, {}).getPath();
 
         if (path) {
-          setSource(getFilePath(path));
+          setSource(getFileUri(path));
         } else {
           getDefaultLogger().warn(
             `[useCachedImage] No cache entry was found for uri:${uri}`,

--- a/src/shared/lib/utils/file.ts
+++ b/src/shared/lib/utils/file.ts
@@ -9,3 +9,6 @@ export const isLocalFileUrl = (value: string) => {
 
 export const getFileUri = (path: string) =>
   IS_ANDROID ? `file://${path}` : path;
+
+export const getFilePath = (uri: string) =>
+  uri.startsWith('file://') ? uri.slice('file://'.length) : uri;

--- a/src/shared/lib/utils/file.ts
+++ b/src/shared/lib/utils/file.ts
@@ -7,5 +7,5 @@ export const isLocalFileUrl = (value: string) => {
   return localFileRegex.test(value);
 };
 
-export const getFilePath = (path: string) =>
+export const getFileUri = (path: string) =>
   IS_ANDROID ? `file://${path}` : path;


### PR DESCRIPTION
🔗 [Jira Ticket M2-10719](https://mindlogger.atlassian.net/browse/M2-10719)

Pull request #1119 resolved the issue in iOS but not in Android. The logs for Android indicated that the Unity files were saved successfully to the file system but could not be uploaded. Turns out that Android tries to URI decode file URIs (prefixed with `file://` scheme) which breaks if there is a literal `%` character in the file path. Consistently passing in the file path (no `file://` scheme) when interacting with the file system resolves the issue.

Changes include:

- Rename `getFilePath` → `getFileUri`. This helper function was previously misnamed.
- Define new `getFilePath` helper function that strips `file://` scheme from file URI.
- Use file path consistently when interacting with the file system.