### PR TITLE
Feat: add south african language support (M2-10768)

### DIFF
--- a/assets/translations/af.json
+++ b/assets/translations/af.json
@@ -1,0 +1,588 @@
+{
+  "auth": {
+    "email": "E-pos",
+    "email_address": "E-posadres",
+    "password": "Wagwoord",
+    "i_agree": "Ek stem in tot die",
+    "terms_of_service": "Diensbepalings",
+    "terms": "Bepalings",
+    "privacy": "Privaatheid",
+    "privacy_policy": "Privaatheidsbeleid",
+    "password_updated": "Wagwoord opgedateer"
+  },
+  "activity": {
+    "completeOnWeb": "Voltooi asseblief op die Curious-webtoep",
+    "incorrect_answer": "Antwoord is verkeerd. Probeer asseblief weer",
+    "failed": "Misluk",
+    "flanker_accuracy_warn": "*Die tydstempels wat vir ’n Android-toestel versamel word, is nie so akkuraat as vir iOS-toestelle nie.",
+    "please_wait": "Wag asseblief",
+    "activity_all_items_hidden": "“{{entityName}}” kan nie begin word nie, want alle items binne die aktiwiteit is versteek",
+    "flow_all_items_hidden": "“{{entityName}}” kan nie begin word nie, want dit bevat ’n aktiwiteit waarin alle items versteek is",
+    "progress": {
+      "upload_files": "Laai tans jou lêers op ...",
+      "encrypt_answers": "Enkripteer tans jou antwoorde ...",
+      "upload_answers": "Laai tans jou antwoorde op ...",
+      "completed": "Aktiwiteit opgelaai"
+    },
+    "step": "Stap",
+    "flowStep": "({{activityPositionInFlow}} van {{numberOfActivitiesInFlow}}) {{activityFlowName}}",
+    "stepCounter": "{{currentStep}} van {{totalSteps}}",
+    "activityCounter": "Aktiwiteit {{currentStep}} van {{totalSteps}}"
+  },
+  "activity_time": {
+    "time_remaining": "oorblywend vir hierdie item"
+  },
+  "timed_activity": {
+    "time_to_complete": "Tyd om te voltooi",
+    "time_to_complete_hm": "Tyd om te voltooi: {{hours}} uur en {{minutes}} minute",
+    "hours": "uur"
+  },
+  "activity_summary": {
+    "terms_text": "Ek verstaan dat die inligting wat in hierdie vraelys verskaf word, nie bedoel is om die advies, diagnose of behandeling wat deur ’n mediese of geestesgesondheidskundige aangebied word, te vervang nie, en dat my anonieme antwoorde gebruik en gedeel kan word vir algemene navorsing oor kinders se geestesgesondheid.",
+    "footer_text": "CHILD MIND INSTITUTE, INC. EN CHILD MIND MEDICAL PRACTICE, PLLC (SAAM “CMI”) BEOEFEN NIE DIREK OF INDIREK GENEESKUNDE OF VERSKAF MEDIESE ADVIES AS DEEL VAN HIERDIE VRAELYS NIE. CMI AANVAAR GEEN AANSPREEKLIKHEID VIR ENIGE DIAGNOSE, BEHANDELING, BESLUIT GENEEM OF AKSIE ONDERNEEM WAT VERTROU OP INLIGTING WAT DEUR HIERDIE VRAELYS VERSKAF WORD NIE, EN AANVAAR GEEN VERANTWOORDELIKHEID VIR JOU GEBRUIK VAN HIERDIE VRAELYS NIE.",
+    "score_on_subscale": "Die telling op die {{name}}-subskaal was",
+    "save": "Stoor",
+    "summary": "Opsomming",
+    "alerts": "Waarskuwings",
+    "report_summary": "Verslagopsomming",
+    "not_yet_completed": "Nog nie voltooi nie",
+    "last_completed": "Laas voltooi",
+    "unscheduled": "Ongeskeduleerd",
+    "due": "Uitstaande",
+    "scheduled_for": "Geskeduleer vir",
+    "category_suicide": "Selfmoord",
+    "category_suicide_message": "Kritieke vlak: Ouer het moontlike boeliegedrag aangedui. Bring dit onmiddellik onder die aandag van die klinikus weens ’n potensiële noodsituasie.",
+    "category_emotional": "Emosioneel",
+    "category_emotional_message": "Binne normale limiete: Geen verdere sifting of assessering word vereis nie.",
+    "category_sport": "Sport",
+    "category_sport_message": "Kliniese reeks: Maak klinikus bewus; voer opvolgassessering uit (aanbeveel); algemene verwysing.",
+    "share_report": "Deel verslag",
+    "share_all_reports": "Deel alle verslae"
+  },
+  "activity_chart": {
+    "title": "Neem asseblief die assessering vir data om vertoon te word.",
+    "monday": "M",
+    "tuesday": "D",
+    "wednesday": "W",
+    "thursday": "D",
+    "friday": "V",
+    "saturday": "S",
+    "sunday": "S"
+  },
+  "calendar": {
+    "months": "Januarie_Februarie_Maart_April_Mei_Junie_Julie_Augustus_September_Oktober_November_Desember",
+    "weekdays": "So_Ma_Di_Wo_Do_Vr_Sa",
+    "x_days": "M_D_W_D_V_S_S"
+  },
+  "applet_data": {
+    "title": "Neem asseblief die assessering vir data om vertoon te word."
+  },
+  "widget_error": {
+    "error_text": "Daar was ’n probleem om hierdie skerm te laai.",
+    "error_description": "Maak asseblief seker dat jy die jongste weergawe van Curious geïnstalleer het, en kontak dan jou aktiwiteitadministrateur indien die probleem steeds voorkom."
+  },
+  "about": {
+    "about": "Meer oor",
+    "applets_title": "Vind meer uit oor elkeen van jou minitoeps en oor die Curious-platform.",
+    "data_title": "Vind meer uit oor die Curious-dataversameling-platform deur te tik op “Meer oor\nCurious” hier onder.",
+    "about_curious": "Meer oor Curious",
+    "icons_title": "NounProject-ikone is geskep deur Alina Oleynik (opname), Beth Bolton (boek) en\nShakeel (grafiek)",
+    "device_id": "Toestel-ID"
+  },
+  "about_app": {
+    "title_with_version": "Wat is Curious? v.{{version}}",
+    "title": "Tensy anders vermeld, is ikone geneem uit OpenMoji en NounProject.",
+    "subtitle": "Tensy anders vermeld, is ikone geneem uit OpenMoji en NounProject.",
+    "curious_about": "## \n ### Wat is Curious? \n\n Hierdie toep is deel van die oopbron Curious-dataversameling- en ontledingsplatform wat ontwerp is deur die MATTER Lab by die Child Mind Institute ([https://matter.childmind.org](https://matter.childmind.org)). \n # \n ### Wat kan Curious doen? \n\n Curious se kenmerkstel groei en ondersteun tans ’n wye verskeidenheid invoertipes. Elke skerm in ’n Curious-aktiwiteit kan enige van die volgende insluit: \n  - Teks, prent en oudio \n  - Vraag gevolg deur beeld- en/of teksantwoord-opsies \n  - Skuifbalk \n  - Teksinskrywing \n  - Tabelinskrywing \n  - Oudio opneem \n  - Foto-/videovaslegging \n  - Teken of tik \n  - Huidige geoligging \n  - Eenvoudige kognitiewe taak \n  - Vertraging voor antwoord \n  - Tydhouer \n  - Voorwaardelike logika om te bepaal waarheen om volgende te gaan \n\n #### Waar kan ek meer uitvind? \n Besoek [https://mindlogger.org](https://mindlogger.org) vir meer inligting.  \n ## [Steundiens]({{credits_link}}) \n ## [Diensbepalings](https://mindlogger.org/terms-of-service) \n ## [Privaatheidsbeleid](https://mindlogger.org/privacy-policy) \n\n ##### Vriendelike groete \n\n ##### die Curious-span \n\n ##### Child Mind Institute"
+  },
+  "applet_footer": {
+    "surveys": "Opnames",
+    "data": "Data",
+    "about": "Meer oor",
+    "activities": "Aktiwiteite",
+    "activity": "Aktiwiteit"
+  },
+  "applet_invite_flow": {
+    "back": "Terug",
+    "next": "Volgende"
+  },
+  "live_connection": {
+    "disconnect": "ONTKOPPEL",
+    "connect": "DIEN IN",
+    "connect_to_server": "Verbind met bediener",
+    "remember": "Onthou",
+    "ip": "IP-adres",
+    "port": "Poort",
+    "connection_closed": "TCP-verbinding is toegemaak",
+    "connection_error": "Verbinding het misluk. Kontroleer asseblief weer IP en poort",
+    "connection_set_error": "Kan nie verbinding stel nie",
+    "live_connection": "Lewende verbinding",
+    "not_available": "nie beskikbaar nie"
+  },
+  "join_invite": {
+    "click_below": "Klik hier onder as jy gereed is om by hierdie studie aan te sluit. Jy kan jouself te eniger tyd van hierdie studie verwyder en/of jou data skrap sonder enige gevolge.",
+    "decline": "Indien jy nie gemaklik voel om jou data van hierdie studie te deel nie, kan jy hierdie uitnodiging van die hand wys. ",
+    "decline_title": "Weier"
+  },
+  "applet_list_component": {
+    "about_title": "Meer oor Curious",
+    "no_applets_yet": "Jy het geen minitoeps nie.",
+    "noon": "Middag",
+    "midnight": "Middernag",
+    "refresh_error_header": "Herlaaifout",
+    "applets_not_refreshed": "Die volgende minitoeps is nie herlaai nie:",
+    "common_refresh_error": "Die minitoep-lys is nie herlaai nie. Probeer asseblief weer."
+  },
+  "activity_list_component": {
+    "no_activities": "Geen aktiwiteite is vir jou beskikbaar om tans te voltooi nie",
+    "insufficient_data_error": "Hierdie minitoep is nie herlaai nie. Probeer asseblief weer herlaai.",
+    "other_error": "Ongedefinieerde fout het voorgekom"
+  },
+  "applet_settings": {
+    "applet_not_defined": "Daar is nie ’n minitoep gedefinieer nie.",
+    "want_remove": "As jy hierdie minitoep wil verwyder, maar jou data behou, klik hier onder",
+    "remove": "Verwyder",
+    "want_delete": "As jy jou data van hierdie minitoep wil skrap en dit wil verwyder, klik hier onder.",
+    "remove_delete": "Verwyder en skrap data",
+    "alert_title": "Is jy seker jy wil jou data skrap?",
+    "alert_message": "Jy sal dit nie weer kan terugkry nie",
+    "cancel_text": "Nee, kanselleer",
+    "confirm_text": "Yes, delete it"
+  },
+  "change_pass_form": {
+    "update": "Dateer op",
+    "cur_pass_placeholder": "Huidige wagwoord",
+    "new_pass_placeholder": "Nuwe wagwoord",
+    "error": "Kon nie gebruikerbesonderhede opdateer nie.",
+    "submission_error": "Die huidige wagwoord wat jy ingevoer het, was verkeerd.",
+    "change_pass": "Verander wagwoord",
+    "password_at_least_characters": "Wagwoord moet ten minste {{min}} karakters wees"
+  },
+  "password_recovery_form": {
+    "password_at_least_characters": "Wagwoord moet ten minste {{min}} karakters wees",
+    "password_no_spaces": "Wagwoord mag nie spasies bevat nie",
+    "passwords_do_not_match": "Wagwoorde is nie dieselfde nie",
+    "password_confirmation_required": "Bevestig asseblief jou wagwoord",
+    "new_password_placeholder": "Nuwe wagwoord",
+    "confirm_password_placeholder": "Bevestig wagwoord",
+    "submit": "Dien in",
+    "invalid_password_reset_link": "Hierdie skakel is ongeldig of het verval.",
+    "click_to_reset_password": "Klik asseblief hier onder om jou wagwoord terug te stel.",
+    "forgot_password": "Wagwoord vergeet",
+    "success": "Jou wagwoord is suksesvol teruggestel. Meld asseblief aan met jou nuwe wagwoord.",
+    "error": "Kon nie jou wagwoord terugstel nie"
+  },
+  "mfa_recovery": {
+    "title": "Bevestig jou identiteit",
+    "subtitle": "Voer asseblief ’n rekeningherstelkode in.",
+    "continue": "Gaan voort",
+    "back": "Terug",
+    "invalid_code_format": "Herstelkode moet in die XXXXX-XXXXX-formaat wees",
+    "placeholder": "XXXXX-XXXXX",
+    "error": "Ongeldige herstelkode. Probeer asseblief weer.",
+    "success": "Identiteit suksesvol bevestig",
+    "error_invalid_code": "Ongeldige herstelkode. Kontroleer asseblief en probeer weer.",
+    "error_code_not_found": "Herstelkode nie gevind nie of reeds gebruik.",
+    "error_session_expired": "Jou sessie het verval. Meld asseblief weer aan.",
+    "error_too_many_attempts": "Te veel mislukte pogings. Probeer asseblief om weer aan te meld.",
+    "error_global_lockout": "Te veel mislukte pogings. Jy is tydelik uitgesluit. Probeer asseblief om weer na 15 minute aan te meld.",
+    "error_network": "Netwerkfout. Kontroleer asseblief jou verbinding en probeer weer.",
+    "error_unknown": "’n Fout het voorgekom. Probeer asseblief weer."
+  },
+  "mfa_verification": {
+    "title": "Bevestig jou identiteit",
+    "subtitle": "Voer asseblief die verifikasiekode in wat in jou waarmerkingstoep (authenticator) vertoon word.",
+    "verify": "Gaan voort",
+    "placeholder": "Voer verifikasiekode in",
+    "invalid_code_format": "Verifikasiekode moet 6 syfers wees",
+    "error": "Ongeldige kode",
+    "success": "Verifikasie suksesvol",
+    "use_recovery_code": "Ek kan nie toegang tot my waarmerkingstoep (authenticator) kry nie",
+    "session_expiry_warning": "Sessie het dalk verval. Verifieer asseblief handmatig of meld weer aan.",
+    "error_invalid_code": "Ongeldige verifikasiekode. Kontroleer asseblief en probeer weer.",
+    "error_session_expired": "Jou sessie het verval. Meld asseblief weer aan.",
+    "error_too_many_attempts": "Te veel mislukte pogings. Probeer asseblief om weer aan te meld.",
+    "error_global_lockout": "Te veel mislukte pogings. Jy is tydelik uitgesluit. Probeer asseblief om weer na 15 minute aan te meld.",
+    "error_network": "Netwerkfout. Kontroleer asseblief jou verbinding en probeer weer.",
+    "error_unknown": "’n Fout het voorgekom. Probeer asseblief weer.",
+    "warning_session_attempts_remaining": ". {{count}} poging oor",
+    "warning_session_attempts_remaining_plural": ". {{count}} pogings oor",
+    "warning_global_attempts_remaining": ". {{count}} poging oor voordat tydelik gesluit word",
+    "warning_global_attempts_remaining_plural": ". {{count}} pogings oor voordat tydelik gesluit word"
+  },
+  "change_study": {
+    "reset": "Stel terug",
+    "submit": "Dien in",
+    "enter_url_manually": "Voer URL handmatig in",
+    "scan_qr": "Skandeer QR",
+    "successfully_changed": "Bediener-URL is suksesvol verander.",
+    "successfully_reset": "Bediener-URL is suksesvol teruggestel.",
+    "change_server": "Verander van bediener",
+    "http_confirm": "Is jy seker jy wil verbind aan ’n bediener wat nie SSL ondersteun nie?",
+    "set_by_qr": "Studie is deur QR gestel.",
+    "yes": "Yes",
+    "no": "Nee"
+  },
+  "consent": {
+    "this_app_provides": "Hierdie toep bied ’n maklike manier om opnames, stemopnames en tekenaktiwiteite te versamel.",
+    "i_understand": "Ek verstaan dat om sekere beelde te kyk, ongemaklik kan wees terwyl hierdie toep gebruik word",
+    "i_will_allow": "Ek sal die Child Mind Institute toelaat om data van die gebruik van hierdie toep op ’n beveiligde\nwolkbediener te bewaar en om toegang tot hierdie inligting te kry vir kliniese en navorsingdoeleindes",
+    "i_premit": "Ek gee toestemming dat die Child Mind Institute my mag kontak oor inligting wat versamel is deur\nhierdie toep vir kliniese of navorsingdoeleindes.",
+    "next": "Volgende"
+  },
+  "forgot_pass_form": {
+    "reset_pass": "Stel wagwoord terug",
+    "enter_email_mess": "Voer asseblief jou e-posadres in",
+    "invalid_email": "Ongeldige e-posadres",
+    "email_address": "E-posadres",
+    "email_send_success": "Terugstel-e-pos is gestuur na <strong>{{email}}</strong> indien die rekening bestaan.",
+    "email_send_error": "Kan tans nie terugstel-e-pos stuur nie.",
+    "forgot_password": "Wagwoord vergeet?"
+  },
+  "login": {
+    "new_user": "Nuwe gebruiker",
+    "account_create": "Skep ’n rekening",
+    "forgot_password": "Wagwoord vergeet?",
+    "what_is": "Wat is",
+    "login_error": "Kon nie aanmeld nie.",
+    "password_at_least_characters": "Wagwoord moet ten minste 10 karakters wees"
+  },
+  "login_form": {
+    "login": "Meld aan",
+    "email_placeholder": "E-pos",
+    "password": "Wagwoord"
+  },
+  "logout_warning": {
+    "warning": "Afmeld-waarskuwing",
+    "uploads_in_progress": "Oplaaie is tans aan die gang",
+    "currently_uploading": "Jy het antwoorde wat tans opgelaai word. As jy nou afmeld en dan as ’n ander gebruiker aanmeld, sal jou antwoorde verlore gaan.",
+    "not_uploaded": "Jy het nie antwoorde opgelaai nie. As jy nou afmeld en dan as ’n ander gebruiker aanmeld, sal jou antwoorde verlore gaan.",
+    "sure_logout": "Is jy seker jy wil afmeld?",
+    "cancel": "Kanselleer",
+    "logout": "Meld af"
+  },
+  "settings": {
+    "logged_out": "Jy het afgemeld.",
+    "change_pass": "Verander wagwoord",
+    "use_cellular_data": "Gebruik sellulêre data",
+    "logout": "Meld af",
+    "permanently_delete_account": "Skrap rekening permanent",
+    "user_settings": "Gebruikerinstellings",
+    "upload_logs": "Laai logs op",
+    "create_new_password": "Skep ’n nuwe wagwoord"
+  },
+  "language_screen": {
+    "app_language": "Toepassingstaal",
+    "change_app_language": "Verander taal",
+    "en": "English",
+    "fr": "Français",
+    "el": "Ελληνικά",
+    "es": "Español",
+    "pt": "Português"
+  },
+  "application_logs_screen": {
+    "upload_button": "Laai logs op",
+    "title": "Tegniese probleme? Jou loglêers sal ons span met probleemoplossing help.",
+    "subTitle": "Laai dit asseblief op deur die knoppie hier onder te gebruik.",
+    "success": "Sukses – ons het jou logs ontvang.",
+    "error": "Fout – logs is nie gestuur nie. Probeer asseblief weer."
+  },
+  "sign_up_form": {
+    "sign_up": "Registreer",
+    "error": "Kon nie registreer nie: gebruikersnaam is reeds in gebruik.",
+    "new_user": "Nuwe gebruiker",
+    "username_validation_error": "Gebruikersnaam moet ten minste 4 karakters lank wees, met ’n letter begin, en mag slegs letters, syfers, strepies en punte bevat.",
+    "email_validation_error": "Lyk of hierdie e-pos onvoltooid is",
+    "email_placeholder": "E-pos",
+    "first_name": "Voornaam",
+    "last_name": "Van",
+    "password_placeholder": "Wagwoord",
+    "please_accept_terms": "Kies asseblief diensbepalings.",
+    "email_looks_incomplete": "Lyk of hierdie e-pos onvoltooid is",
+    "sign_up_agree": "Deur te registreer, stem jy in tot Curious se",
+    "and": "en"
+  },
+  "password_requirements": {
+    "at_least_characters": "10 karakters",
+    "no_blank_spaces": "geen oop spasies nie",
+    "must_include": "Wagwoord moet ten minste {{minLength}} karakters bevat, geen spasies en ten minste {{types}} van die 4 hier onder:",
+    "must_include_minimum": "Wagwoord moet ten minste {{minLength}} karakters bevat en geen spasies nie",
+    "requirements_met": "Daar is aan alle vereistes voldoen.",
+    "must_include_uppercase": "Hoofletters (A-Z)",
+    "must_include_lowercase": "Kleinletters (a-z)",
+    "must_include_digits": "Syfers (0-9)",
+    "must_include_symbol": "Simbole (!@#$ ...)",
+    "cannot_contain_emojis": "Wagwoorde mag nie emoji bevat nie."
+  },
+  "geolocation": {
+    "get_location": "KRY LIGGING",
+    "must_enable_location": "Jy moet liggingdienste aktiveer om hierdie taak te voltooi. Gee asseblief Curious toestemming in jou iOS-instellings en druk weer die knoppie.",
+    "must_enable_location_subtitle": "Jy moet liggingdienste aktiveer om hierdie taak te voltooi. Druk asseblief weer die knoppie en gee Curious toestemming om jou ligging te gebruik.",
+    "location_saved": "Ligging gestoor.",
+    "service_not_available": "Liggingdiens is nie beskikbaar nie."
+  },
+  "select": {
+    "select_one": "Kies een",
+    "no_items": "Geen items nie"
+  },
+  "permissions": {
+    "alert_button_cancel": "Weier",
+    "alert_button_ok": "Maak instellings oop",
+    "alarm_permission_warning": "Alarmtoestemming-versoek",
+    "alarm_permission_disabled": "Skakel asseblief die alarmtoestemmings op jou toestel aan om die Curious-herinneringe betyds te ontvang. Let wel: die toepassing sal outomaties toegemaak word sodra jy die alarmtoestemmings aanskakel.",
+    "gallery": "“Curious” wil graag jou galery gebruik om hierdie taak te voltooi",
+    "camera": "“Curious” wil graag jou kamera gebruik om hierdie taak te voltooi"
+  },
+  "media": {
+    "alert_message": "Dit kan in instellings opgestel word",
+    "media_found_title": "Jy is vanlyn",
+    "media_found_body": "Hierdie aktiwiteit bevat items wat ’n internetverbinding vereis. Skakel asseblief die internet aan om voort te gaan."
+  },
+  "audio_recorder": {
+    "permission": "Jy moet toestemming gee om jou mikrofoon te gebruik om hierdie taak te voltooi.",
+    "alert_title": "“Curious” wil graag jou mikrofoon gebruik om hierdie taak te voltooi.",
+    "alert_message": "Dit kan in instellings opgestel word.",
+    "record_error": "Kon nie die opnemer begin nie.",
+    "stop": "STOP",
+    "record": "NEEM OP",
+    "recording": "Neem tans op ...",
+    "seconds": "sekondes",
+    "file_saved": "Lêer gestoor."
+  },
+  "audio_player": {
+    "stop": "STOP",
+    "playing": "SPEEL TANS ...",
+    "play": "SPEEL",
+    "done": "KLAAR",
+    "loading": "LAAI TANS"
+  },
+  "optional_text": {
+    "required": "Hierdie is ’n vereiste veld.",
+    "enter_text": "Voer asseblief die teks in."
+  },
+  "date_picker": {
+    "ok": "Goed"
+  },
+  "table_input": {
+    "short_press_detail": "* ’n Kortdruk vermeerder die teller",
+    "long_press_detail": "* ’n Langdruk verminder die teller"
+  },
+  "activity_due_date": {
+    "available_all_day": "Beskikbaar: Heeldag",
+    "scheduled_at": "Geskeduleer om",
+    "available": "Beskikbaar vanaf",
+    "to": "tot",
+    "day": "dag",
+    "days": "dae",
+    "am": "vm.",
+    "the_following_day": "die volgende dag"
+  },
+  "form_item": {
+    "required": "Word vereis",
+    "must_be": "Moet",
+    "characters_or_less": "karakters of minder wees",
+    "must_be_a_number": "Moet ’n syfer wees"
+  },
+  "applet_about": {
+    "loading": "laai tans",
+    "no_info": "Die outeurs van hierdie minitoep het geen inligting verskaf nie!"
+  },
+  "firebase_messaging": {
+    "alert_title": "“Curious” wil graag kennisgewings aan jou stuur",
+    "alert_message": "Dit kan in instellings opgestel word",
+    "alert_text": "Maak instellings oop",
+    "response_refresh_request": "Antwoordherlaai-versoek",
+    "refresh_request_details": "Aangesien jou wagwoord teruggestel is, moet jou vorige antwoorde herlaai word. Wil jy dit versoek?",
+    "refresh_request_text": "Jou bestuurders sal binnekort die herlaai inisieer.",
+    "applet_not_found_1": "Minitoep is nie gevind nie",
+    "applet_not_found_2": "Daar is geen minitoep vir gegewe ID nie.",
+    "activity_not_found": "Aktiwiteit “{{entityName}}” is tans nie beskikbaar nie.",
+    "activity_not_available_title": "Aktiwiteit is onbeskikbaar",
+    "activity_not_available_message": "Die aktiwiteit wat jy probeer oopmaak het, is tans nie beskikbaar nie. Jy kan later weer gedurende die volgende geskeduleerde tydvenster probeer.",
+    "activity_not_assigned": "Hierdie {{entityName}} is nie aan jou toegewys nie.",
+    "activity_not_available": "Hierdie {{entityName}} is nie meer beskikbaar nie.",
+    "activity_scheduled_today": "Die {{entityName}} is geskeduleer om beskikbaar te wees om {{time}}.",
+    "activity_completed_today": "{{entityName}} is reeds vir vandag voltooi.",
+    "already_completed": "Jy het dit reeds voltooi",
+    "app_killed_on_redux_persist": "Hierdie aktiwiteit kan nie begin word nie. Kontak asseblief die steundiens.",
+    "activity_was_due_at": "Hierdie aktiwiteit was uitstaande om",
+    "if_progress_was_made_on_the": "As vordering gemaak is op die",
+    "it_was_saved_but_it_can_no_longer_be_taken": "dan was dit gestoor maar dit kan nie meer",
+    "today": "vandag geneem word nie.",
+    "today2": "Vandag geskeduleer",
+    "activity_not_ready": "Aktiwiteit is nie gereed nie",
+    "not_able_to_start": "Jy is nog nie in staat om die aktiwiteit te begin nie",
+    "is": "is",
+    "scheduled_to_start_at": "geskeduleer om te begin om",
+    "postponed_notification": "Sodra die antwoorde opgelaai is, sal ons probeer om die aktiwiteit oop te maak"
+  },
+  "local_notifications": {
+    "complete_activity": "Voltooi asseblief hierdie aktiwiteit."
+  },
+  "join_demo_applets": {
+    "healthy_brain_network": "Healthy Brain Network: EMA",
+    "cognitive_tasks": "Kognitiewe take",
+    "mind_logger_demos": "Curious-demonstrasies"
+  },
+  "data_invite": {
+    "message": "Ons dink dit is belangrik dat jy weet wie toegang tot jou data het as jy hierdie uitnodiging aanvaar.\n\nDie volgende mense sal toegang tot jou data hê as jy hierdie uitnodiging aanvaar:"
+  },
+  "sidebar": {
+    "home": "Tuis",
+    "settings": "Instellings",
+    "about": "Meer oor",
+    "logout": "Meld af"
+  },
+  "navigator": {
+    "exit_title": "Verlaat toep",
+    "exit_subtitle": "Verlaat die toepassing?",
+    "cancel": "Kanselleer"
+  },
+  "activity_navigation": {
+    "next": "Volgende",
+    "skip": "Slaan oor",
+    "done": "Klaar",
+    "back": "Terug",
+    "return": "Keer terug",
+    "undo": "Ontdoen",
+    "exit": "Stoor en verlaat"
+  },
+  "network_alerts": {
+    "no_internet_title": "Geen interverbinding nie",
+    "no_internet_subtitle": "Verbind asseblief met die internet",
+    "no_internet_text": "Weier",
+    "cellular_data_title": "Sellulêre data is gedeaktiveer",
+    "cellular_data_subtitle": "Verbind asseblief met Wi-Fi of laat sellulêre data toe",
+    "cellular_data_text": "Weier",
+    "use_cellular_data": "Gebruik sellulêre data"
+  },
+  "timing": {
+    "provide_option": "Jy moet die opsie “na” of “elke” verskaf",
+    "to_be_number": "Verwagte opsies.na om ’n getal te wees",
+    "every_number": "Verwagte opsies.elke om ’n getal te wees"
+  },
+  "camera": {
+    "choose_photo": "Kies foto",
+    "choose_video": "Kies video",
+    "take_a_photo": "Neem ’n nuwe foto of kies een uit jou biblioteek",
+    "take_a_video": "Neem ’n nuwe video of kies een uit jou biblioteek",
+    "camera": "Kamera",
+    "library": "Biblioteek"
+  },
+  "text_entry": {
+    "type_placeholder": "Tik asseblief teks in",
+    "paragraph_placeholder": "Tik jou antwoord hier in."
+  },
+  "character_counter": {
+    "characters": "{{numberOfCharacters}}/{{limit}} karakters"
+  },
+  "additional": {
+    "server-error": "Bedienerfout het voorgekom",
+    "time-end": "Tyd is verstreke!",
+    "time-end-tap": "Tyd is verstreke. Tik om te voltooi",
+    "thanks": "Dankie!",
+    "sorry": "Jammer",
+    "saved_answers": "Ons het jou antwoorde gestoor!",
+    "submit_flow_answers": "Tik die",
+    "submit": "Dien in",
+    "submit_flow_answers_ex": "knoppie om jou antwoorde te stoor en voort te gaan na:",
+    "close": "Maak toe",
+    "resume_activity": "Hervat aktiwiteit",
+    "activity_resume_restart": "Wil jy hierdie aktiwiteit wat aan die gang is, hervat of weer begin?",
+    "restart": "Herbegin",
+    "resume": "Hervat",
+    "retry": "Probeer weer",
+    "send": "Stuur",
+    "later": "Later",
+    "in_progress": "Tans aan die gang",
+    "unscheduled": "Ongeskeduleerd",
+    "scheduled": "Geskeduleerd",
+    "past_due": "Agterstallig",
+    "available": "Beskikbaar",
+    "sure_delete_account_data": "Is jy seker jy wil jou rekening en data skrap?",
+    "no_cancel": "Nee, kanselleer",
+    "yes_delete": "Yes, delete it",
+    "hi": "Hallo",
+    "enter_old_password": "Voer asseblief jou ou wagwoord in",
+    "enter_new_password": "Voer asseblief ’n nuwe wagwoord in",
+    "data_not_sent": "Klik Stuur om die data wat vroeër versamel is, op te laai",
+    "data_is_sending": "Laai tans die data op wat vroeër versamel is",
+    "upload_error": "Oplaaifout",
+    "want_to_retry": "Jou internet is dalk onstabiel. Ons kon nie vir jou data stuur nie."
+  },
+  "prize": {
+    "lack_tokens_title": "Probeer weer",
+    "lack_tokens_subtitle": "Jy het nie genoeg tokens nie.\nKies asseblief ’n ander prys"
+  },
+  "cognitive": {
+    "incorrect_start_point": "Beginpunt is verkeerd!",
+    "incorrect_line": "Lyn is verkeerd!",
+    "finished_continue": "Klaar. Klik Volgende om voort te gaan.",
+    "finished_complete": "Klaar. Klik Klaar om te voltooi.",
+    "begin": "Begin",
+    "end": "Einde"
+  },
+  "system": {
+    "migration_not_applied_text": "Datamigrasie is nie suksesvol toegepas nie. Kontak asseblief die steundiens.",
+    "ok": "Goed"
+  },
+  "activity_skip_popup": {
+    "popup_title": "Slaan oor na die volgende proef?",
+    "popup_description": "Hierdie proef is onvoltooid. As jy na die volgende proef oorslaan, sal jou vordering gestoor word. Jy sal nie hierdie proef later kan voltooi nie.",
+    "keep_working": "Hou aan werk",
+    "skip": "Slaan oor"
+  },
+  "autocompletion": {
+    "done": "Klaar",
+    "time_limit_reached": "Tydlimiet is bereik",
+    "time_expired": "Die tyd om {{activityNames}} te voltooi, het verval. Jou antwoorde sal outomaties ingedien word.",
+    "processing_answers": "Verwerk tans antwoorde",
+    "preparing_answers": "Wag asseblief en moenie die skerm toemaak nie.",
+    "answers_submitted": "Antwoorde ingedien",
+    "thanks": "Dankie! Ons het alles gestoor.",
+    "time_is_up_modal_description": "Daar is nie meer tyd oor om aan hierdie aktiwiteit te werk nie. Al die werk wat jy gedoen het, sal gestoor en ingedien word.",
+    "time_is_up_modal_title": "Tyd is verstreke",
+    "ok": "Goed"
+  },
+  "data_sharing": {
+    "consent": "Ek stem in om my antwoorde te gee",
+    "media_consent": "Ek stem in om my media-antwoorde",
+    "public": "openbaar te maak",
+    "dialog": {
+      "body": "Om antwoorde openbaar te deel, impliseer dat inligting wat deur individuele gebruikers verskaf word, bv. opname-antwoorde of terugvoer, openlik beskikbaar sal wees vir ander om te besigtig."
+    }
+  },
+  "assignment": {
+    "badge": "Meer oor {{name}}",
+    "banner": "Maak asseblief seker al jou antwoorde handel oor <strong>{{name}}</strong>"
+  },
+  "splash": {
+    "version": "Weergawe"
+  },
+  "requestHealthRecordData": {
+    "title": "Versoek gesondheidsrekorddata",
+    "linkText": "Vind uit hoe Curious beveiligd toegang tot gesondheidsorgdata verkry.",
+    "partnershipText": "Curious gebruik 1UpHealth se mediese inligtingsdiens om jou navorser in staat te stel om toegang tot inligting in jou gesondheidsorgrekords te verkry.\n\nIn die volgende skerms sal jy gevra word om by jou gesondheidsorgverskafferstelsels aan te meld en jou gesondheidsorgdata met hierdie studie te deel. Jy sal terugkeer na die Curious-aktiwiteit wanneer jy klaar is.",
+    "enterYourHealthSystem": "Voer jou gesondheidstelsel in:",
+    "healthSystemName": "Naam van gesondheidstelsel",
+    "search": "Soek",
+    "additionalPromptText": "Jy het klaar aangemeld by jou gesondheidsorgrekening.\n\nWil jy by enige bykomende gesondheidsorgrekeninge aanmeld?",
+    "yes": "Yes",
+    "no": "Nee",
+    "noResults": "Geen gesondheidsorgverskaffers is gevind wat by jou soektog pas nie."
+  },
+  "announcementBanner": {
+    "content": "<0>Ons kry ’n nuwe voorkoms!</0> <1>Ontwerpopdaterings is op pad – dieselfde wonderlike toep, vars nuwe voorkoms. Nuuskierig?</1> <2>Tik vir meer inligting.</2>"
+  },
+  "unity": {
+    "error_title": "Unity Build het misluk",
+    "error_message": "Kon nie die aktiwiteit laai nie; kontak asseblief die outeur vir hulp. Die aktiwiteit sal nou toemaak.",
+    "error_message_flow": "Kon nie die aktiwiteit laai nie; kontak asseblief die outeur vir hulp. Jy sal na die volgende aktiwiteit in die vloei geneem word: ",
+    "error_ok": "Goed",
+    "restart_title": "Unity Build-fout",
+    "restart_message": "Die aktiwiteit het ’n kritieke fout teëgekom en moet toemaak. Die data wat tot dusver uit hierdie aktiwiteit versamel is, sal verlore gaan.\n\nJy kan die aktiwiteit herbegin om weer te probeer.",
+    "restart_primary": "Herbegin aktiwiteit",
+    "restart_secondary_solo": "Verlaat",
+    "restart_secondary_flow": "Gaan voort na volgende aktiwiteit"
+  }
+}

