### PR TITLE
fix: correct Xhosa calendar weekday and chart day labels (M2-10858)

### DIFF
--- a/assets/translations/xh.json
+++ b/assets/translations/xh.json
@@ -62,17 +62,17 @@
   "activity_chart": {
     "title": "Nceda uthathe uvavanyo ukuze idatha iboniswe.",
     "monday": "M",
-    "tuesday": "L",
-    "wednesday": "L",
-    "thursday": "L",
-    "friday": "L",
+    "tuesday": "S",
+    "wednesday": "S",
+    "thursday": "S",
+    "friday": "H",
     "saturday": "M",
     "sunday": "C"
   },
   "calendar": {
     "months": "NgoJanuwari_Februwari_Matshi_Apreli_Meyi_Juni_Julayi_Agasti_Septemba_Okthobha_Novemba_Disemba",
     "weekdays": "Cawa_Mvu_Lwesibi_Lwesith_Levine_Lwesihlanu_Mgqi",
-    "x_days": "M_L_L_L_L_M_C"
+    "x_days": "M_S_S_S_H_M_C"
   },
   "applet_data": {
     "title": "Nceda uthathe uvavanyo ukuze idatha iboniswe."

--- a/assets/translations/xh.json
+++ b/assets/translations/xh.json
@@ -61,18 +61,18 @@
   },
   "activity_chart": {
     "title": "Nceda uthathe uvavanyo ukuze idatha iboniswe.",
-    "monday": "UMVULO",
-    "tuesday": "ULWESIBINI",
-    "wednesday": "ULWESITHATHU",
-    "thursday": "ULWESIBINI",
-    "friday": "ULWESIHLANU",
-    "saturday": "UMGQIBELO",
-    "sunday": "UMGQIBELO"
+    "monday": "M",
+    "tuesday": "L",
+    "wednesday": "L",
+    "thursday": "L",
+    "friday": "L",
+    "saturday": "M",
+    "sunday": "C"
   },
   "calendar": {
     "months": "NgoJanuwari_Februwari_Matshi_Apreli_Meyi_Juni_Julayi_Agasti_Septemba_Okthobha_Novemba_Disemba",
-    "weekdays": "Langa_Mso_Lwesibini_Lwesithathu_Lwesine_Lwesihlanu_Sat",
-    "x_days": "MVULO_LWESIBINI_LWESITHATHU_LWESINE_LWESIHLANU_MGQIBELO_CAWE"
+    "weekdays": "Cawa_Mvu_Lwesibi_Lwesith_Levine_Lwesihlanu_Mgqi",
+    "x_days": "M_L_L_L_L_M_C"
   },
   "applet_data": {
     "title": "Nceda uthathe uvavanyo ukuze idatha iboniswe."

--- a/src/shared/ui/HorizontalCalendar.tsx
+++ b/src/shared/ui/HorizontalCalendar.tsx
@@ -56,6 +56,11 @@ export const HorizontalCalendar: FC<BoxProps> = styledProps => {
                 lineHeight={16}
                 letterSpacing={0.5}
                 color={textColor}
+                width={daySize}
+                ta="center"
+                numberOfLines={1}
+                adjustsFontSizeToFit
+                minimumFontScale={0.6}
               >
                 {weekDayName}
               </Text>


### PR DESCRIPTION
- [ ] Tests for the changes have been added
- [ ] Related documentation has been added / updated
- [ ] OSS packages added to Curious [open source credit page](https://mindlogger.atlassian.net/jira/servicedesk/projects/MLA/knowledge/articles/340623543?spaceKey=MLA)

### 📝 Description

🔗 [Jira Ticket M2-10858](https://mindlogger.atlassian.net/browse/M2-10858)

The Xhosa calendar weekday labels were long, overlapping, and partly wrong ("Sat" left in English), and the analytics chart day labels were full words with duplicates. Updated the Xhosa day values (from the translators' document) and made the calendar weekday label shrink to fit one line.

Changes include:

- Updated Xhosa `calendar.weekdays` to short, differentiable abbreviations.
- Updated Xhosa `calendar.x_days` and `activity_chart` to single-letter labels.
- Made the calendar weekday label auto-shrink to one line so long translations fit.


### 🪤 Peer Testing

- Switch the app to **Xhosa**, log in, and open an applet's data screen.

    **Expected outcome:** The calendar weekday labels show on one line and are all distinct; the analytics chart day labels are short and correct.

