### PR TITLE
fix: keep activity navigation button text on one line (M2-10839, M2-10841)

### DIFF
--- a/src/shared/ui/Stepper/BackButton.tsx
+++ b/src/shared/ui/Stepper/BackButton.tsx
@@ -30,6 +30,7 @@ export function BackButton({ children, isIcon }: Props) {
       maxWidth="100%"
       width={120}
       px={10}
+      textProps={{ numberOfLines: 1, adjustsFontSizeToFit: true }}
     >
       {children}
     </SubmitButton>

--- a/src/shared/ui/Stepper/NextButton.tsx
+++ b/src/shared/ui/Stepper/NextButton.tsx
@@ -50,6 +50,7 @@ export function NextButton({ children, isIcon, accessibilityLabel }: Props) {
       maxWidth="100%"
       width={120}
       px={10}
+      textProps={{ numberOfLines: 1, adjustsFontSizeToFit: true }}
     >
       {children}
     </SubmitButton>

--- a/src/shared/ui/Stepper/UndoButton.tsx
+++ b/src/shared/ui/Stepper/UndoButton.tsx
@@ -30,6 +30,7 @@ export function UndoButton({ children, isIcon }: Props) {
       maxWidth="100%"
       width={120}
       px={10}
+      textProps={{ numberOfLines: 1, adjustsFontSizeToFit: true }}
     >
       {children}
     </SubmitButton>

--- a/src/widgets/survey/ui/completion/CircleProgressStep.tsx
+++ b/src/widgets/survey/ui/completion/CircleProgressStep.tsx
@@ -22,11 +22,29 @@ export const CircleProgressStep = ({
     <Box f={1} ai="center" jc="center" pos="relative">
       <CircleProgress progress={currentStep / totalSteps} size={circleSize} />
 
-      <Box pos="absolute">
-        <Text ta="center" tt="uppercase" fontSize={12} lineHeight={16} ls={0.5}>
+      <Box pos="absolute" w={circleSize} px={18}>
+        <Text
+          ta="center"
+          tt="uppercase"
+          fontSize={12}
+          lineHeight={16}
+          ls={0.5}
+          numberOfLines={1}
+          adjustsFontSizeToFit
+          minimumFontScale={0.5}
+        >
           {t('activity:step')}
         </Text>
-        <Text fontWeight="700" fontSize={12} lineHeight={16} ls={0.5}>
+        <Text
+          ta="center"
+          fontWeight="700"
+          fontSize={12}
+          lineHeight={16}
+          ls={0.5}
+          numberOfLines={1}
+          adjustsFontSizeToFit
+          minimumFontScale={0.5}
+        >
           {t('activity:stepCounter', { currentStep, totalSteps })}
         </Text>
       </Box>


### PR DESCRIPTION
- [ ] Tests for the changes have been added
- [ ] Related documentation has been added / updated
- [ ] OSS packages added to Curious [open source credit page](https://mindlogger.atlassian.net/jira/servicedesk/projects/MLA/knowledge/articles/340623543?spaceKey=MLA)

### 📝 Description

🔗 [Jira Ticket M2-10839](https://mindlogger.atlassian.net/browse/M2-10839)
🔗 [Jira Ticket M2-10841](https://mindlogger.atlassian.net/browse/M2-10841)

The 'Next' button text ("Okulandelayo" in Xhosa) wrapped onto two lines because the button has a fixed width and longer translations didn't fit. Forced the navigation button labels onto a single line, shrinking the font slightly to fit when needed. Short labels (e.g. English "Next") are unaffected.

The processing-answers step label ("INYATHELO" in Xhosa, "ISINYATHELO" in Zulu) overflowed the progress circle because the longer translations didn't fit inside it. Constrained the label to the circle and shrink the font slightly to fit when needed. Short labels (e.g. English "STEP") are unaffected.

Changes include:

- Added `numberOfLines: 1` and `adjustsFontSizeToFit` to the Next, Back, and Undo navigation buttons.
- Constrained the processing-answers step label to the progress circle with `numberOfLines: 1` and `adjustsFontSizeToFit`.

### 📸 Screenshots

| Before                                 | After                                 |
| -------------------------------------- | ------------------------------------- |
| <img width="357" height="724" alt="image" src="https://github.com/user-attachments/assets/2ccb3e68-86f8-4cb3-b58f-deabd3376a20" />| <img width="353" height="726" alt="image" src="https://github.com/user-attachments/assets/489c8cd8-78c4-46b5-b54f-4257c906ad1e" /> |

### 🪤 Peer Testing

- Switch the app to **Xhosa**, start an activity, and select any answer.

    **Expected outcome:** The 'Okulandelayo' (Next) button text is shown on one line.

- Switch the app to **Xhosa/Zulu**, start an activity, select any answers, and complete the activity.

    **Expected outcome:** The processing-answers step label is shown correctly inside the progress circle.

### ✏️ Notes

- Fix applies to all languages, not just Xhosa:  any long button translation will now fit on one line instead of wrapping.
- The step label fix also applies to all languages: any long translation will fit inside the progress circle.
