### PR TITLE
test: test for validating translation lists against English reference (M2-10836)

### DIFF
--- a/src/entities/localization/lib/setupLocalization.ts
+++ b/src/entities/localization/lib/setupLocalization.ts
@@ -3,6 +3,7 @@ import { initReactI18next } from 'react-i18next';
 import { z } from 'zod';
 import { zodI18nMap } from 'zod-i18n-map';
 
+import { getDefaultLogger } from '@app/shared/lib/services/loggerInstance';
 import af from '@assets/translations/af.json';
 import el from '@assets/translations/el.json';
 import en from '@assets/translations/en.json';
@@ -13,6 +14,7 @@ import xh from '@assets/translations/xh.json';
 import zu from '@assets/translations/zu.json';
 
 import { getDefaultLocalizationStorage } from './localizationStorageInstance';
+import { validateTranslations } from './validateTranslations';
 
 declare module 'i18next' {
   interface CustomTypeOptions {
@@ -22,23 +24,40 @@ declare module 'i18next' {
 
 z.setErrorMap(zodI18nMap);
 
+const resources = {
+  en,
+  fr,
+  el,
+  es,
+  pt: ptBr,
+  af,
+  xh,
+  zu,
+};
+
+const REFERENCE_LANGUAGE = 'en';
+
+// Surface malformed list values in Datadog so a bad translation file is caught even after release.
+function reportMalformedTranslations() {
+  const malformed = validateTranslations(resources, REFERENCE_LANGUAGE).filter(
+    finding => finding.type === 'malformed-list',
+  );
+
+  malformed.forEach(finding => {
+    getDefaultLogger().warn('[i18n] Malformed translation list', finding);
+  });
+}
+
 export function setupLocalization() {
   const language = getDefaultLocalizationStorage().getLanguage() ?? 'en';
+
+  reportMalformedTranslations();
 
   return i18n.use(initReactI18next).init({
     compatibilityJSON: 'v3',
     lng: language,
     fallbackLng: 'en',
-    resources: {
-      en,
-      fr,
-      el,
-      es,
-      pt: ptBr,
-      af,
-      xh,
-      zu,
-    },
+    resources,
     returnNull: false,
   });
 

--- a/src/entities/localization/lib/setupLocalization.ts
+++ b/src/entities/localization/lib/setupLocalization.ts
@@ -3,7 +3,6 @@ import { initReactI18next } from 'react-i18next';
 import { z } from 'zod';
 import { zodI18nMap } from 'zod-i18n-map';
 
-import { getDefaultLogger } from '@app/shared/lib/services/loggerInstance';
 import af from '@assets/translations/af.json';
 import el from '@assets/translations/el.json';
 import en from '@assets/translations/en.json';
@@ -14,7 +13,6 @@ import xh from '@assets/translations/xh.json';
 import zu from '@assets/translations/zu.json';
 
 import { getDefaultLocalizationStorage } from './localizationStorageInstance';
-import { validateTranslations } from './validateTranslations';
 
 declare module 'i18next' {
   interface CustomTypeOptions {
@@ -35,23 +33,8 @@ const resources = {
   zu,
 };
 
-const REFERENCE_LANGUAGE = 'en';
-
-// Surface malformed list values in Datadog so a bad translation file is caught even after release.
-function reportMalformedTranslations() {
-  const malformed = validateTranslations(resources, REFERENCE_LANGUAGE).filter(
-    finding => finding.type === 'malformed-list',
-  );
-
-  malformed.forEach(finding => {
-    getDefaultLogger().warn('[i18n] Malformed translation list', finding);
-  });
-}
-
 export function setupLocalization() {
   const language = getDefaultLocalizationStorage().getLanguage() ?? 'en';
-
-  reportMalformedTranslations();
 
   return i18n.use(initReactI18next).init({
     compatibilityJSON: 'v3',

--- a/src/entities/localization/lib/validateTranslations.test.ts
+++ b/src/entities/localization/lib/validateTranslations.test.ts
@@ -1,0 +1,26 @@
+import af from '@assets/translations/af.json';
+import el from '@assets/translations/el.json';
+import en from '@assets/translations/en.json';
+import es from '@assets/translations/es.json';
+import fr from '@assets/translations/fr.json';
+import ptBr from '@assets/translations/pt.json';
+import xh from '@assets/translations/xh.json';
+import zu from '@assets/translations/zu.json';
+
+import { validateTranslations } from './validateTranslations';
+
+// Mirrors the resources registered in setupLocalization.
+const resources = { en, fr, el, es, pt: ptBr, af, xh, zu };
+const REFERENCE_LANGUAGE = 'en';
+
+describe('translations', () => {
+  // Malformed list values still resolve in i18next, so the fallback never triggers and consumers crash.
+  it('has no list values that diverge from the English reference', () => {
+    const malformed = validateTranslations(
+      resources,
+      REFERENCE_LANGUAGE,
+    ).filter(finding => finding.type === 'malformed-list');
+
+    expect(malformed).toEqual([]);
+  });
+});

--- a/src/entities/localization/lib/validateTranslations.test.ts
+++ b/src/entities/localization/lib/validateTranslations.test.ts
@@ -23,4 +23,19 @@ describe('translations', () => {
 
     expect(malformed).toEqual([]);
   });
+
+  // A key present in the English reference but absent in another language is reported.
+  it('reports keys missing from a non-reference language', () => {
+    const findings = validateTranslations(
+      {
+        en: { greeting: 'Hello', farewell: 'Goodbye' },
+        fr: { greeting: 'Bonjour' },
+      },
+      'en',
+    );
+
+    expect(findings).toEqual([
+      { type: 'missing-key', language: 'fr', key: 'farewell' },
+    ]);
+  });
 });

--- a/src/entities/localization/lib/validateTranslations.ts
+++ b/src/entities/localization/lib/validateTranslations.ts
@@ -1,0 +1,81 @@
+type JsonValue =
+  | string
+  | number
+  | boolean
+  | null
+  | { [key: string]: JsonValue }
+  | JsonValue[];
+
+export type TranslationFinding =
+  | { type: 'missing-key'; language: string; key: string }
+  | {
+      type: 'malformed-list';
+      language: string;
+      key: string;
+      expectedSegments: number;
+      actualSegments: number;
+    };
+
+// Lists are delimiter-separated strings (e.g. "Sun_Mon_Tue") where segment count matters.
+const LIST_DELIMITER = '_';
+
+const flattenStrings = (
+  value: JsonValue,
+  prefix: string,
+  out: Map<string, string>,
+) => {
+  if (typeof value === 'string') {
+    out.set(prefix, value);
+    return;
+  }
+
+  if (value && typeof value === 'object' && !Array.isArray(value)) {
+    for (const [key, child] of Object.entries(value)) {
+      flattenStrings(child, prefix ? `${prefix}.${key}` : key, out);
+    }
+  }
+};
+
+// Reports keys missing in a language and list values whose segment count diverges from the reference.
+export const validateTranslations = (
+  resources: Record<string, JsonValue>,
+  referenceLanguage: string,
+): TranslationFinding[] => {
+  const findings: TranslationFinding[] = [];
+
+  const reference = new Map<string, string>();
+  flattenStrings(resources[referenceLanguage], '', reference);
+
+  for (const [language, tree] of Object.entries(resources)) {
+    if (language === referenceLanguage) continue;
+
+    const current = new Map<string, string>();
+    flattenStrings(tree, '', current);
+
+    for (const [key, referenceValue] of reference) {
+      const value = current.get(key);
+
+      if (value === undefined) {
+        findings.push({ type: 'missing-key', language, key });
+        continue;
+      }
+
+      if (referenceValue.includes(LIST_DELIMITER)) {
+        const expectedSegments = referenceValue.split(LIST_DELIMITER).length;
+        const actualSegments = value.split(LIST_DELIMITER).length;
+
+        if (expectedSegments !== actualSegments) {
+          findings.push({
+            type: 'malformed-list',
+            language,
+            key,
+            expectedSegments,
+            actualSegments,
+          });
+        }
+      }
+    }
+  }
+
+  return findings;
+};


### PR DESCRIPTION
🔗 [Jira Ticket M2-10836](https://mindlogger.atlassian.net/browse/M2-10836)

### 📝 Description

Some translation files use delimiter-separated lists (e.g. `Sun_Mon_Tue`). When a
language has the wrong number of segments, i18next still resolves the value, so the
fallback never triggers and consumers can crash.

Changes include:

- Add `validateTranslations` to compare each language's list values against the English reference by segment count
- Report malformed lists to Datadog on `setupLocalization`, so a bad translation file is caught even after release
- Add a test asserting no list values diverge from the English reference


