### PR TITLE
fix: add missing Xhosa weekday and fall back to English (M2-10835)

### DIFF
--- a/assets/translations/xh.json
+++ b/assets/translations/xh.json
@@ -71,7 +71,7 @@
   },
   "calendar": {
     "months": "NgoJanuwari_Februwari_Matshi_Apreli_Meyi_Juni_Julayi_Agasti_Septemba_Okthobha_Novemba_Disemba",
-    "weekdays": "Langa_Mso_Lwesibini_Lwesithathu_Lwesihlanu_Sat",
+    "weekdays": "Langa_Mso_Lwesibini_Lwesithathu_Lwesine_Lwesihlanu_Sat",
     "x_days": "MVULO_LWESIBINI_LWESITHATHU_LWESINE_LWESIHLANU_MGQIBELO_CAWE"
   },
   "applet_data": {

--- a/src/shared/ui/HorizontalCalendar.tsx
+++ b/src/shared/ui/HorizontalCalendar.tsx
@@ -17,6 +17,8 @@ export const HorizontalCalendar: FC<BoxProps> = styledProps => {
 
   // Get weekday abbreviations from translations instead of date-fns locale
   const weekdays = t('calendar:weekdays').split('_');
+  // Fall back to English per-day if a translation is missing/malformed
+  const enWeekdays = t('calendar:weekdays', { lng: 'en' }).split('_');
 
   return (
     <Box gap={8} pt={16} px={16} {...styledProps}>
@@ -28,7 +30,11 @@ export const HorizontalCalendar: FC<BoxProps> = styledProps => {
         {dates.map(date => {
           const dateOfMonth = date.getDate();
           const dayIndex = date.getDay(); // 0 = Sunday, 6 = Saturday
-          const weekDayName = weekdays[dayIndex].toUpperCase();
+          const weekDayName = (
+            weekdays[dayIndex] ??
+            enWeekdays[dayIndex] ??
+            ''
+          ).toUpperCase();
 
           const isToday = currentDate.getDate() === dateOfMonth;
           const textColor = isToday ? '$primary' : '$outline';


### PR DESCRIPTION
- [ ] Tests for the changes have been added
- [ ] Related documentation has been added / updated
- [ ] OSS packages added to Curious [open source credit page](https://mindlogger.atlassian.net/jira/servicedesk/projects/MLA/knowledge/articles/340623543?spaceKey=MLA)

### 📝 Description

🔗 [Jira Ticket M2-10835](https://mindlogger.atlassian.net/browse/M2-10835)

App crashed on opening an applet when the language was set to Xhosa (`Cannot read property 'toUpperCase' of undefined` in `HorizontalCalendar`). Root cause was a data issue : the Xhosa `calendar.weekdays` string was missing Thursday (`Lwesine`), so it had 6 days instead of 7 and the calendar hit an undefined entry for Saturday.

Changes include:

- Added the missing Xhosa weekday (`Lwesine`) to `xh.json`.
- Added a per-day fallback to English in `HorizontalCalendar` so a missing/malformed translation renders the English label instead of crashing.

### 🪤 Peer Testing

- Switch language to **Xhosa**, log in, and tap on an applet card.

    **Expected outcome:** The applet screen opens normally (no crash) and the calendar shows all 7 weekdays.

### ✏️ Notes

- Affected Xhosa only - Zulu and Afrikaans already had all 7 weekdays.