--- a/assets/translations/af.json
+++ b/assets/translations/af.json
@@ -278,7 +278,10 @@
     "fr": "Français",
     "el": "Ελληνικά",
     "es": "Español",
-    "pt": "Português"
+    "pt": "Português",
+    "af": "Afrikaans",
+    "xh": "isiXhosa",
+    "zu": "isiZulu"
   },
   "application_logs_screen": {
     "upload_button": "Laai logs op",

--- a/assets/translations/el.json
+++ b/assets/translations/el.json
@@ -240,7 +240,10 @@
     "fr": "Français",
     "el": "Ελληνικά",
     "es": "Español",
-    "pt": "Português"
+    "pt": "Português",
+    "af": "Afrikaans",
+    "xh": "isiXhosa",
+    "zu": "isiZulu"
   },
   "application_logs_screen": {
     "upload_button": "Μεταφόρτωση αρχείων καταγραφής",

--- a/assets/translations/en.json
+++ b/assets/translations/en.json
@@ -278,7 +278,10 @@
     "fr": "Français",
     "el": "Ελληνικά",
     "es": "Español",
-    "pt": "Português"
+    "pt": "Português",
+    "af": "Afrikaans",
+    "xh": "isiXhosa",
+    "zu": "isiZulu"
   },
   "application_logs_screen": {
     "upload_button": "Upload logs",

--- a/assets/translations/es.json
+++ b/assets/translations/es.json
@@ -240,7 +240,10 @@
     "fr": "Français",
     "el": "Ελληνικά",
     "es": "Español",
-    "pt": "Português"
+    "pt": "Português",
+    "af": "Afrikaans",
+    "xh": "isiXhosa",
+    "zu": "isiZulu"
   },
   "application_logs_screen": {
     "upload_button": "Cargar registros",

--- a/assets/translations/fr.json
+++ b/assets/translations/fr.json
@@ -465,7 +465,10 @@
     "fr": "Français",
     "el": "Ελληνικά",
     "es": "Español",
-    "pt": "Português"
+    "pt": "Português",
+    "af": "Afrikaans",
+    "xh": "isiXhosa",
+    "zu": "isiZulu"
   },
   "application_logs_screen": {
     "upload_button": "Télécharger les journaux",

--- a/assets/translations/pt.json
+++ b/assets/translations/pt.json
@@ -240,7 +240,10 @@
     "fr": "Français",
     "el": "Ελληνικά",
     "es": "Español",
-    "pt": "Português"
+    "pt": "Português",
+    "af": "Afrikaans",
+    "xh": "isiXhosa",
+    "zu": "isiZulu"
   },
   "application_logs_screen": {
     "upload_button": "Carregar registros",

--- a/assets/translations/xh.json
+++ b/assets/translations/xh.json
@@ -1,0 +1,588 @@
+{
+  "auth": {
+    "email": "I-imeyile",
+    "email_address": "Idilesi yemeyile",
+    "password": "Inombolo yokuvula",
+    "i_agree": "Ndiyavumelana ne",
+    "terms_of_service": "Imimmisele yenkonzo",
+    "terms": "Imigaqo",
+    "privacy": "Ubumfihlo",
+    "privacy_policy": "Umthetho wabucala",
+    "password_updated": "Iphasiwedi ihlaziyiwe"
+  },
+  "activity": {
+    "completeOnWeb": "Nceda ugcwalise kwi-Curious web app",
+    "incorrect_answer": "Impendulo engalunganga. Nceda zama kwakhona",
+    "failed": "Ayiphumelelanga",
+    "flanker_accuracy_warn": "*Izitampu zexesha eziqokelelweyo ze-android azichanekanga njengezixhobo ze-iOS.",
+    "please_wait": "Nceda linda",
+    "activity_all_items_hidden": "\"{{entityName}}\" ayinakuqalwa kuba zonke izinto ezingaphakathi komsebenzi zifihliwe",
+    "flow_all_items_hidden": "\"{{entityName}}\" ayinakuqalwa kuba iqulethe umsebenzi apho zonke izinto zifihlwe",
+    "progress": {
+      "upload_files": "Kunyuswa iifayile zakho...",
+      "encrypt_answers": "Iguqulela ngokuntsonkothileyo iimpendulo zakho...",
+      "upload_answers": "Ifakela iimpendulo zakho...",
+      "completed": "Umsebenzi ulayishiwe"
+    },
+    "step": "Inyathelo",
+    "flowStep": "({{activityPositionInFlow}} ye {{numberOfActivitiesInFlow}}){{activityFlowName}}",
+    "stepCounter": "{{currentStep}} ye {{totalSteps}}",
+    "activityCounter": "Umsebenzi {{currentStep}} we {{totalSteps}}"
+  },
+  "activity_time": {
+    "time_remaining": "eseleyo kule nto"
+  },
+  "timed_activity": {
+    "time_to_complete": "Ixesha lokugqiba",
+    "time_to_complete_hm": "Ixesha lokugqiba: {{hours}} Iiyure kunye {{minutes}}imizuzu",
+    "hours": "iiyure"
+  },
+  "activity_summary": {
+    "terms_text": "Ndiyaqonda ukuba ulwazi olunikelwe kolu luhlu ayenzelwanga ukuthatha indawo yengcebiso, uxilongo, okanye unyango olunikwa ngugqirha okanye ingcali yempilo yengqondo, kwaye iimpendulo zam ezingachazwanga zisenokusetyenziswa kwaye kwabelwane ngazo kuphando ngokubanzi ngempilo yengqondo yabantwana.",
+    "footer_text": "KUNYE NOKWENZA UNYANGO LWENGQONDO YOMNTWANA, I-PLLC (KUNYE, “I-CMI”) AYIWENZI NGQO OKANYE NGINGQONDO NGENGQONDO OKANYE IKHIWE INGCEBISO ZEZONYANGO NJENGXALENYE LWEMIBUZO. I-CMI AYIQINISEKI NGAYO NALUPHI UXANDUVA, UNYANGO, ISIGQIBO EESENZELWEYO, OKANYE INYATHELO ELITHATYATHIWEYO NGOKUXHOMEKELA KULWAZI LWEMIBUZO, KWAYE AYIQINISEKI UXANDUVA LOKUSEBENZISA LE MIBUZO.",
+    "score_on_subscale": "Amanqaku kwi {{name}} subscale yaba",
+    "save": "Gcina",
+    "summary": "Isishwankathelo",
+    "alerts": "Izilumkiso",
+    "report_summary": "Ingxelo isishwankathelo",
+    "not_yet_completed": "Ayikagqitywa",
+    "last_completed": "Igqityelwe ukugqitywa",
+    "unscheduled": "Ayicwangciswanga",
+    "due": "Kufuneka",
+    "scheduled_for": "Icwangciselwe",
+    "category_suicide": "Ukuzibulala",
+    "category_suicide_message": "Umzali wabonisa ukuba kunokwenzeka ukuxhatshazwa. Zisa kugqirha ngokukhawuleza ngenxa yemeko engxamisekileyo.",
+    "category_emotional": "Ngokweemvakalelo",
+    "category_emotional_message": "Akukho luvavanyo lungaphaya olufunekayo.",
+    "category_sport": "Ezemidlalo",
+    "category_sport_message": "Yazisa ugqirha; Yenza uvavanyo lokulandelela (Kuyacetyiswa); Yenza ukuthunyelwa.",
+    "share_report": "Yabelana ngeNgxelo",
+    "share_all_reports": "Yabelana Ngazo Zonke Iingxelo"
+  },
+  "activity_chart": {
+    "title": "Nceda uthathe uvavanyo ukuze idatha iboniswe.",
+    "monday": "UMVULO",
+    "tuesday": "ULWESIBINI",
+    "wednesday": "ULWESITHATHU",
+    "thursday": "ULWESIBINI",
+    "friday": "ULWESIHLANU",
+    "saturday": "UMGQIBELO",
+    "sunday": "UMGQIBELO"
+  },
+  "calendar": {
+    "months": "NgoJanuwari_Februwari_Matshi_Apreli_Meyi_Juni_Julayi_Agasti_Septemba_Okthobha_Novemba_Disemba",
+    "weekdays": "Langa_Mso_Lwesibini_Lwesithathu_Lwesihlanu_Sat",
+    "x_days": "MVULO_LWESIBINI_LWESITHATHU_LWESINE_LWESIHLANU_MGQIBELO_CAWE"
+  },
+  "applet_data": {
+    "title": "Nceda uthathe uvavanyo ukuze idatha iboniswe."
+  },
+  "widget_error": {
+    "error_text": "Bekukho ingxaki ekulayisheni esi sikrini.",
+    "error_description": "Nceda uqinisekise ukuba unoguqulelo lwamva nje lweCurious efakiweyo, emva koko uqhagamshelane nomphathi wakho ukuba ingxaki isenzeka."
+  },
+  "about": {
+    "about": "Malunga",
+    "applets_title": "Fumana ulwazi oluthe kratya malunga ne-applet yakho nganye kunye neqonga lokuCurious.",
+    "data_title": "Fumana ulwazi oluthe kratya malunga neqonga lokuqokelelwa kwedatha eCurious ngokucofa u-'About\nUnomdla' ngezantsi.",
+    "about_curious": "Malunga noCurious",
+    "icons_title": "Iimpawu zeNounProject zenziwe ngu-Alina Oleynik (uvavanyo), beth bolton (incwadi), kunye\niShakeel (itshathi)",
+    "device_id": "I-ID yesixhobo"
+  },
+  "about_app": {
+    "title_with_version": "Yintoni Curious? v.{{version}}",
+    "title": "Ngaphandle kokuba kuchazwe kwenye indawo, ii-icon zizotywa kwi-OpenMoji kunye ne-NounProject.",
+    "subtitle": "Ngaphandle kokuba kuchazwe kwenye indawo, ii-icon zizotywa kwi-OpenMoji kunye ne-NounProject.",
+    "curious_about": "## \n ### Yintoni uCurious? \n\n Le app yinxalenye yomthombo ovulelekileyo wokuqokelelwa kwedatha kunye neqonga lohlalutyo eliyilwe yi-MATTER Lab kwiziko leNgqondo yoMntwana ([https://matter.childmind.org](https://matter.childmind.org)). \n # \n ### Yintoni enokwenziwa nguCurious? \n\n Iseti yenqaku leCurious iyakhula, kwaye okwangoku ixhasa iintlobo ngeentlobo zegalelo. Isikrini ngasinye kumsebenzi onomdla sinokubandakanya nayiphi na kwezi zilandelayo: \n  -Umbhalo, umfanekiso kunye nesandi \n  - Umbuzo olandelwa ngumfanekiso kunye/okanye ukhetho lokuphendula okubhaliweyo \n  -Ibha yesilayidi \n  - Ungeniso lokubhaliweyo \n  - Ungeno lwetheyibhile \n  - Irekhodi yomsindo \n  -Ukuthathwa kwefoto/ividiyo \n  - Ukuzoba okanye ukucofa \n  -I-geolocation yangoku \n  - Umsebenzi wengqiqo olula \n  - Libazise phambi kwempendulo \n  - Isibali-xesha \n  -Ingqiqo yoxhomekeko yokumisela ukuba ungaya phi ngokulandelayo \n\n #### Ndingafunda phi ngakumbi? \n Nceda ndwendwela [https://mindlogger.org] (https://mindlogger.org) ngolwazi olungakumbi.  \n ## [Inkxaso] ({{credits_link}}) \n ## [Imiqathango yenkonzo] (https://mindlogger.org/terms-of-service) \n ## [Umgaqo-nkqubo wabucala](https://mindlogger.org/privacy-policy) \n\n ##### Masinwabe, \n\n ##### Iqela elinomdla \n\n ##### i-Child Mind Institute"
+  },
+  "applet_footer": {
+    "surveys": "Uvavanyo",
+    "data": "Idatha",
+    "about": "Malunga",
+    "activities": "Imisebenzi",
+    "activity": "Umsebenzi"
+  },
+  "applet_invite_flow": {
+    "back": "Emva",
+    "next": "Okulandelayo"
+  },
+  "live_connection": {
+    "disconnect": "NQAPHELA",
+    "connect": "NGENISA",
+    "connect_to_server": "Qhagamshela Kwiseva",
+    "remember": "Khumbula",
+    "ip": "Idilesi yeIP",
+    "port": "Izibuko",
+    "connection_closed": "I-TCP Connection yavalwa",
+    "connection_error": "Uqhagamshelo aluphumelelanga. Nceda ujonge kabini i-ip kunye nezibuko",
+    "connection_set_error": "Ayinakuseta uqhagamshelwano",
+    "live_connection": "I Live Connection",
+    "not_available": "Ayifumaneki"
+  },
+  "join_invite": {
+    "click_below": "Cofa ngezantsi ukuba ukulungele ukujoyina olu phononongo. Ungazisusa kolu phononongo kunye/okanye ucime idatha yakho nangaliphi na ixesha ngaphandle kweziphumo.",
+    "decline": "Ukuba awuziva ukhululekile ngokwabelana ngedatha yakho kolu phononongo, ungasala esi simemo. ",
+    "decline_title": "Yala"
+  },
+  "applet_list_component": {
+    "about_title": "Malunga noCurious",
+    "no_applets_yet": "Awunazo ii-apile.",
+    "noon": "Emini emaqanda",
+    "midnight": "Ezinzulwini zobusuku",
+    "refresh_error_header": "Hlaziya imposiso",
+    "applets_not_refreshed": "Ezi applets zilandelayo azizange zihlaziywe:",
+    "common_refresh_error": "Uluhlu lwe applets aluzange luhlaziywe. Nceda zama kwakhona."
+  },
+  "activity_list_component": {
+    "no_activities": "Akukho misebenzi ikhoyo onokuthi uyigqibe ngoku",
+    "insufficient_data_error": "Le applet ayizange ihlaziywe. Nceda uzame ukuhlaziya kwakhona.",
+    "other_error": "Kwenzeke impazamo engachazwanga"
+  },
+  "applet_settings": {
+    "applet_not_defined": "Akukho applet ichaziweyo.",
+    "want_remove": "Ukuba ufuna ukususa le applet, kodwa gcina idatha yakho, cofa ngezantsi",
+    "remove": "Susa",
+    "want_delete": "Ukuba ufuna ukucima idatha yakho kule applet kwaye uyisuse, cofa ngezantsi.",
+    "remove_delete": "Susa kwaye ucime iDatha",
+    "alert_title": "Ngaba uqinisekile ukuba ufuna ukucima idatha yakho?",
+    "alert_message": "Awunakukwazi ukuyibuyisela",
+    "cancel_text": "Hayi, rhoxisa",
+    "confirm_text": "Ewe, yicime"
+  },
+  "change_pass_form": {
+    "update": "Hlaziya",
+    "cur_pass_placeholder": "Iphasiwedi yangoku",
+    "new_pass_placeholder": "Iphasiwedi entsha",
+    "error": "Akukwazeki ukuhlaziya iinkcukacha zomsebenzisi.",
+    "submission_error": "Igama lokugqithisa langoku olifakileyo belingalunganga.",
+    "change_pass": "Tshintsha iphasiwedi",
+    "password_at_least_characters": "Phasiwedi bayibe nonobumba {{min}} ubuncinane"
+  },
+  "password_recovery_form": {
+    "password_at_least_characters": "Phasiwedi bayibe nonobumba {{min}} ubuncinane",
+    "password_no_spaces": "Phasiwedi mayingabinazithuba phakathi",
+    "passwords_do_not_match": "IiPhasiwedi azihambelani",
+    "password_confirmation_required": "Nceda uqinisekise igama eliyimfihlo",
+    "new_password_placeholder": "Iphasiwedi entsha",
+    "confirm_password_placeholder": "Ngqina iphasiwedi",
+    "submit": "Ngenisa",
+    "invalid_password_reset_link": "Eli khonkco alisebenzi okanye liphelelwe lixesha.",
+    "click_to_reset_password": "Nceda ucofe ngezantsi ukuseta ngokutsha igama lakho lokugqithisa.",
+    "forgot_password": "Ingaba uyilibele iphasiwedi",
+    "success": "Igama lokugqithisa lakho limiselwe ngokutsha ngempumelelo. Nceda ungene ngephasiwedi yakho entsha.",
+    "error": "Impazamo yokusetha kwakhona igama lokugqithisa lakho"
+  },
+  "mfa_recovery": {
+    "title": "Qinisekisa ukuba ungubani",
+    "subtitle": "Nceda ngenisa ikhowudi yokubuyisela i-akhawunti.",
+    "continue": "Qhubeka",
+    "back": "Emva",
+    "invalid_code_format": "Ikhowudi yokubuyisela must be ibekwifomathi XXXXX-XXXXX",
+    "placeholder": "XXXXX-XXXXX",
+    "error": "Ikhowudi yokubuyisela engasebenziyo. Nceda zama kwakhona.",
+    "success": "Isazisi siqinisekiswe ngempumelelo",
+    "error_invalid_code": "Ikhowudi yokubuyisela engasebenziyo. Nceda ujonge kwaye uzame kwakhona.",
+    "error_code_not_found": "Ikhowudi yokubuyisela ayifunyenwanga okanye sele isetyenzisiwe.",
+    "error_session_expired": "Iseshoni yakho iphelelwe lixesha. Nceda ungene kwakhona.",
+    "error_too_many_attempts": "Mininzi kakhulu imizamo engaphumeleliyo. Nceda uzame ukungena kwakhona.",
+    "error_global_lockout": "Mininzi kakhulu imizamo engaphumeleliyo. Uvalelwe ngaphandle okwethutyana. Nceda uzame ukungena emva kwemizuzu eyi-15.",
+    "error_network": "Impazamo yenethiwekhi. Nceda ujonge uqhakamshelwano lwakho kwaye uzame kwakhona.",
+    "error_unknown": "Impazamo yenzekile. Nceda zama kwakhona."
+  },
+  "mfa_verification": {
+    "title": "Qinisekisa ukuba ungubani",
+    "subtitle": "Nceda ngenisa ikhowudi yokuqinisekisa eboniswe kwi-app yakho yesiqinisekiso.",
+    "verify": "Qhubeka",
+    "placeholder": "Faka ikhowudi yokugqina",
+    "invalid_code_format": "Ikhowudi yokuqinisekisa must be inamanani ama-6",
+    "error": "Ikhowudi engasebenziyo",
+    "success": "Uqinisekiso luphumelele",
+    "use_recovery_code": "Andikwazi ukufikelela kwi-app yam yesiqinisekisi",
+    "session_expiry_warning": "Iseshini inokuba iphelile. Nceda uqinisekise ngesandla okanye ungene kwakhona.",
+    "error_invalid_code": "Ikhowudi yokuqinisekisa engasebenziyo. Nceda ujonge kwaye uzame kwakhona.",
+    "error_session_expired": "Iseshoni yakho iphelelwe lixesha. Nceda ungene kwakhona.",
+    "error_too_many_attempts": "Mininzi kakhulu imizamo engaphumeleliyo. Nceda uzame ukungena kwakhona.",
+    "error_global_lockout": "Mininzi kakhulu imizamo engaphumeleliyo. Uvalelwe ngaphandle okwethutyana. Nceda uzame ukungena emva kwemizuzu eyi-15.",
+    "error_network": "Impazamo yenethiwekhi. Nceda ujonge uqhakamshelwano lwakho kwaye uzame kwakhona.",
+    "error_unknown": "Impazamo yenzekile. Nceda zama kwakhona.",
+    "warning_session_attempts_remaining": ". {{count}} umzamo oseleyo",
+    "warning_session_attempts_remaining_plural": ". {{count}} imizamo eseleyo",
+    "warning_global_attempts_remaining": ". {{count}} ukuzama okushiyekileyo phambi kokutshixa okwethutyana",
+    "warning_global_attempts_remaining_plural": ". {{count}} imizamo eshiyekileyo phambi kokutshixa okwethutyana"
+  },
+  "change_study": {
+    "reset": "Lungisa kwakhona",
+    "submit": "Ngenisa",
+    "enter_url_manually": "Ngenisa i-URL ngesandla",
+    "scan_qr": "Skena i-QR",
+    "successfully_changed": "Iseva ye-Url yatshintshwa ngempumelelo.",
+    "successfully_reset": "Iseva ye-Url iye yamiselwa ngokutsha ngempumelelo.",
+    "change_server": "Guqula iseva",
+    "http_confirm": "Uqinisekile ufuna ukudibanisa kwiseva engaxhasi i-ssl?",
+    "set_by_qr": "Uphononongo lusetwe yi-QR.",
+    "yes": "Ewe",
+    "no": "Hayi"
+  },
+  "consent": {
+    "this_app_provides": "Le app ibonelela ngendlela elula yokuqokelela uphando, ilizwi, imisebenzi yokuzoba.",
+    "i_understand": "Ndiyaqonda ukuba ukujonga imifanekiso ethile kunokungakhululeki ngelixa usebenzisa le app",
+    "i_will_allow": "Ndiza kuvumela iZiko leNgqondo yoMntwana ukuba ligcine idatha ekusebenziseni le app kwindawo ekhuselekileyo\numncedisi welifu, kunye nokufikelela kolu lwazi ngeenjongo zeklinikhi kunye nophando",
+    "i_premit": "Ndivumela iZiko leeNgqondo zaBantwana ukuba liqhagamshelane nam malunga nolwazi oluqokelelwe kulo\nle app ngeenjongo zeklinikhi okanye zophando.",
+    "next": "Okulandelayo"
+  },
+  "forgot_pass_form": {
+    "reset_pass": "Lungisa Igama Lokugqithisa",
+    "enter_email_mess": "Nceda ngenisa idilesi yemeyile yakho",
+    "invalid_email": "Idilesi yemeyile engekhoyo",
+    "email_address": "Idilesi yemeyile",
+    "email_send_success": "Phinda umisele i-imeyile ithunyelwe <strong>{{email}}</strong> ukuba i-akhawunti ikhona.",
+    "email_send_error": "Akukwazeki ukuthumela i-imeyile ngokutsha ngeli xesha.",
+    "forgot_password": "Ingaba uyilibele iphasiwedi?"
+  },
+  "login": {
+    "new_user": "Umsebenzisi omtsha",
+    "account_create": "Yenza i-akhawunti",
+    "forgot_password": "Ingaba uyilibele iphasiwedi?",
+    "what_is": "Yintoni i",
+    "login_error": "Ukungena akuphumelelanga.",
+    "password_at_least_characters": "Igama lokugqithisa must be libe nonobumba abali-10"
+  },
+  "login_form": {
+    "login": "Ngena",
+    "email_placeholder": "I-imeyile",
+    "password": "Inombolo yokuvula"
+  },
+  "logout_warning": {
+    "warning": "Phuma Isilumkiso",
+    "uploads_in_progress": "Ukulayisha kuyaqhubeka",
+    "currently_uploading": "Uneempendulo ezilayishayo ngoku. Ukuba uphuma ngoku kwaye ungene njengomsebenzisi owahlukileyo, iimpendulo zakho ziya kulahleka.",
+    "not_uploaded": "Awulayishanga iimpendulo. Ukuba uphuma ngoku kwaye ungene njengomsebenzisi owahlukileyo, iimpendulo zakho ziya kulahleka.",
+    "sure_logout": "Uqinisekile ukuba ufuna ukuphuma?",
+    "cancel": "Rhoxisa",
+    "logout": "Phuma"
+  },
+  "settings": {
+    "logged_out": "Uphumile.",
+    "change_pass": "Tshintsha iphasiwedi",
+    "use_cellular_data": "Sebenzisa iDatha yeSelula",
+    "logout": "Phuma",
+    "permanently_delete_account": "Cima ngokusisigxina i-akhawunti",
+    "user_settings": "Iisetingi zomsebenzisi",
+    "upload_logs": "Layisha Logs",
+    "create_new_password": "Yenza iphasiwedi entsha"
+  },
+  "language_screen": {
+    "app_language": "Ulwimi lwesicelo",
+    "change_app_language": "Guqula ulwimi",
+    "en": "English",
+    "fr": "Français",
+    "el": "Ελληνικά",
+    "es": "Español",
+    "pt": "Português"
+  },
+  "application_logs_screen": {
+    "upload_button": "Layisha logs",
+    "title": "Unemiba yobugcisa? Iifayile zakho zelog ziya kunceda iqela lethu ukulungisa ingxaki.",
+    "subTitle": "Nceda uzilayishe usebenzisa iqhosha elingezantsi.",
+    "success": "Impumelelo-sifumene iilog zakho.",
+    "error": "Impazamo - iilog azithunyelwanga. Nceda zama kwakhona."
+  },
+  "sign_up_form": {
+    "sign_up": "Bhalisa",
+    "error": "Ukubhalisa akuphumelelanga: igama lomsebenzisi lisenokuba sele lisetyenziswa.",
+    "new_user": "Umsebenzisi omtsha",
+    "username_validation_error": "Igama lomsebenzisi must be libe nonobumba aba-4 ubuncinane, liqale ngonobumba, kwaye lingaqulatha kuphela oonobumba, amanani, iidash, kunye namachaphaza.",
+    "email_validation_error": "Kubonakala ngathi le imeyile ayigqitywanga",
+    "email_placeholder": "I-imeyile",
+    "first_name": "Igama lakho",
+    "last_name": "Ifani",
+    "password_placeholder": "Inombolo yokuvula",
+    "please_accept_terms": "Nceda wamkele imiqathango yenkonzo.",
+    "email_looks_incomplete": "Kubonakala ngathi le imeyile ayigqitywanga",
+    "sign_up_agree": "Ngokubhalisa, uyavumelana neCurious's",
+    "and": "kwaye"
+  },
+  "password_requirements": {
+    "at_least_characters": "Abalinganiswa abali-10",
+    "no_blank_spaces": "akukho zithuba zingenanto",
+    "must_include": "Iphasiwedi kufuneka iqulathe ubuncinane {{minLength}} amagama, kungabikho zithuba, kwaye noko {{types}} kwezi 4 zingezantsi:",
+    "must_include_minimum": "Igama lokugqithisa kufuneka liqulathe ubuncinane {{minLength}} amagama kwaye kungabikho zithuba",
+    "requirements_met": "Zonke iimfuno zifezekisiwe.",
+    "must_include_uppercase": "Oonobumba abakhulu (A-Z)",
+    "must_include_lowercase": "Oonobumba abancinci (a-z)",
+    "must_include_digits": "Inani (0-9)",
+    "must_include_symbol": "Iimpawu (! @#$...)",
+    "cannot_contain_emojis": "Igama lokugqithisa alinakuqulatha i-emojis."
+  },
+  "geolocation": {
+    "get_location": "FUMANA INDAWO",
+    "must_enable_location": "Kufuneka uvule iinkonzo zeNdawo ukugqiba lo msebenzi. Nceda unike imvume yeCurious kwiiSetingi zakho ze-iOS kwaye ucinezele iqhosha kwakhona.",
+    "must_enable_location_subtitle": "Kufuneka uvule iinkonzo zeNdawo ukugqiba lo msebenzi. Nceda ucinezele iqhosha kwakhona kwaye unike imvume yokuba ukwazi ukusebenzisa indawo yakho.",
+    "location_saved": "Indawo igciniwe.",
+    "service_not_available": "Inkonzo yendawo ayifumaneki."
+  },
+  "select": {
+    "select_one": "Khetha enye",
+    "no_items": "Akukho zinto"
+  },
+  "permissions": {
+    "alert_button_cancel": "Gxotha",
+    "alert_button_ok": "Vula iiSetingi",
+    "alarm_permission_warning": "Isicelo semvume yokulumkisa",
+    "alarm_permission_disabled": "Nceda uvule iimvume ze-alam kwisixhobo sakho ukuze ufumane izikhumbuzi zeCurious kwishedyuli. Nceda uqaphele ukuba usetyenziso luya kuvalwa ngokuzenzekelayo wakube uvule iimvume ze-alam.",
+    "gallery": "\"Unomdla\" ungathanda ukusebenzisa igalari yakho ukugqiba lo msebenzi",
+    "camera": "\"Curious\" ingathanda ukusebenzisa ikhamera yakho ukugqiba lo msebenzi"
+  },
+  "media": {
+    "alert_message": "Ezi zinokumiselwa kwiiSetingi",
+    "media_found_title": "Awukho kwi-intanethi",
+    "media_found_body": "Lo msebenzi uqulethe izinto ezifuna uqhagamshelo lwe-intanethi. Nceda uvule i-intanethi ukuze uqhubeke."
+  },
+  "audio_recorder": {
+    "permission": "Kufuneka unike imvume yokusebenzisa imakrofoni yakho ukugqiba lo msebenzi.",
+    "alert_title": "\"Curious\" ingathanda ukusebenzisa imakrofoni yakho ukugqiba lo msebenzi.",
+    "alert_message": "Ezi zinokumiselwa kwiiSetingi.",
+    "record_error": "Kubekho impazamo ekuqaliseni ushicilelo.",
+    "stop": "YEKA",
+    "record": "INGXELO",
+    "recording": "Iyarekhoda...",
+    "seconds": "imizuzwana",
+    "file_saved": "Ifayile igciniwe."
+  },
+  "audio_player": {
+    "stop": "YEKA",
+    "playing": "IYADLALA...",
+    "play": "DLALA",
+    "done": "YENZIWE",
+    "loading": "IYALAYISHA"
+  },
+  "optional_text": {
+    "required": "Le yindawo efunekayo.",
+    "enter_text": "Nceda ngenisa okubhaliweyo."
+  },
+  "date_picker": {
+    "ok": "KULUNGILE"
+  },
+  "table_input": {
+    "short_press_detail": "* Ucofa omfutshane wongeza isixhobo sokubala",
+    "long_press_detail": "• Ukucofa ixesha elide kuthoba isixhobo sokubala"
+  },
+  "activity_due_date": {
+    "available_all_day": "Ifumaneka Ukusuka",
+    "scheduled_at": "Icwangciswe ngo",
+    "available": "Ifumaneka Ukusuka",
+    "to": "Ukuya",
+    "day": "usuku",
+    "days": "iintsuku",
+    "am": "EKUSENI",
+    "the_following_day": "ngosuku olulandelayo"
+  },
+  "form_item": {
+    "required": "Kufuneka",
+    "must_be": "Must be",
+    "characters_or_less": "abalinganiswa okanye ngaphantsi",
+    "must_be_a_number": "Must be inani"
+  },
+  "applet_about": {
+    "loading": "iyalayisha",
+    "no_info": "Ababhali bale applet abanikanga naluphi na ulwazi!"
+  },
+  "firebase_messaging": {
+    "alert_title": "\"Curious\" ingathanda ukukuthumelela izaziso",
+    "alert_message": "Ezi zinokumiselwa kwiiSetingi",
+    "alert_text": "Vula iiSetingi",
+    "response_refresh_request": "Isicelo sokuhlaziya impendulo",
+    "refresh_request_details": "Kuba igama lokugqithisa lakho lisetyenzisiwe, iimpendulo zakho ezidlulileyo kufuneka zihlaziywe. Uyafuna ukuyicela lento?",
+    "refresh_request_text": "Abaphathi bakho baya kuqalisa ukuhlaziya kungekudala.",
+    "applet_not_found_1": "I-Applet ayifunyanwanga",
+    "applet_not_found_2": "Akukho applet ye id enikiweyo.",
+    "activity_not_found": "Umsebenzi \"{{entityName}}\" awufumaneki ngoku.",
+    "activity_not_available_title": "Umsebenzi awufumaneki",
+    "activity_not_available_message": "Umsebenzi ozame ukufikelela kuwo awukho okwangoku. Ungazama kwakhona kamva ngexesha elilandelayo elicwangcisiweyo lefestile.",
+    "activity_not_assigned": "Oku {{entityName}} akunikezelwa kuwe.",
+    "activity_not_available": "Le {{entityName}} ayisafumaneki.",
+    "activity_scheduled_today": "I {{entityName}} icwangciselwe ukuba ifumaneke e {{time}}.",
+    "activity_completed_today": "{{entityName}}sele igqityiwe okwangoku.",
+    "already_completed": "Sele ugqibile",
+    "app_killed_on_redux_persist": "Lo msebenzi awunakuqalwa. Nceda, qhagamshelana nenkxaso.",
+    "activity_was_due_at": "This activity was due at",
+    "if_progress_was_made_on_the": "If progress was made on the",
+    "it_was_saved_but_it_can_no_longer_be_taken": "it was saved but it can no longer be taken",
+    "today": "namhlanje.",
+    "today2": "Imiselwe namhlanje",
+    "activity_not_ready": "Umsebenzi awukalungi",
+    "not_able_to_start": "Awunakukwazi ukuqalisa umsebenzi okwangoku",
+    "is": "yi",
+    "scheduled_to_start_at": "icwangciselwe ukuqala nge",
+    "postponed_notification": "Nje ukuba iimpendulo zilayishiwe, siya kuzama ukuvula umsebenzi"
+  },
+  "local_notifications": {
+    "complete_activity": "Nceda ugqibezele lo msebenzi."
+  },
+  "join_demo_applets": {
+    "healthy_brain_network": "Uthungelwano lweNgqondo esempilweni:",
+    "cognitive_tasks": "Imisebenzi yokuqonda",
+    "mind_logger_demos": "Iidemo ezinomdla"
+  },
+  "data_invite": {
+    "message": "Sicinga ukuba kubalulekile ukuba wazi ukuba ngubani onokufikelela kwidatha yakho ukuba uyasamkela esi simemo.\n\nAba bantu balandelayo baya kuba nofikelelo kwidatha yakho ukuba uyasamkela esi simemo:"
+  },
+  "sidebar": {
+    "home": "Ekhaya",
+    "settings": "Iisetingi",
+    "about": "Malunga",
+    "logout": "Phuma"
+  },
+  "navigator": {
+    "exit_title": "Phuma kwi-App",
+    "exit_subtitle": "Uyaphuma kwisicelo?",
+    "cancel": "Rhoxisa"
+  },
+  "activity_navigation": {
+    "next": "Okulandelayo",
+    "skip": "Tsiba",
+    "done": "Yenziwe",
+    "back": "Emva",
+    "return": "Buyela",
+    "undo": "Qhaqha",
+    "exit": "Gcina & Uphume"
+  },
+  "network_alerts": {
+    "no_internet_title": "Alukho uQhagamshelwano lwe-Intanethi",
+    "no_internet_subtitle": "Nceda uqhagamshele kwi-intanethi",
+    "no_internet_text": "Gxotha",
+    "cellular_data_title": "Idatha yeSelula ivaliwe",
+    "cellular_data_subtitle": "Nceda uqhagamshele kwi-wi-fi okanye uvumele idatha yeselula",
+    "cellular_data_text": "Gxotha",
+    "use_cellular_data": "Sebenzisa iDatha yeSelula"
+  },
+  "timing": {
+    "provide_option": "You must provide the \"after\" or \"every\" option",
+    "to_be_number": "Expected options.after to be a number",
+    "every_number": "Expected options.every to be a number"
+  },
+  "camera": {
+    "choose_photo": "Khetha ifoto",
+    "choose_video": "Khetha ividiyo",
+    "take_a_photo": "Thatha ifoto entsha okanye ukhethe enye kwithala leencwadi lakho",
+    "take_a_video": "Thatha ividiyo entsha okanye ukhethe enye kwithala leencwadi lakho",
+    "camera": "Ikhamera",
+    "library": "Ithala leencwadi"
+  },
+  "text_entry": {
+    "type_placeholder": "Nceda uchwetheze umbhalo",
+    "paragraph_placeholder": "Chwetheza impendulo yakho apha."
+  },
+  "character_counter": {
+    "characters": "{{numberOfCharacters}}/{{limit}} abalinganiswa"
+  },
+  "additional": {
+    "server-error": "Kwenzeke impazamo kwiseva",
+    "time-end": "Ixesha liphelile!",
+    "time-end-tap": "Ixesha liphelile. Cofa ukuze ugqibezele",
+    "thanks": "Enkosi!",
+    "sorry": "Uxolo",
+    "saved_answers": "Sizigcinile iimpendulo zakho!",
+    "submit_flow_answers": "Cofa i",
+    "submit": "Ngenisa",
+    "submit_flow_answers_ex": "iqhosha lokugcina iimpendulo zakho kwaye uqhubeke uku:",
+    "close": "Vala",
+    "resume_activity": "Qhubeka nomsebenzi",
+    "activity_resume_restart": "Ngaba ungathanda ukuqalisa kwakhona lo msebenzi uqhubekayo okanye uqalise kwakhona?",
+    "restart": "Phinda Uqalele",
+    "resume": "Phinda Uqalele",
+    "retry": "Zama kwakhona",
+    "send": "Thumela",
+    "later": "Kamva",
+    "in_progress": "Iyaqhubeka",
+    "unscheduled": "Ayicwangciswanga",
+    "scheduled": "Icwangcisiwe",
+    "past_due": "Udlule kudala",
+    "available": "Iyafumaneka",
+    "sure_delete_account_data": "Ngaba uqinisekile ukuba ufuna ukucima i-akhawunti yakho kunye nedatha?",
+    "no_cancel": "Hayi, rhoxisa",
+    "yes_delete": "Ewe, yicime",
+    "hi": "Mholo",
+    "enter_old_password": "Nceda ngenisa igama lokugqithisa lakho elidala",
+    "enter_new_password": "Nceda ngenisa igama lokugqithisa elitsha",
+    "data_not_sent": "Cofa Thumela ukulayisha idatha eqokelelwe ngaphambili",
+    "data_is_sending": "Ukulayisha idatha eqokelelwe ngaphambili",
+    "upload_error": "Imposiso Yokulayisha",
+    "want_to_retry": "I-Intanethi yakho isenokungazinzanga. Asikwazanga ukuthumela idatha yakho."
+  },
+  "prize": {
+    "lack_tokens_title": "Zama kwakhona",
+    "lack_tokens_subtitle": "You don't have enough tokens.\nNceda ukhethe elinye ibhaso"
+  },
+  "cognitive": {
+    "incorrect_start_point": "Indawo yokuqala engalunganga!",
+    "incorrect_line": "Umgca ongalunganga!",
+    "finished_continue": "Igqitywe tu. Cofa ngokulandelayo ukuze uqhubeke.",
+    "finished_complete": "Igqitywe tu. Cofa uGqibile ukuze ugqibezele.",
+    "begin": "Qala",
+    "end": "Isiphelo"
+  },
+  "system": {
+    "migration_not_applied_text": "Ukufuduswa kwedatha akuzange kusetyenziswe ngempumelelo. Nceda, qhagamshelana nenkxaso.",
+    "ok": "KULUNGILE"
+  },
+  "activity_skip_popup": {
+    "popup_title": "Tsibela kulingo olulandelayo?",
+    "popup_description": "Olu lingo aluphelelanga. Ukuba utsiba kulingo olulandelayo, inkqubela yakho iya kugcinwa. Awuzukwazi ukugqiba olulingo kamva.",
+    "keep_working": "Qhubeka usebenze",
+    "skip": "Tsiba"
+  },
+  "autocompletion": {
+    "done": "Yenziwe",
+    "time_limit_reached": "Ixesha elimiselweyo lifikelelwe",
+    "time_expired": "Ixesha lokugqiba {{activityNames}} liphelile. Iimpendulo zakho ziya kuthunyelwa ngokuzenzekelayo.",
+    "processing_answers": "Ukulungiswa kweempendulo",
+    "preparing_answers": "Nceda ulinde kwaye ungasivali isikrini.",
+    "answers_submitted": "Iimpendulo zingenisiwe",
+    "thanks": "Enkosi! Sigcine yonke into.",
+    "time_is_up_modal_description": "Alisekho ixesha lokusebenza kulo msebenzi. Wonke umsebenzi owenzileyo uya kugcinwa kwaye ungeniswe.",
+    "time_is_up_modal_title": "Ixesha liphelile",
+    "ok": "KULUNGILE"
+  },
+  "data_sharing": {
+    "consent": "Ndiyavuma ukwenza iimpendulo zam",
+    "media_consent": "Ndiyavuma ukwenza iimpendulo zam zosasazo",
+    "public": "uluntu",
+    "dialog": {
+      "body": "Ukwabelana ngeempendulo esidlangalaleni kuthetha ukuba ulwazi olunikezelwe ngabasebenzisi ngabanye, njengeempendulo zophando okanye ingxelo, luya kufumaneka ngokuvulelekileyo ukuze abanye bajongwe."
+    }
+  },
+  "assignment": {
+    "badge": "Malunga{{name}}",
+    "banner": "Nceda uqinisekise ukuba zonke iimpendulo zakho zimalunga<strong>{{name}}</strong>"
+  },
+  "splash": {
+    "version": "Inguqulelo"
+  },
+  "requestHealthRecordData": {
+    "title": "Cela iData yeRekhodi yezeMpilo",
+    "linkText": "Funda ngakumbi malunga nendlela Curious efikelela ngokukhuselekileyo kwidatha yenkathalo yezempilo.",
+    "partnershipText": "Unomdla usebenzisa i-1upHealth's Medical Information Service ukwenza ukuba umphandi wakho afikelele kulwazi kwiirekhodi zakho zokhathalelo lwempilo.\n\nKwezi zikrini zilandelayo, uya kucelwa ukuba ungene kwiinkqubo zakho zoBonelelo lwezeMpilo kwaye wabelane ngedatha yakho yokhathalelo lwempilo nolu phononongo. Uya kubuyela kumsebenzi weCurious xa ugqibile.",
+    "enterYourHealthSystem": "Ngenisa iNkqubo yakho yezeMpilo:",
+    "healthSystemName": "Igama leNkqubo yezeMpilo",
+    "search": "Khangela",
+    "additionalPromptText": "Ugqibile ukungena kwi-akhawunti yakho yokhathalelo lwempilo.\n\nNgaba ungathanda ukungena kuzo naziphi na ii-akhawunti zokhathalelo lwempilo ezongezelelweyo?",
+    "yes": "Ewe",
+    "no": "Hayi",
+    "noResults": "Akukho baBoneleli bezeMpilo bafunyenwe behambelana nophendlo lwakho."
+  },
+  "announcementBanner": {
+    "content": "<0>Uhlaziyo loyilo lusendleleni</0> <1> - usetyenziso oluhle olufanayo, inkangeleko entsha. Cofa </1> <2>ukufunda ngakumbi.</2>"
+  },
+  "unity": {
+    "error_title": "Ukwakha Umanyano Akuphumelelanga",
+    "error_message": "Umsebenzi awuphumelelanga, nceda uqhagamshelane nombhali ngoncedo. Umsebenzi uya kuphuma ngoku.",
+    "error_message_flow": "Umsebenzi awuphumelelanga, nceda uqhagamshelane nombhali ngoncedo. Uya kusiwa kumsebenzi olandelayo ekuhambeni: ",
+    "error_ok": "Kulungile",
+    "restart_title": "Imposiso yokwakha Umanyano",
+    "restart_message": "Umsebenzi ufumene impazamo enkulu kwaye kufuneka uphume. Idatha eqokelelwe kulo msebenzi ukuza kuthi ga ngoku iya kulahleka.\n\nUngawuqala kwakhona umsebenzi ukuze uzame kwakhona.",
+    "restart_primary": "Qala kwakhona uMsebenzi",
+    "restart_secondary_solo": "Phuma",
+    "restart_secondary_flow": "Qhubekela kuMsebenzi olandelayo"
+  }
+}

--- a/assets/translations/xh.json
+++ b/assets/translations/xh.json
@@ -278,7 +278,10 @@
     "fr": "Français",
     "el": "Ελληνικά",
     "es": "Español",
-    "pt": "Português"
+    "pt": "Português",
+    "af": "Afrikaans",
+    "xh": "isiXhosa",
+    "zu": "isiZulu"
   },
   "application_logs_screen": {
     "upload_button": "Layisha logs",

--- a/assets/translations/zu.json
+++ b/assets/translations/zu.json
@@ -1,0 +1,588 @@
+{
+  "auth": {
+    "email": "I-imeyili",
+    "email_address": "Ikheli le-imeyili",
+    "password": "Iphasiwedi",
+    "i_agree": "Ngivumelana ne",
+    "terms_of_service": "Imigomo Yesevisi",
+    "terms": "Imigomo",
+    "privacy": "Ubumfihlo",
+    "privacy_policy": "Inqubomgomo yobumfihlo",
+    "password_updated": "Iphasiwedi ibuyekeziwe"
+  },
+  "activity": {
+    "completeOnWeb": "Sicela ugcwalise ku-app yewebhu ye-Curious",
+    "incorrect_answer": "Impendulo engalungile. Sicela uzame futhi",
+    "failed": "Yehlulekile",
+    "flanker_accuracy_warn": "*Izitembu zesikhathi eziqoqwe ku-android azinembile njengamadivayisi we-iOS.",
+    "please_wait": "Ngicela ulinde",
+    "activity_all_items_hidden": "\"{{entityName}}\" ayikwazi ukuqaliswa ngoba zonke izinto ezingaphakathi komsebenzi zifihliwe",
+    "flow_all_items_hidden": "“”{{entityName}}” ayikwazi ukuqaliswa ngoba iqukethe umsebenzi lapho zonke izinto zifihlwe khona",
+    "progress": {
+      "upload_files": "Ilayisha amafayela akho...",
+      "encrypt_answers": "Ibethela izimpendulo zakho...",
+      "upload_answers": "Ilayisha izimpendulo zakho...",
+      "completed": "Umsebenzi ulayishiwe"
+    },
+    "step": "Isinyathelo",
+    "flowStep": "({{activityPositionInFlow}} kokungu-{{numberOfActivitiesInFlow}}) {{activityFlowName}}",
+    "stepCounter": "{{currentStep}} kokuthi {{totalSteps}}",
+    "activityCounter": "Umsebenzi {{currentStep}} wokuthi {{totalSteps}}"
+  },
+  "activity_time": {
+    "time_remaining": "usele kule nto"
+  },
+  "timed_activity": {
+    "time_to_complete": "Isikhathi sokuqeda",
+    "time_to_complete_hm": "Isikhathi sokuqeda: {{hours}} amahora kanye nemizuzu engu-{{minutes}}",
+    "hours": "amahora"
+  },
+  "activity_summary": {
+    "terms_text": "Ngiyaqonda ukuthi ulwazi oluhlinzekwe yilolu hlu lwemibuzo akuhloselwe ukuthatha indawo yeseluleko, ukuxilongwa, noma ukwelashwa okunikezwa uchwepheshe wezempilo noma wengqondo, nokuthi izimpendulo zami ezingaziwa zingasetshenziswa futhi kwabelwane ngazo ukuze kwenziwe ucwaningo olujwayelekile mayelana nempilo yengqondo yezingane.",
+    "footer_text": "I-CHILD MIND INSTITUTE, INC. FUTHI UKWELASHWA KOMQONDO WENGANE, I-PLLC (NDAWONYE, “I-CMI”) AYISEBENZI NGEMITHI NGOKUQONDILE NOMA NGOKUNGAQONDILE NOMA IKHIPHE ISELULEKO SOKWELAPHA NJENGXENYE YALE MIBUZO. I-CMI AYITHATHI ISIBOPHO SOKUHLOLA, UKWELASHWA, ISINQUMO ESENZIWE, NOMA ISINYATHELO ESITHATHWE NGOKUTHEMBA ULWAZI OLUNIKEZWE NGALOLU LWEMIBUZO, FUTHI AYIQINISEKI ISIBOPHO NGOKUSEBENZISA KWAKHO LE MIBUZO.",
+    "score_on_subscale": "Isikolo sesikali esingaphansi se-{{name}} besithi",
+    "save": "Londoloza",
+    "summary": "Isifinyezo",
+    "alerts": "Izexwayiso",
+    "report_summary": "Bika Isifinyezo",
+    "not_yet_completed": "Akukaqedwa",
+    "last_completed": "Kugcine ukuqedwa",
+    "unscheduled": "Akuhleliwe",
+    "due": "Ifuneka",
+    "scheduled_for": "Kuhlelelwe",
+    "category_suicide": "Ukuzibulala",
+    "category_suicide_message": "Izinga elibalulekile: Umzali ubonise ubuxhwanguxhwangu obungase bube khona. Letha kudokotela ngokushesha ngenxa yesimo esiphuthumayo esingaba khona.",
+    "category_emotional": "Okungokomzwelo",
+    "category_emotional_message": "Ngaphakathi kwemikhawulo evamile: Akukho okunye ukuhlolwa noma ukuhlolwa okudingekayo.",
+    "category_sport": "Ezemidlalo",
+    "category_sport_message": "Ibanga Lezokwelashwa: Yazisa umtholampilo; Yenza ukuhlolwa kokulandelela (Kunconyiwe); Khiqiza ukudluliselwa.",
+    "share_report": "Yabelana ngombiko",
+    "share_all_reports": "Yabelana Ngayo Yonke Imibiko"
+  },
+  "activity_chart": {
+    "title": "Sicela uthathe ukuhlolwa ukuze idatha iboniswe.",
+    "monday": "M",
+    "tuesday": "T",
+    "wednesday": "W",
+    "thursday": "T",
+    "friday": "F",
+    "saturday": "S",
+    "sunday": "S"
+  },
+  "calendar": {
+    "months": "January_February_March_April_May_June_July_August_September_October_November_December",
+    "weekdays": "Sun_Mon_Tue_Wed_Thu_Fri_Sat",
+    "x_days": "M_T_W_T_F_S_S"
+  },
+  "applet_data": {
+    "title": "Sicela uthathe ukuhlolwa ukuze idatha iboniswe."
+  },
+  "widget_error": {
+    "error_text": "Kube nenkinga ekulayisheni lesi sikrini.",
+    "error_description": "Sicela uqinisekise ukuthi unenguqulo yakamuva ye-Curious efakiwe, bese uthinta umlawuli wakho womsebenzi uma inkinga isenzeka."
+  },
+  "about": {
+    "about": "Mayelana",
+    "applets_title": "Thola okwengeziwe mayelana ne-applet yakho ngayinye kanye nenkundla ye-Curious.",
+    "data_title": "Thola okwengeziwe mayelana nenkundla yokuqoqwa kwedatha ye-Curious ngokuthepha okuthi ‘Mayelana\nne-Curious' ngezansi.",
+    "about_curious": "Mayelana Ne-Curious",
+    "icons_title": "Izithonjana ze-NounProject zisungulwe ngu-Alina Oleynik (inhlolovo), u-beth bolton (incwadi), kanye\nno-Shakeel (ishadi)",
+    "device_id": "I-ID yedivayisi"
+  },
+  "about_app": {
+    "title_with_version": "Iyini i-Curious? v.{{version}}",
+    "title": "Ngaphandle kwalapho kushiwo kwenye indawo, izithonjana zidwetshwa ku-OpenMoji naku-NounProject.",
+    "subtitle": "Ngaphandle kwalapho kushiwo kwenye indawo, izithonjana zidwetshwa ku-OpenMoji naku-NounProject.",
+    "curious_about": "## \n ### Iyini i-Curious? \n\n Le app iyingxenye yomthombo ovulekile wokuqoqwa kwedatha ye-Curious nenkundla yokuhlaziya eklanywe i-MATTER Lab ku-Child Mind Institute ([https://matter.childmind.org](https://matter.childmind.org)). \n # \n ### Yini ekwazi ukwenziwa yi-Curious? \n\n Isethi yesici se-Curious iyakhula, futhi njengamanje isekela izinhlobo zokufaka ezibanzi. Isikrini ngasinye kumsebenzi Wokufuna ukwazi singafaka noma yikuphi kokulandelayo: \n  - Umbhalo, isithombe, nomsindo \n  - Umbuzo olandelwa isithombe kanye/noma izinketho zokuphendula umbhalo \n  - Ibha yesilayidi \n  - Okufakiwe kombhalo \n  - Ukufakwa kwethebula \n  - Irekhodi lomsindo \n  - Ukuthwebula isithombe/ividiyo \n  - Ukudweba noma ukuthepha \n  - I-geolocation yamanje \n  - Umsebenzi wengqondo elula \n  - Ukubambezeleka ngaphambi kwempendulo \n  - Isikhathi \n  - I-logic enemibandela yokunquma ukuthi uzoya kuphi ngokulandelayo \n\n #### Ngingakufunda kuphi okwengeziwe? \n Sicela uvakashele okuthi [https://mindlogger.org](https://mindlogger.org) ukuze uthole ulwazi olwengeziwe.  \n ## [Usekelo]({{credits_link}}) \n ## [Imigomo yesevisi](https://mindlogger.org/terms-of-service) \n ## [Inqubomgomo yobumfihlo](https://mindlogger.org/privacy-policy) \n\n ##### Usale kahle, \n\n ##### Ithimba Le-Curious \n\n ##### I-Child Mind Institute"
+  },
+  "applet_footer": {
+    "surveys": "Inhlolovo",
+    "data": "Idatha",
+    "about": "Mayelana",
+    "activities": "Imisebenzi",
+    "activity": "Umsebenzi"
+  },
+  "applet_invite_flow": {
+    "back": "Emuva",
+    "next": "Olandelayo"
+  },
+  "live_connection": {
+    "disconnect": "NQAMULA",
+    "connect": "THUMELA",
+    "connect_to_server": "Xhuma Kuseva",
+    "remember": "Khumbula",
+    "ip": "Ikheli le-IP",
+    "port": "Imbobo",
+    "connection_closed": "I-TCP Connection ivaliwe",
+    "connection_error": "Uxhumano lwehlulekile. Sicela uhlole kabili i-ip kanye nembobo",
+    "connection_set_error": "Ayikwazi ukusetha uxhumano",
+    "live_connection": "Uxhumano Olubukhoma",
+    "not_available": "akutholakali"
+  },
+  "join_invite": {
+    "click_below": "Chofoza ngezansi uma usukulungele ukujoyina lolu cwaningo. Ungazikhipha kulolu cwaningo futhi/noma ususe idatha yakho noma nini ngaphandle kwemiphumela.",
+    "decline": "Uma ungazizwa ukhululekile ngokwabelana ngedatha yakho yalolu cwaningo, ungasenqaba lesi simemo. ",
+    "decline_title": "Yenqaba"
+  },
+  "applet_list_component": {
+    "about_title": "Mayelana Ne-Curious",
+    "no_applets_yet": "Awunawo ama-applet.",
+    "noon": "Emini",
+    "midnight": "Phakathi kwamabili",
+    "refresh_error_header": "Vuselela iphutha",
+    "applets_not_refreshed": "Ama-applet alandelayo awavuselelwanga:",
+    "common_refresh_error": "Uhlu lwama-applet aluvuselelwanga. Sicela uzame futhi."
+  },
+  "activity_list_component": {
+    "no_activities": "Ayikho imisebenzi etholakalayo ukuthi uyiqedele njengamanje",
+    "insufficient_data_error": "Le applet ayizange ivuselelwe. Sicela uzame ukuvuselela futhi.",
+    "other_error": "Kwenzeke iphutha elingachazwanga"
+  },
+  "applet_settings": {
+    "applet_not_defined": "Alikho i-applet echaziwe.",
+    "want_remove": "Uma ufuna ukususa le applet, kodwa ugcine idatha yakho, chofoza ngezansi",
+    "remove": "Susa",
+    "want_delete": "Uma ufuna ukususa idatha yakho kule applet futhi uyisuse, chofoza ngezansi.",
+    "remove_delete": "Susa futhi Susa idatha",
+    "alert_title": "Uqinisekile ukuthi ufuna ukususa idatha yakho?",
+    "alert_message": "Ngeke ukwazi ukukubuyisela",
+    "cancel_text": "Cha, khansela",
+    "confirm_text": "Yebo, yisuse"
+  },
+  "change_pass_form": {
+    "update": "Buyekeza",
+    "cur_pass_placeholder": "Iphasiwedi Yamanje",
+    "new_pass_placeholder": "Iphasiwedi Entsha",
+    "error": "Ayikwazi ukubuyekeza imininingwane yomsebenzisi.",
+    "submission_error": "Iphasiwedi yamanje oyifakile ibingalungile.",
+    "change_pass": "Shintsha iphasiwedi",
+    "password_at_least_characters": "Iphasiwedi kumele okungenani ibe nezinhlamvu ezingu-{{min}}"
+  },
+  "password_recovery_form": {
+    "password_at_least_characters": "Iphasiwedi kumele okungenani ibe nezinhlamvu ezingu-{{min}}",
+    "password_no_spaces": "Iphasiwedi akumele iqukathe izikhala",
+    "passwords_do_not_match": "Amaphasiwedi awafani",
+    "password_confirmation_required": "Sicela uqinisekise iphasiwedi yakho",
+    "new_password_placeholder": "Iphasiwedi Entsha",
+    "confirm_password_placeholder": "Qinisekisa Iphasiwedi",
+    "submit": "Thumela",
+    "invalid_password_reset_link": "Le linki ayivumelekile noma iphelelwe yisikhathi.",
+    "click_to_reset_password": "Sicela uchofoze ngezansi ukuze usethe kabusha iphasiwedi yakho.",
+    "forgot_password": "Ukhohlwe iphasiwedi",
+    "success": "Iphasiwedi yakho isethwe kabusha ngempumelelo. Sicela ungene ngemvume ngephasiwedi yakho entsha.",
+    "error": "Iphutha lokusetha kabusha iphasiwedi yakho"
+  },
+  "mfa_recovery": {
+    "title": "Qinisekisa Ubuwena",
+    "subtitle": "Sicela ufake ikhodi yokutakula i-akhawunti.",
+    "continue": "Qhubeka",
+    "back": "Emuva",
+    "invalid_code_format": "Ikhodi yokutakula kufanele ibe ngefomethi ethi XXXXX-XXXXX",
+    "placeholder": "XXXXX-XXXXX",
+    "error": "Ikhodi yokutakula engavumelekile. Sicela uzame futhi.",
+    "success": "Ubunikazi buqinisekiswe ngempumelelo",
+    "error_invalid_code": "Ikhodi yokutakula engavumelekile. Sicela uhlole bese uzama futhi.",
+    "error_code_not_found": "Ikhodi yokutakula ayitholakali noma isivele isetshenzisiwe.",
+    "error_session_expired": "Isikhathi sakho siphelelwe yisikhathi. Sicela ungene futhi.",
+    "error_too_many_attempts": "Imizamo eminingi kakhulu ehlulekile. Sicela uzame ukungena futhi.",
+    "error_global_lockout": "Imizamo eminingi kakhulu ehlulekile. Ukhiyelwe ngaphandle okwesikhashana. Sicela uzame ukungena ngemva kwemizuzu engu-15.",
+    "error_network": "Iphutha lenethiwekhi. Sicela uhlole uxhumo lwakho bese uzama futhi.",
+    "error_unknown": "Kwenzeke iphutha. Sicela uzame futhi."
+  },
+  "mfa_verification": {
+    "title": "Qinisekisa Ubuwena",
+    "subtitle": "Sicela ufake ikhodi yokuqinisekisa eboniswe ku-app yakho yokufakazela ubuqiniso.",
+    "verify": "Qhubeka",
+    "placeholder": "Faka ikhodi yokuqinisekisa",
+    "invalid_code_format": "Ikhodi yokuqinisekisa kufanele ibe namadijithi ayi-6",
+    "error": "Ikhodi engavumelekile",
+    "success": "Ukuqinisekisa kuphumelele",
+    "use_recovery_code": "Angikwazi ukufinyelela i-app yami yokufakazela ubuqiniso",
+    "session_expiry_warning": "Iseshini kungenzeka iphelelwe yisikhathi. Sicela uqinisekise mathupha noma ungene ngemvume futhi.",
+    "error_invalid_code": "Ikhodi yokuqinisekisa engavumelekile. Sicela uhlole bese uzama futhi.",
+    "error_session_expired": "Isikhathi sakho siphelelwe yisikhathi. Sicela ungene futhi.",
+    "error_too_many_attempts": "Imizamo eminingi kakhulu ehlulekile. Sicela uzame ukungena futhi.",
+    "error_global_lockout": "Imizamo eminingi kakhulu ehlulekile. Ukhiyelwe ngaphandle okwesikhashana. Sicela uzame ukungena ngemva kwemizuzu engu-15.",
+    "error_network": "Iphutha lenethiwekhi. Sicela uhlole uxhumo lwakho bese uzama futhi.",
+    "error_unknown": "Kwenzeke iphutha. Sicela uzame futhi.",
+    "warning_session_attempts_remaining": ". Kusele umzamo ongu-{{count}}",
+    "warning_session_attempts_remaining_plural": ". Kusele imizamo engu-{{count}}",
+    "warning_global_attempts_remaining": ". Kusele umzamo ongu-{{count}} ngaphambi kokuvalwa kwesikhashana",
+    "warning_global_attempts_remaining_plural": ". Kusele imizamo engu-{{count}} ngaphambi kokuvalwa kwesikhashana"
+  },
+  "change_study": {
+    "reset": "Setha kabusha",
+    "submit": "Thumela",
+    "enter_url_manually": "Faka i-URL ngokwenza",
+    "scan_qr": "Skena i-QR",
+    "successfully_changed": "I-Url yeseva ishintshwe ngempumelelo.",
+    "successfully_reset": "I-Url yeseva isethwe kabusha ngempumelelo.",
+    "change_server": "Shintsha iseva",
+    "http_confirm": "Uqinisekile ukuthi ufuna ukuxhuma kuseva engasekeli i-ssl?",
+    "set_by_qr": "Ucwaningo lusethwe yi-QR.",
+    "yes": "Yebo",
+    "no": "Cha"
+  },
+  "consent": {
+    "this_app_provides": "Le app inikeza indlela elula yokuqoqa inhlolovo, izwi, imisebenzi yokudweba.",
+    "i_understand": "Ngiyaqonda ukuthi ukubuka izithombe ezithile kungase kukwenze ungakhululeki ngenkathi usebenzisa le app",
+    "i_will_allow": "Ngizovumela i-Child Mind Institute ukuthi igcine idatha yokusetshenziswa kwale app ivikelekile\niseva ye-cloud, kanye nokufinyelela lolu lwazi ngezinjongo zokwelashwa nezocwaningo",
+    "i_premit": "Ngivumela i-Child Mind Institute ukuthi ingithinte mayelana nolwazi oluqoqwe kulo\nle app yezinjongo zokwelashwa noma zocwaningo.",
+    "next": "Olandelayo"
+  },
+  "forgot_pass_form": {
+    "reset_pass": "Setha kabusha Iphasiwedi",
+    "enter_email_mess": "Sicela ufake ikheli lakho le-imeyili",
+    "invalid_email": "Ikheli le-imeyili elingavumelekile",
+    "email_address": "Ikheli le-imeyili",
+    "email_send_success": "I-imeyili yokusetha kabusha ithunyelwe kokuthi <strong>{{email}}</strong> uma i-akhawunti ikhona.",
+    "email_send_error": "Ayikwazi ukuthumela i-imeyili yokusetha kabusha ngalesi sikhathi.",
+    "forgot_password": "Ukhohlwe iphasiwedi?"
+  },
+  "login": {
+    "new_user": "Umsebenzisi Omusha",
+    "account_create": "Yenza i-akhawunti",
+    "forgot_password": "Ukhohlwe iphasiwedi?",
+    "what_is": "Yini",
+    "login_error": "Ukungena kokuyimfihlo ayiphumelelanga.",
+    "password_at_least_characters": "Iphasiwedi kumele okungenani ibe nezinhlamvu eziyi-10"
+  },
+  "login_form": {
+    "login": "Ngena ngemvume",
+    "email_placeholder": "I-imeyili",
+    "password": "Iphasiwedi"
+  },
+  "logout_warning": {
+    "warning": "Isexwayiso Sokuphuma",
+    "uploads_in_progress": "Ukulayisha kuyaqhubeka",
+    "currently_uploading": "Unezimpendulo ezilayishayo njengamanje. Uma uphuma manje bese ungena njengomsebenzisi ohlukile, izimpendulo zakho zizolahleka.",
+    "not_uploaded": "Awulayishile izimpendulo. Uma uphuma manje bese ungena njengomsebenzisi ohlukile, izimpendulo zakho zizolahleka.",
+    "sure_logout": "Uqinisekile ukuthi ufuna ukuphuma?",
+    "cancel": "Khansela",
+    "logout": "Phuma"
+  },
+  "settings": {
+    "logged_out": "Uphumile.",
+    "change_pass": "Shintsha iphasiwedi",
+    "use_cellular_data": "Sebenzisa Idatha Yeselula",
+    "logout": "Phuma",
+    "permanently_delete_account": "Susa Unomphela I-akhawunti",
+    "user_settings": "Amasethingi Omsebenzisi",
+    "upload_logs": "Layisha Amalogi",
+    "create_new_password": "Sungula iphasiwedi entsha"
+  },
+  "language_screen": {
+    "app_language": "Ulimi lwe-application",
+    "change_app_language": "Shintsha Ulimi",
+    "en": "IsiNgisi",
+    "fr": "Français",
+    "el": "Ελληνικά",
+    "es": "Español",
+    "pt": "Português"
+  },
+  "application_logs_screen": {
+    "upload_button": "Layisha Amalogi",
+    "title": "Unezinkinga zobuchwepheshe? Amafayela akho okungena azosiza ithimba lethu ukuxazulula inkinga.",
+    "subTitle": "Sicela uwalayishe usebenzisa inkinobho engezansi.",
+    "success": "Impumelelo - sithole amalogi akho.",
+    "error": "Iphutha - amalogi awathunyelwanga. Sicela uzame futhi."
+  },
+  "sign_up_form": {
+    "sign_up": "Bhalisela",
+    "error": "Ukubhalisa kwehlulekile: igama lomsebenzisi kungenzeka selivele liyasetshenziswa.",
+    "new_user": "Umsebenzisi Omusha",
+    "username_validation_error": "Igama lomsebenzisi kufanele okungenani libe nezinhlamvu ezi-4, liqale ngohlamvu, futhi lingaqukatha kuphela izinhlamvu, izinombolo, amadeshi namachashazi.",
+    "email_validation_error": "Kubonakala sengathi le imeyili ayiphelele",
+    "email_placeholder": "I-imeyili",
+    "first_name": "Igama",
+    "last_name": "Isibongo",
+    "password_placeholder": "Iphasiwedi",
+    "please_accept_terms": "Sicela wamukele imigomo yesevisi.",
+    "email_looks_incomplete": "Kubonakala sengathi le imeyili ayiphelele",
+    "sign_up_agree": "Ngokubhalisa, uyavumelana ne-Curious",
+    "and": "futhi"
+  },
+  "password_requirements": {
+    "at_least_characters": "Izinhlamvu ezingu-10",
+    "no_blank_spaces": "azikho izikhala ezingenalutho",
+    "must_include": "Iphasiwedi kumele okungenani iqukathe izinhlamvu ezingu-{{minLength}}, azikho izikhala, futhi okungenani okuthi {{types}} koku-4 kokungezansi:",
+    "must_include_minimum": "Iphasiwedi kumele okungenani iqukathe izinhlamvu ezingu-{{minLength}} futhi zingabikhona izikhala",
+    "requirements_met": "Zonke izimfuneko zifinyelelwe.",
+    "must_include_uppercase": "Izinhlamvu ezinkulu (A-Z)",
+    "must_include_lowercase": "Izinhlamvu ezincane (a-z)",
+    "must_include_digits": "Inombolo (0-9)",
+    "must_include_symbol": "Izimpawu (!@#$...)",
+    "cannot_contain_emojis": "Iphasiwedi ayikwazi ukuqukatha ama-emoji."
+  },
+  "geolocation": {
+    "get_location": "THOLA INDAWO",
+    "must_enable_location": "Kufanele unike amandla amasevisi endawo ukuze uqedele lo msebenzi. Sicela unikeze imvume ye-Curious kumaSethingi akho e-iOS bese ucindezela inkinobho futhi.",
+    "must_enable_location_subtitle": "Kufanele unike amandla amasevisi endawo ukuze uqedele lo msebenzi. Sicela ucindezele inkinobho futhi bese unikeza i-Curious imvume yokusebenzisa indawo yakho.",
+    "location_saved": "Indawo ilondoloziwe.",
+    "service_not_available": "Isevisi yendawo ayitholakali."
+  },
+  "select": {
+    "select_one": "Khetha eyodwa",
+    "no_items": "Azikho izinto"
+  },
+  "permissions": {
+    "alert_button_cancel": "Cashisa",
+    "alert_button_ok": "Vula Amasethingi",
+    "alarm_permission_warning": "Isicelo sezimvume ze-alamu",
+    "alarm_permission_disabled": "Sicela uvule izimvume ze-alamu kudivayisi yakho ukuze uthole izikhumbuzi ze-Curious ngesikhathi. Sicela uqaphele ukuthi i-app izovalwa ngokuzenzakalelayo uma usuvule izimvume ze-alamu.",
+    "gallery": "\"I-Curious\" ingathanda ukusebenzisa igalari yakho ukuqedela lo msebenzi",
+    "camera": "”I-Curious” ingathanda ukusebenzisa ikhamera yakho ukuze iqedele lo msebenzi"
+  },
+  "media": {
+    "alert_message": "Lokhu kungalungiselelwa kokuthi Amasethingi",
+    "media_found_title": "Awuxhunyiwe ku-inthanethi",
+    "media_found_body": "Lo msebenzi uqukethe izinto ezidinga uxhumano lwe-inthanethi. Sicela uvule i-inthanethi ukuze uqhubeke."
+  },
+  "audio_recorder": {
+    "permission": "Kufanele unikeze imvume yokusebenzisa imakrofoni yakho ukuze uqedele lo msebenzi.",
+    "alert_title": "I-”Curious” ingathanda ukusebenzisa imakrofoni yakho ukuze iqedele lo msebenzi.",
+    "alert_message": "Lokhu kungalungiselelwa kokuthi Amasethingi.",
+    "record_error": "Kube nephutha ukuqalisa isiqophi.",
+    "stop": "IMA",
+    "record": "REKHODA",
+    "recording": "Iyarekhoda...",
+    "seconds": "imizuzwana",
+    "file_saved": "Ifayela lilondoloziwe."
+  },
+  "audio_player": {
+    "stop": "IMA",
+    "playing": "IYADLALA...",
+    "play": "DLALA",
+    "done": "KWENZIWE",
+    "loading": "IYALAYISHA"
+  },
+  "optional_text": {
+    "required": "Lena inkambu edingekayo.",
+    "enter_text": "Sicela ufake umbhalo."
+  },
+  "date_picker": {
+    "ok": "KULUNGILE"
+  },
+  "table_input": {
+    "short_press_detail": "* Ukucindezela okufushane kwandisa ikhawunta",
+    "long_press_detail": "* Ukucindezela isikhathi eside kunciphisa ikhawunta"
+  },
+  "activity_due_date": {
+    "available_all_day": "Iyatholakala: Usuku lonke",
+    "scheduled_at": "Ihlelwe Ngo-",
+    "available": "Itholakala Kusuka",
+    "to": "Kuya",
+    "day": "usuku",
+    "days": "izinsuku",
+    "am": "AM",
+    "the_following_day": "ngosuku olulandelayo"
+  },
+  "form_item": {
+    "required": "Kudingeka",
+    "must_be": "Kumele",
+    "characters_or_less": "izinhlamvu noma ngaphansi",
+    "must_be_a_number": "Kufanele kube inombolo"
+  },
+  "applet_about": {
+    "loading": "iyalayisha",
+    "no_info": "Ababhali bale applet abanikezanga noma yiluphi ulwazi!"
+  },
+  "firebase_messaging": {
+    "alert_title": "”I-Curious” ingathanda ukukuthumelela izaziso",
+    "alert_message": "Lokhu kungalungiselelwa kokuthi Amasethingi",
+    "alert_text": "Vula Amasethingi",
+    "response_refresh_request": "Isicelo sokuvuselela impendulo",
+    "refresh_request_details": "Njengoba iphasiwedi yakho isethwe kabusha, izimpendulo zakho ezedlule zidinga ukuvuselelwa. Uyafuna ukukucela lokhu?",
+    "refresh_request_text": "Abaphathi bakho bazoqalisa ukuvuselela maduze nje.",
+    "applet_not_found_1": "I-Applet ayitholakalanga",
+    "applet_not_found_2": "Alikho i-applet ye-id enikeziwe.",
+    "activity_not_found": "Umsebenzi othi ”{{entityName}}” ayitholakali manje.",
+    "activity_not_available_title": "Umsebenzi awutholakali",
+    "activity_not_available_message": "Umsebenzi ozame ukufinyelela kuwo awutholakali okwamanje. Ungazama futhi ngemva kwewindi lesikhathi esihleliwe elilandelayo.",
+    "activity_not_assigned": "Lokhu okuthi {{entityName}} akwabelwe wena.",
+    "activity_not_available": "Lokhu okuthi {{entityName}} akusatholakali.",
+    "activity_scheduled_today": "Okuthi {{entityName}} kuhlelelwe ukuthi kutholakale ngo-{{time}}.",
+    "activity_completed_today": "{{entityName}} seyiqediwe namuhla.",
+    "already_completed": "Usuvele uqedile",
+    "app_killed_on_redux_persist": "Lo msebenzi awukwazi ukuqaliswa. Sicela uthinte abosekelo.",
+    "activity_was_due_at": "Lo msebenzi ubuzodingeka ngo-",
+    "if_progress_was_made_on_the": "Uma inqubekelaphambili yenziwe ku-",
+    "it_was_saved_but_it_can_no_longer_be_taken": "yasindiswa kodwa ngeke isathathwa",
+    "today": "namuhla.",
+    "today2": "Kuhlelelwe namuhla",
+    "activity_not_ready": "Umsebenzi awukalungi",
+    "not_able_to_start": "Awukwazi ukuqala umsebenzi okwamanje",
+    "is": "kuyinto",
+    "scheduled_to_start_at": "ihlelelwe ukuqala ngo",
+    "postponed_notification": "Uma izimpendulo sezilayishiwe, sizozama ukuvula umsebenzi"
+  },
+  "local_notifications": {
+    "complete_activity": "Sicela uqedele lo msebenzi."
+  },
+  "join_demo_applets": {
+    "healthy_brain_network": "I-Healthy Brain Network: I-EMA",
+    "cognitive_tasks": "Imisebenzi Yokuqonda",
+    "mind_logger_demos": "Amademo E-Curious"
+  },
+  "data_invite": {
+    "message": "Sicabanga ukuthi kubalulekile kuwena ukwazi ukuthi ubani onokufinyelela idatha yakho uma wamukela lesi simemo.\n\nAbantu abalandelayo bazokwazi ukufinyelela idatha yakho uma wamukela lesi simemo:"
+  },
+  "sidebar": {
+    "home": "Ikhaya",
+    "settings": "Amasethingi",
+    "about": "Mayelana",
+    "logout": "Phuma"
+  },
+  "navigator": {
+    "exit_title": "Phuma Ku-app",
+    "exit_subtitle": "Phuma ku-application?",
+    "cancel": "Khansela"
+  },
+  "activity_navigation": {
+    "next": "Olandelayo",
+    "skip": "Yeqa",
+    "done": "Kwenziwe",
+    "back": "Emuva",
+    "return": "Buyela",
+    "undo": "Hlehlisa",
+    "exit": "Londoloza futhi Uphume"
+  },
+  "network_alerts": {
+    "no_internet_title": "Alukho Uxhumo Lwe-inthanethi",
+    "no_internet_subtitle": "Sicela uxhume ku-inthanethi",
+    "no_internet_text": "Cashisa",
+    "cellular_data_title": "Idatha Yeselula Ikhutshaziwe",
+    "cellular_data_subtitle": "Sicela uxhume ku-wi-fi noma uvumele idatha yeselula",
+    "cellular_data_text": "Cashisa",
+    "use_cellular_data": "Sebenzisa Idatha Yeselula"
+  },
+  "timing": {
+    "provide_option": "Kufanele unikeze inketho ethi “ngemuva” noma “yonke”.",
+    "to_be_number": "Izinketho ezilindelwe.ngemuva kokuba inombolo",
+    "every_number": "Izinketho ezilindelwe.zonke zibe yinombolo"
+  },
+  "camera": {
+    "choose_photo": "Khetha isithombe",
+    "choose_video": "Khetha ividiyo",
+    "take_a_photo": "Thatha isithombe esisha noma khetha esisodwa kulabhulari yakho",
+    "take_a_video": "Thatha ividiyo entsha noma khetha eyodwa kulabhulari yakho",
+    "camera": "Ikhamera",
+    "library": "Ilabhulari"
+  },
+  "text_entry": {
+    "type_placeholder": "Sicela uthayiphe umbhalo",
+    "paragraph_placeholder": "Thayipha impendulo yakho lapha."
+  },
+  "character_counter": {
+    "characters": "{{numberOfCharacters}}/izinhlamvu ezingu-{{limit}}"
+  },
+  "additional": {
+    "server-error": "Kwenzeke iphutha leseva",
+    "time-end": "Siphelile isikhathi!",
+    "time-end-tap": "Siphelile isikhathi. Thepha ukuze uqedele",
+    "thanks": "Siyabonga!",
+    "sorry": "Uxolo",
+    "saved_answers": "Sizigcinile izimpendulo zakho!",
+    "submit_flow_answers": "Thepha okuthi",
+    "submit": "Thumela",
+    "submit_flow_answers_ex": "inkinobho ukuze ulondoloze izimpendulo zakho futhi uqhubekele kokuthi:",
+    "close": "Vala",
+    "resume_activity": "Qalisa kabusha umsebenzi",
+    "activity_resume_restart": "Ungathanda ukuqalisa kabusha lo msebenzi oqhubekayo noma uqale kabusha?",
+    "restart": "Qala kabusha",
+    "resume": "Qalisa kabusha",
+    "retry": "Zama futhi",
+    "send": "Thumela",
+    "later": "Kamuva",
+    "in_progress": "Kuyaqhubeka",
+    "unscheduled": "Akuhleliwe",
+    "scheduled": "Okuhleliwe",
+    "past_due": "Isikhathi Esidlule",
+    "available": "Iyatholakala",
+    "sure_delete_account_data": "Uqinisekile ukuthi ufuna ukususa i-akhawunti yakho nedatha?",
+    "no_cancel": "Cha, khansela",
+    "yes_delete": "Yebo, yisuse",
+    "hi": "Sawubona",
+    "enter_old_password": "Sicela ufake iphasiwedi yakho endala",
+    "enter_new_password": "Sicela ufake iphasiwedi entsha",
+    "data_not_sent": "Chofoza okuthi Thumela ukuze ulayishe idatha eqoqwe ngaphambilini",
+    "data_is_sending": "Ilayisha idatha eqoqwe ngaphambilini",
+    "upload_error": "Iphutha Lokulayisha",
+    "want_to_retry": "I-inthanethi yakho ingase ingazinzi. Asikwazanga ukuthumela idatha yakho."
+  },
+  "prize": {
+    "lack_tokens_title": "Zama futhi",
+    "lack_tokens_subtitle": "Awunawo amathokheni anele.\nSicela ukhethe omunye umklomelo"
+  },
+  "cognitive": {
+    "incorrect_start_point": "Iphoyinti lokuqala elingalungile!",
+    "incorrect_line": "Umugqa ongalungile!",
+    "finished_continue": "Kuqediwe. Chofoza okulandelayo ukuze uqhubeke.",
+    "finished_complete": "Kuqediwe. Chofoza okuthi Kwenziwe ukuze uqedele.",
+    "begin": "Qala",
+    "end": "Qeda"
+  },
+  "system": {
+    "migration_not_applied_text": "Ukuthuthwa kwedatha akuzange kusetshenziswe ngempumelelo. Sicela uthinte abosekelo.",
+    "ok": "KULUNGILE"
+  },
+  "activity_skip_popup": {
+    "popup_title": "Yeqela esivivinyweni esilandelayo?",
+    "popup_description": "Lesi sivivinyo asiphelele. Uma weqela esivivinyweni esilandelayo, ukuqhubeka kwakho kuzolondolozwa. Ngeke ukwazi ukuqeda lesi sivivinyo kamuva.",
+    "keep_working": "Qhubeka usebenza",
+    "skip": "Yeqa"
+  },
+  "autocompletion": {
+    "done": "Kwenziwe",
+    "time_limit_reached": "Umkhawulo wesikhathi ufinyelelwe",
+    "time_expired": "Isikhathi sokuqeda okuthi {{activityNames}} siphelelwe yisikhathi. Izimpendulo zakho zizothunyelwa ngokuzenzakalelayo.",
+    "processing_answers": "Icubungula Izimpendulo",
+    "preparing_answers": "Sicela ulinde futhi ungasivali isikrini.",
+    "answers_submitted": "Izimpendulo zithunyelwe",
+    "thanks": "Siyabonga! Silondoloze yonke into.",
+    "time_is_up_modal_description": "Asisekho isikhathi sokusebenza kulo msebenzi. Wonke umsebenzi owenzile uzogcinwa futhi uhanjiswe.",
+    "time_is_up_modal_title": "Isikhathi siphelile",
+    "ok": "KULUNGILE"
+  },
+  "data_sharing": {
+    "consent": "Ngiyavuma ukwenza izimpendulo zami",
+    "media_consent": "Ngiyavuma ukwenza izimpendulo zami zemidiya",
+    "public": "umphakathi",
+    "dialog": {
+      "body": "Ukwabelana ngezimpendulo esidlangalaleni kusho ukuthi ulwazi olunikezwa abasebenzisi ngabanye, njengezimpendulo zenhlolovo noma impendulo, luzotholakala ngokusobala ukuze abanye balubuke."
+    }
+  },
+  "assignment": {
+    "badge": "Mayelana {{name}}",
+    "banner": "Sicela uqinisekise ukuthi zonke izimpendulo zakho zimayelana <strong>{{name}}</strong>"
+  },
+  "splash": {
+    "version": "Inguqulo"
+  },
+  "requestHealthRecordData": {
+    "title": "Cela Idatha Yerekhodi Lezempilo",
+    "linkText": "Funda kabanzi mayelana nendlela i-Curious efinyelela ngayo ngokuphephile kudatha yokunakekelwa kwezempilo.",
+    "partnershipText": "I-Curious isebenzisa i-1upHealth’s Medical Information Service ukuze umcwaningi wakho akwazi ukufinyelela ulwazi kumarekhodi akho okunakekelwa kwezempilo.\n\nKuzikrini ezilandelayo, uzocelwa ukuthi ungene ngemvume kumasistimu akho Omhlinzeki Wokunakekelwa Kwezempilo futhi wabelane ngedatha yakho yokunakekelwa kwezempilo nalolu cwaningo. Uzobuyela emsebenzini we-Curious uma usuqedile.",
+    "enterYourHealthSystem": "Faka Uhlelo lwakho Lwezempilo:",
+    "healthSystemName": "Igama Lesistimu Yezempilo",
+    "search": "Sesha",
+    "additionalPromptText": "Usuqedile ukungena ku-akhawunti yakho yokunakekelwa kwezempilo.\n\nUngathanda ukungena ngemvume kunoma imaphi ama-akhawunti okunakekelwa kwezempilo engeziwe?",
+    "yes": "Yebo",
+    "no": "Cha",
+    "noResults": "Abekho Abahlinzeki Bezempilo abatholakele abafana nosesho lwakho."
+  },
+  "announcementBanner": {
+    "content": "<0>Senza kabusha!</0> <1>Izibuyekezo zedizayini zisendleleni—i-app enhle efanayo, ukubukeka okusha. Ufuna ukwazi?</1> <2>Thepha ukuze ufunde kabanzi.</2>"
+  },
+  "unity": {
+    "error_title": "Ukwakhiwa Kobumbano Kwehlulekile",
+    "error_message": "Umsebenzi wehlulekile ukulayishwa, sicela uxhumane nombhali ukuze uthole usizo. Umsebenzi usuzophuma manje.",
+    "error_message_flow": "Umsebenzi wehlulekile ukulayishwa, sicela uxhumane nombhali ukuze uthole usizo. Uzoyiswa kumsebenzi olandelayo ekuhambeni: ",
+    "error_ok": "Kulungile",
+    "restart_title": "Iphutha Lokwakha Ubumbano",
+    "restart_message": "Umsebenzi uhlangabezane nephutha elibucayi futhi kufanele uphume. Idatha eqoqwe kulo msebenzi kuze kube manje izolahleka.\n\nUngaqala kabusha umsebenzi ukuze uzame futhi.",
+    "restart_primary": "Qala kabusha Umsebenzi",
+    "restart_secondary_solo": "Phuma",
+    "restart_secondary_flow": "Qhubekela kumsebenzi olandelayo"
+  }
+}

--- a/assets/translations/zu.json
+++ b/assets/translations/zu.json
@@ -278,7 +278,10 @@
     "fr": "Français",
     "el": "Ελληνικά",
     "es": "Español",
-    "pt": "Português"
+    "pt": "Português",
+    "af": "Afrikaans",
+    "xh": "isiXhosa",
+    "zu": "isiZulu"
   },
   "application_logs_screen": {
     "upload_button": "Layisha Amalogi",

--- a/src/entities/localization/lib/setupLocalization.ts
+++ b/src/entities/localization/lib/setupLocalization.ts
@@ -3,11 +3,14 @@ import { initReactI18next } from 'react-i18next';
 import { z } from 'zod';
 import { zodI18nMap } from 'zod-i18n-map';
 
+import af from '@assets/translations/af.json';
 import el from '@assets/translations/el.json';
 import en from '@assets/translations/en.json';
 import es from '@assets/translations/es.json';
 import fr from '@assets/translations/fr.json';
 import ptBr from '@assets/translations/pt.json';
+import xh from '@assets/translations/xh.json';
+import zu from '@assets/translations/zu.json';
 
 import { getDefaultLocalizationStorage } from './localizationStorageInstance';
 
@@ -32,6 +35,9 @@ export function setupLocalization() {
       el,
       es,
       pt: ptBr,
+      af,
+      xh,
+      zu,
     },
     returnNull: false,
   });

