### PR TITLE
Fix: abtrails android flicker (M2-10772)

### DIFF
--- a/src/entities/abTrail/ui/AbCanvas.tsx
+++ b/src/entities/abTrail/ui/AbCanvas.tsx
@@ -78,6 +78,11 @@ export const AbCanvas: FC<Props> = props => {
 
     const id = setTimeout(() => {
       setErrorPath(null);
+      // Clear the live stroke with the error path; guard against a new stroke
+      // started during the error window.
+      if (!getCurrentPath()) {
+        sketchCanvasRef.current?.clear();
+      }
     }, ErrorLineTimeout);
 
     return () => {
@@ -344,7 +349,9 @@ export const AbCanvas: FC<Props> = props => {
       markLastLogPoints({ valid: true });
       addOverCorrectPointToStream(point, time);
       keepPathInState();
-      resetCurrentPath();
+      // Don't clear the live stroke — keep it visible under the committed last
+      // segment so there's no frame where the line disappears (blink).
+      currentPathRef.current = null;
       onMessage(MessageType.Completed);
       incrementCurrentIndex();
       onResult();
@@ -366,6 +373,9 @@ export const AbCanvas: FC<Props> = props => {
       const node = findNodeByPoint(point)!;
       hideSketchCanvas();
       setErrorPath(currentPath);
+      // Null the ref so onTouchEnd doesn't call resetCurrentPath() and clear().
+      // Clearing livePath before errorPath renders causes a one-frame blink.
+      currentPathRef.current = null;
       markLastLogPoints({ valid: false, actual: node.label });
       setFlareGreenPointIndex({ index: getCurrentIndex() });
       onMessage(MessageType.IncorrectLine);
@@ -402,15 +412,14 @@ export const AbCanvas: FC<Props> = props => {
   return (
     <Box {...props} borderWidth={1} borderColor="$outline">
       <Box width={width} height={width}>
-        {isSketchCanvasShown && !readonly && (
-          <SketchCanvas
-            ref={sketchCanvasRef}
-            initialLines={[]}
-            onStrokeStart={onTouchStart}
-            onStrokeChanged={onTouchProgress}
-            onStrokeEnd={onTouchEnd}
-          />
-        )}
+        <SketchCanvas
+          ref={sketchCanvasRef}
+          initialLines={[]}
+          enabled={isSketchCanvasShown && !readonly}
+          onStrokeStart={onTouchStart}
+          onStrokeChanged={onTouchProgress}
+          onStrokeEnd={onTouchEnd}
+        />
       </Box>
 
       {canvasData && (

--- a/src/shared/ui/SketchCanvas/SketchCanvas.tsx
+++ b/src/shared/ui/SketchCanvas/SketchCanvas.tsx
@@ -21,13 +21,14 @@ export type SketchCanvasRef = {
 
 type Props = {
   initialLines: Array<Point[]>;
+  enabled?: boolean;
   onStrokeStart: (x: number, y: number, time: number) => void;
   onStrokeChanged: (x: number, y: number, time: number) => void;
   onStrokeEnd: (x: number, y: number, time: number) => void;
 };
 
 export const SketchCanvas = forwardRef<SketchCanvasRef, Props>((props, ref) => {
-  const { initialLines, onStrokeStart, onStrokeChanged, onStrokeEnd } = props;
+  const { initialLines, enabled = true, onStrokeStart, onStrokeChanged, onStrokeEnd } = props;
 
   const fullPath = useSharedValue<SkPath>(
     initialLines
@@ -116,7 +117,7 @@ export const SketchCanvas = forwardRef<SketchCanvasRef, Props>((props, ref) => {
   };
 
   const drawingGesture = useDrawingGesture(
-    { areaSize: width },
+    { areaSize: width, enabled },
     { onTouchStart, onTouchProgress, onTouchEnd },
   );
 

--- a/src/shared/ui/SketchCanvas/SketchCanvas.tsx
+++ b/src/shared/ui/SketchCanvas/SketchCanvas.tsx
@@ -28,7 +28,13 @@ type Props = {
 };
 
 export const SketchCanvas = forwardRef<SketchCanvasRef, Props>((props, ref) => {
-  const { initialLines, enabled = true, onStrokeStart, onStrokeChanged, onStrokeEnd } = props;
+  const {
+    initialLines,
+    enabled = true,
+    onStrokeStart,
+    onStrokeChanged,
+    onStrokeEnd,
+  } = props;
 
   const fullPath = useSharedValue<SkPath>(
     initialLines

--- a/src/shared/ui/SketchCanvas/useDrawingGesture.ts
+++ b/src/shared/ui/SketchCanvas/useDrawingGesture.ts
@@ -12,6 +12,7 @@ import { Point } from './LineSketcher';
 
 type Options = {
   areaSize: SharedValue<number>;
+  enabled?: boolean;
 };
 
 type Callbacks = {
@@ -30,7 +31,7 @@ const findTouchById = (event: GestureTouchEvent, id?: number) => {
 };
 
 export function useDrawingGesture(
-  { areaSize }: Options,
+  { areaSize, enabled = true }: Options,
   { onTouchStart, onTouchProgress, onTouchEnd }: Callbacks,
 ) {
   const registeredTouch = useSharedValue<TouchData | null>(null);
@@ -246,10 +247,14 @@ export function useDrawingGesture(
         onTouchEnd(event, Date.now());
       });
 
-  const iosGesture = () => iosManualGesture();
+  const iosGesture = () => iosManualGesture().enabled(enabled);
 
   const androidGesture = () =>
-    Gesture.Exclusive(androidPanGesture(), tapGesture(), longTapGesture());
+    Gesture.Exclusive(
+      androidPanGesture().enabled(enabled),
+      tapGesture().enabled(enabled),
+      longTapGesture().enabled(enabled),
+    );
 
   const gesture = IS_IOS ? iosGesture() : androidGesture();
 


### PR DESCRIPTION
- [ ] Tests for the changes have been added
- [ ] Related documentation has been added / updated
- [ ] OSS packages added to Curious [open source credit page](https://mindlogger.atlassian.net/jira/servicedesk/projects/MLA/knowledge/articles/340623543?spaceKey=MLA)

### 📝 Description

🔗 [Jira Ticket M2-10772](https://mindlogger.atlassian.net/browse/M2-10772)

A/B Trails lines were blinking on Android (Samsung S23 FE, Pixel 9 Pro XL) after connecting the last point or drawing an incorrect line. 

**Root cause:** The drawing canvas (`SketchCanvas`) was being unmounted every time a line was committed or rejected via `hideSketchCanvas()`. On `@shopify/react-native-skia` 2.4.21 (bumped in the 16KB page-size compliance update), Android forces a full repaint on any neighbouring native Skia surface when one is destroyed. That repaint drops one frame : the blink.

**Fix:** Keep `SketchCanvas` always mounted. Instead of unmounting it, disable the drawing gesture via a new `enabled` prop. The canvas stays alive on screen; only touch input is paused. Android sees no surface change, so no forced repaint, no blink.

Changes include:

- `useDrawingGesture.ts` - added `enabled` prop; wires `.enabled(false/true)` to all gesture recognisers (iOS manual + Android pan/tap/longPress)
- `SketchCanvas.tsx` - added `enabled` prop; passes it through to `useDrawingGesture`
- `AbCanvas.tsx` - replaced the `isSketchCanvasShown && !readonly` mount gate with `enabled={isSketchCanvasShown && !readonly}` on an always-mounted `SketchCanvas`; null `currentPathRef` instead of calling `resetCurrentPath()` in the completion and wrong-line branches to avoid clearing the live stroke at the same instant React is painting a new committed/error line; clear the live stroke in the error timeout instead, where no concurrent paint is happening

### 🪤 Peer Testing

- Open an A/B Trails activity on an Android device.

- Connect points in the correct order up to the last connection. Complete the trail by connecting the final point.

    **Expected outcome:** The line does not blink or flash when the last connection is made.

- Start a new A/B Trails activity. Draw a line to an incorrect node.

    **Expected outcome:** The red error line appears without any blink. The error clears after 1 second without any flash.

- Repeat both steps on iOS.

    **Expected outcome:** Behaviour unchanged on iOS.

### ✏️ Notes

- `hideSketchCanvas()` and `useSketchCanvasTimedVisibility` are intentionally kept - they now control the `enabled` flag instead of the mount state, so the 50ms re-enable delay still applies after a wrong connection.
- The fix is isolated to `AbCanvas` and the shared `SketchCanvas` + `useDrawingGesture` primitives. `AbShapes` is untouched.