### PR TITLE
fix: Lock iOS to portrait after app mounts (M2-10845, M2-10877)

### DIFF
--- a/index.js
+++ b/index.js
@@ -12,9 +12,6 @@ import { AppRegistry } from 'react-native';
 import { Buffer } from 'buffer';
 import process from 'process';
 import PropTypes from 'prop-types';
-import RNOrientationDirector, {
-  Orientation,
-} from 'react-native-orientation-director';
 import SystemNavigationBar from 'react-native-system-navigation-bar';
 
 import { palette } from '@shared/lib/constants/palette';
@@ -57,6 +54,5 @@ HeadlessCheck.propTypes = {
 };
 
 SystemNavigationBar.setNavigationColor(palette.surface1, 'dark', 'navigation');
-RNOrientationDirector.lockTo(Orientation.portrait);
 
 AppRegistry.registerComponent(appName, () => HeadlessCheck);

--- a/ios/MindloggerMobile/AppDelegate.swift
+++ b/ios/MindloggerMobile/AppDelegate.swift
@@ -42,6 +42,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     supportedInterfaceOrientationsFor window: UIWindow?
   ) -> UIInterfaceOrientationMask {
     // Mask must be static option set (M2-10056)
+    // Constrain orientations with OrientationAwareRootViewController
     return [.portrait, .landscapeLeft, .landscapeRight]
   }
 
@@ -77,5 +78,17 @@ class ReactNativeDelegate: RCTDefaultReactNativeFactoryDelegate {
     #else
     return Bundle.main.url(forResource: "main", withExtension: "jsbundle")
     #endif
+  }
+
+  override func createRootViewController() -> UIViewController {
+    return OrientationAwareRootViewController()
+  }
+}
+
+class OrientationAwareRootViewController: UIViewController {
+  override var supportedInterfaceOrientations: UIInterfaceOrientationMask {
+    // Constrain view controller to orientations configured by react-native-orientation-director
+    // Intersects with the app's static orientation mask above (M2-10056)
+    return OrientationDirector.getSupportedInterfaceOrientationsForWindow()
   }
 }

--- a/ios/MindloggerMobile/AppDelegate.swift
+++ b/ios/MindloggerMobile/AppDelegate.swift
@@ -4,6 +4,7 @@ import React_RCTAppDelegate
 import ReactAppDependencyProvider
 import TSBackgroundFetch
 import Firebase
+import react_native_orientation_director
 
 @main
 class AppDelegate: UIResponder, UIApplicationDelegate {

--- a/src/app/index.tsx
+++ b/src/app/index.tsx
@@ -1,3 +1,4 @@
+import { useEffect } from 'react';
 import { LogBox, StyleSheet } from 'react-native';
 
 import {
@@ -7,6 +8,9 @@ import {
   SdkVerbosity,
   UploadFrequency,
 } from '@datadog/mobile-react-native';
+import RNOrientationDirector, {
+  Orientation,
+} from 'react-native-orientation-director';
 import Animated, { LinearTransition } from 'react-native-reanimated';
 
 import { Banners } from '@app/entities/banner/ui/Banners';
@@ -70,6 +74,11 @@ if (__DEV__) {
 }
 
 const App = () => {
+  useEffect(() => {
+    // Lock to portrait after app mounts
+    RNOrientationDirector.lockTo(Orientation.portrait);
+  }, []);
+
   return (
     <DatadogProvider configuration={config}>
       <AppProvider>


### PR DESCRIPTION
### 📝 Description

🔗 [Jira Ticket M2-10845](https://mindlogger.atlassian.net/browse/M2-10845)
🔗 [Jira Ticket M2-10877](https://mindlogger.atlassian.net/browse/M2-10877)

Previously, I tried to lock to portrait when the module loaded which caused the `lockTo` method to be a no-op. Instead, we need to: (a) wait until the app mounts to lock to portrait and (b) override the view controller to constrain orientations because we set a static orientation mask on the app in #1116 to address M2-10056.

### ✏️ Notes

This issue only appeared in iOS because we lock to portrait with the manifest on Android.