--- a/src/shared/lib/types/language.ts
+++ b/src/shared/lib/types/language.ts
@@ -1,1 +1,1 @@
-export type Language = 'en' | 'fr' | 'el' | 'es' | 'pt';
+export type Language = 'en' | 'fr' | 'el' | 'es' | 'pt' | 'af' | 'xh' | 'zu';

--- a/src/shared/lib/utils/dateTime.ts
+++ b/src/shared/lib/utils/dateTime.ts
@@ -4,8 +4,9 @@ import {
   subDays,
   getUnixTime,
   subMonths,
+  Locale,
 } from 'date-fns';
-import { enGB, fr, el, es, ptBR } from 'date-fns/locale';
+import { enGB, fr, el, es, ptBR, af } from 'date-fns/locale';
 import i18n from 'i18next';
 
 import { getTwoDigits, range } from './common';
@@ -17,7 +18,17 @@ import {
 import { DayMonthYear, HourMinute } from '../types/dateTime';
 import { Language } from '../types/language';
 
-const dateFnsLocales = { fr, en: enGB, el, es, pt: ptBR };
+// xh and zu fall back to date-fns' default (en-US-style) because no isiXhosa
+// or isiZulu locales ship with date-fns. Typed as Partial so the lookup safely
+// yields undefined for unsupported languages.
+const dateFnsLocales: Partial<Record<Language, Locale>> = {
+  fr,
+  en: enGB,
+  el,
+  es,
+  pt: ptBR,
+  af,
+};
 
 export const getMsFromHours = (hours: number): number => {
   return hours * (MINUTES_IN_HOUR * MS_IN_MINUTE);


### PR DESCRIPTION
- [x] Tests for the changes have been added
- [ ] Related documentation has been added / updated
- [ ] OSS packages added to Curious [open source credit page](https://mindlogger.atlassian.net/jira/servicedesk/projects/MLA/knowledge/articles/340623543?spaceKey=MLA)

### 📝 Description

🔗 [Jira Ticket M2-10768](https://mindlogger.atlassian.net/browse/M2-10768)

Adds Afrikaans, isiXhosa and isiZulu as UI languages in the mobile app. Same pattern as PR #1026 (Portuguese).

Changes:

- New translation files: `assets/translations/{af,xh,zu}.json` ( full parity with `en.json`)
- Added `af`, `xh`, `zu` labels in the `language_screen` namespace of all 8 translation files so the picker labels resolve in every UI language
- Extended the `Language` type union in `src/shared/lib/types/language.ts`
- Registered the three new resources in `setupLocalization.ts`
- Added the Afrikaans locale to `dateFnsLocales` in `src/shared/lib/utils/dateTime.ts`. Typed the map as `Partial<Record<Language, Locale>>` so xh/zu fall through to date-fns' default (no isiXhosa/isiZulu locales exist in date-fns)

`ChangeLanguageSelector` already reads `Object.keys(i18n.services.resourceStore.data)` to render available languages, so it picks up the new ones automatically.


### 🪤 Peer Testing

- Open **Settings → Change Language**.

    **Expected:** 8 options visible — English, Français, Ελληνικά, Español, Português, Afrikaans, isiXhosa, isiZulu.

- Pick new language and navigate around the app.

    **Expected:** UI strings render in selected language (e.g. login screen, applet list). 

### ✏️ Notes

- Backend email template support for these languages is in a separate PR on `mindlogger-backend-refactor`. The password recovery email will arrive in the chosen language once that deploys; MFA notification emails still default to English regardless of UI language (pre-existing, unrelated to this PR).

