### PR TITLE
Added isiZulu translations for days of week (M2-10861)

### DIFF
--- a/assets/translations/zu.json
+++ b/assets/translations/zu.json
@@ -62,17 +62,17 @@
   "activity_chart": {
     "title": "Sicela uthathe ukuhlolwa ukuze idatha iboniswe.",
     "monday": "M",
-    "tuesday": "T",
-    "wednesday": "W",
-    "thursday": "T",
-    "friday": "F",
-    "saturday": "S",
+    "tuesday": "B",
+    "wednesday": "T",
+    "thursday": "S",
+    "friday": "H",
+    "saturday": "M",
     "sunday": "S"
   },
   "calendar": {
     "months": "January_February_March_April_May_June_July_August_September_October_November_December",
-    "weekdays": "Sun_Mon_Tue_Wed_Thu_Fri_Sat",
-    "x_days": "M_T_W_T_F_S_S"
+    "weekdays": "Mso_Bil_Tha_Sine_Hla_Mgqi_Sonto",
+    "x_days": "M_B_T_S_H_M_S"
   },
   "applet_data": {
     "title": "Sicela uthathe ukuhlolwa ukuze idatha iboniswe."


### PR DESCRIPTION
### 📝 Description

🔗 [Jira Ticket M2-10861](https://mindlogger.atlassian.net/browse/M2-10861)

The calendar and activity chart in the isiZulu locale were displaying English day-of-week abbreviations instead of isiZulu
ones. This PR updates the translations so that days are shown in isiZulu.

Changes include:

- Updated `activity_chart` day abbreviations to use isiZulu single-letter abbreviations (M, B, T, S, H, M, S)
- Updated `calendar.weekdays` from English abbreviations (Sun, Mon, Tue, ...) to isiZulu abbreviations (Mso, Bil, Tha, Sine, Hla, Mgqi, Sonto)
- Updated `calendar.x_days` to match the isiZulu single-letter abbreviations