### PR TITLE
fix: keep A/B Trails live canvas mounted after completion (M2-10772)

### DIFF
--- a/src/entities/abTrail/ui/AbCanvas.tsx
+++ b/src/entities/abTrail/ui/AbCanvas.tsx
@@ -294,7 +294,7 @@ export const AbCanvas: FC<Props> = props => {
     const isFinished = currentIndexRef.current === testData.nodes.length;
 
     if (readonly || isFinished) {
-      hideSketchCanvas();
+      // Don't unmount the canvas (flickers on Android); resetCurrentPath clears without unmounting.
       resetCurrentPath();
       return;
     }
@@ -329,7 +329,10 @@ export const AbCanvas: FC<Props> = props => {
     const currentPath = getCurrentPath();
 
     if (!currentPath) {
-      hideSketchCanvas();
+      // Once finished, don't unmount the canvas on finger-move (flickers the last line on Android).
+      if (currentIndexRef.current !== testData.nodes.length) {
+        hideSketchCanvas();
+      }
       return;
     }
 
@@ -340,11 +343,11 @@ export const AbCanvas: FC<Props> = props => {
     addLogPoint(createLogPoint(point, time));
 
     if (isOverNext(point) && isOverLast(point)) {
-      hideSketchCanvas();
       markLastLogPoints({ valid: true });
       addOverCorrectPointToStream(point, time);
       keepPathInState();
-      resetCurrentPath();
+      // Just null the ref so onTouchEnd no-ops; don't unmount the live canvas — that flickers the last line on Android (Skia 2.4+).
+      currentPathRef.current = null;
       onMessage(MessageType.Completed);
       incrementCurrentIndex();
       onResult();
@@ -402,7 +405,8 @@ export const AbCanvas: FC<Props> = props => {
   return (
     <Box {...props} borderWidth={1} borderColor="$outline">
       <Box width={width} height={width}>
-        {isSketchCanvasShown && !readonly && (
+        {/* Keep mounted after completion; unmounting flickers the canvas on Android. Input is blocked above. */}
+        {isSketchCanvasShown && (
           <SketchCanvas
             ref={sketchCanvasRef}
             initialLines={[]}


### PR DESCRIPTION
- [ ] Tests for the changes have been added
- [ ] Related documentation has been added / updated
- [ ] OSS packages added to Curious [open source credit page](https://mindlogger.atlassian.net/jira/servicedesk/projects/MLA/knowledge/articles/340623543?spaceKey=MLA)

### 📝 Description

🔗 [Jira Ticket M2-10772](https://mindlogger.atlassian.net/browse/M2-10772)

On Android, the last line in an A/B Trails activity flickers when you connect the final point. It doesn't happen on iOS, and it started after the Skia upgrade in the 16 KB page-size update.

A/B Trails draws on two stacked canvases: a live one that follows your finger and a final one (on top) that holds the locked-in lines. When a trail finishes, the live canvas was being removed. In the new Skia version, removing a canvas makes the neighbouring canvas redraw on Android, which is the flicker.

Fix: keep the live canvas mounted after the trail finishes instead of removing it. It's already invisible (the final canvas covers it) and drawing is already blocked once finished, so nothing changes for the user except the flicker is gone.

Changes:

- Keep the live sketch canvas mounted after completion (don't unmount on `readonly`)
- Stop unmounting it on finger-move / tap once the trail is finished


### 🪤 Peer Testing

- Start an A/B Trails activity and skip the instructions.
- Connect all the points in the correct order.
- Pay attention to the last line as you connect the final point.

    **Expected outcome:** The last line does not blink/flicker. Test on Android (e.g. Samsung S23 FE / Pixel 9).

- After finishing, continue to the next trail/activity.

    **Expected outcome:** Navigation still works normally.
