### PR TITLE
fix: AB Trails Android flicker at rendering layer (M2-10920,M2-10921,M2-10922)

### DIFF
--- a/src/shared/ui/SketchCanvas/DrawingLayer.tsx
+++ b/src/shared/ui/SketchCanvas/DrawingLayer.tsx
@@ -1,0 +1,115 @@
+import { FC } from 'react';
+import { StyleSheet, View } from 'react-native';
+
+import { SkPath } from '@shopify/react-native-skia';
+import { GestureDetector } from 'react-native-gesture-handler';
+import { runOnJS, SharedValue, useSharedValue } from 'react-native-reanimated';
+
+import {
+  createLine,
+  getCurrentShape,
+  Point,
+  progressLine,
+  Shape,
+} from './LineSketcher';
+import { useDrawingGesture } from './useDrawingGesture';
+
+type Props = {
+  fullPath: SharedValue<SkPath>;
+  width: SharedValue<number>;
+  onStrokeStart: (x: number, y: number, time: number) => void;
+  onStrokeChanged: (x: number, y: number, time: number) => void;
+  onStrokeEnd: (x: number, y: number, time: number) => void;
+};
+
+// Mounted only while drawing is enabled, so each hide/show cycle unmounts it
+// and gives the next stroke a fully reset gesture, without unmounting the Skia
+// Canvas. `fullPath` lives in the parent so drawing persists across remounts.
+export const DrawingLayer: FC<Props> = ({
+  fullPath,
+  width,
+  onStrokeStart,
+  onStrokeChanged,
+  onStrokeEnd,
+}) => {
+  const points = useSharedValue<Point[]>([]);
+  const lastPointTime = useSharedValue<number | null>(null);
+
+  const onTouchStart = (point: Point, time: number) => {
+    'worklet';
+    fullPath.value.addPath(createLine(points, point));
+    runOnJS(onStrokeStart)(point.x, point.y, time);
+  };
+
+  const onTouchProgress = (
+    point: Point,
+    straightLine: boolean,
+    time: number,
+  ) => {
+    'worklet';
+    const lastDrawnPoint = points.value[points.value.length - 1];
+
+    if (lastDrawnPoint) {
+      const dx = point.x - lastDrawnPoint.x;
+      const dy = point.y - lastDrawnPoint.y;
+
+      const isSameTime = lastPointTime.value === time;
+      const isSamePoint = dx === 0 && dy === 0;
+
+      if (isSamePoint || isSameTime) {
+        return;
+      }
+    }
+
+    lastPointTime.value = time;
+
+    fullPath.modify(value => {
+      'worklet';
+      progressLine(points, value, point, straightLine);
+
+      return value;
+    });
+
+    runOnJS(onStrokeChanged)(point.x, point.y, time);
+  };
+
+  const createDot = (point: Point, time: number) => {
+    'worklet';
+    runOnJS(onStrokeChanged)(point.x, point.y, time);
+
+    fullPath.modify(value => {
+      'worklet';
+      progressLine(points, value, point);
+
+      return value;
+    });
+  };
+
+  const onTouchEnd = (point: Point, time: number) => {
+    'worklet';
+    if (getCurrentShape(points) === Shape.Dot) {
+      const firstPoint = points.value[points.value.length - 1];
+
+      createDot(
+        {
+          x: firstPoint.x + 1.5,
+          y: firstPoint.y + 1.5,
+        },
+        Date.now(),
+      );
+    }
+
+    runOnJS(onStrokeEnd)(point.x, point.y, time);
+  };
+
+  const drawingGesture = useDrawingGesture(
+    { areaSize: width },
+    { onTouchStart, onTouchProgress, onTouchEnd },
+  );
+
+  return (
+    <GestureDetector gesture={drawingGesture}>
+      <View style={StyleSheet.absoluteFill} />
+    </GestureDetector>
+  );
+};

--- a/src/shared/ui/SketchCanvas/SketchCanvas.tsx
+++ b/src/shared/ui/SketchCanvas/SketchCanvas.tsx
@@ -2,18 +2,10 @@ import { forwardRef, useImperativeHandle } from 'react';
 import { StyleSheet, View } from 'react-native';
 
 import { Canvas, Path, Skia, SkPath } from '@shopify/react-native-skia';
-import { GestureDetector } from 'react-native-gesture-handler';
-import { runOnJS, useSharedValue } from 'react-native-reanimated';
+import { useSharedValue } from 'react-native-reanimated';
 
-import {
-  createLine,
-  createPathFromPoints,
-  getCurrentShape,
-  Point,
-  progressLine,
-  Shape,
-} from './LineSketcher';
-import { useDrawingGesture } from './useDrawingGesture';
+import { DrawingLayer } from './DrawingLayer';
+import { createPathFromPoints, Point } from './LineSketcher';
 
 export type SketchCanvasRef = {
   clear: () => void;
@@ -42,9 +34,6 @@ export const SketchCanvas = forwardRef<SketchCanvasRef, Props>((props, ref) => {
       .reduce((path, curr) => path.addPath(curr), Skia.Path.Make()),
   );
 
-  const points = useSharedValue<Point[]>([]);
-
-  const lastPointTime = useSharedValue<number | null>(null);
   const width = useSharedValue(0);
 
   useImperativeHandle(ref, () => {
@@ -55,94 +44,35 @@ export const SketchCanvas = forwardRef<SketchCanvasRef, Props>((props, ref) => {
     };
   });
 
-  const onTouchStart = (point: Point, time: number) => {
-    'worklet';
-    fullPath.value.addPath(createLine(points, point));
-    runOnJS(onStrokeStart)(point.x, point.y, time);
-  };
-
-  const onTouchProgress = (
-    point: Point,
-    straightLine: boolean,
-    time: number,
-  ) => {
-    'worklet';
-    const lastDrawnPoint = points.value[points.value.length - 1];
-
-    if (lastDrawnPoint) {
-      const dx = point.x - lastDrawnPoint.x;
-      const dy = point.y - lastDrawnPoint.y;
-
-      const isSameTime = lastPointTime.value === time;
-      const isSamePoint = dx === 0 && dy === 0;
-
-      if (isSamePoint || isSameTime) {
-        return;
-      }
-    }
-
-    lastPointTime.value = time;
-
-    fullPath.modify(value => {
-      'worklet';
-      progressLine(points, value, point, straightLine);
-
-      return value;
-    });
-
-    runOnJS(onStrokeChanged)(point.x, point.y, time);
-  };
-
-  const createDot = (point: Point, time: number) => {
-    'worklet';
-    runOnJS(onStrokeChanged)(point.x, point.y, time);
-
-    fullPath.modify(value => {
-      'worklet';
-      progressLine(points, value, point);
-
-      return value;
-    });
-  };
-
-  const onTouchEnd = (point: Point, time: number) => {
-    'worklet';
-    if (getCurrentShape(points) === Shape.Dot) {
-      const firstPoint = points.value[points.value.length - 1];
-
-      createDot(
-        {
-          x: firstPoint.x + 1.5,
-          y: firstPoint.y + 1.5,
-        },
-        Date.now(),
-      );
-    }
-
-    runOnJS(onStrokeEnd)(point.x, point.y, time);
-  };
-
-  const drawingGesture = useDrawingGesture(
-    { areaSize: width, enabled },
-    { onTouchStart, onTouchProgress, onTouchEnd },
-  );
-
   return (
-    <GestureDetector gesture={drawingGesture}>
-      <View
-        style={styles.canvas}
-        onLayout={e => (width.value = e.nativeEvent.layout.width)}
-      >
-        <Canvas style={StyleSheet.absoluteFill}>
-          <Path
-            path={fullPath}
-            strokeWidth={1.5}
-            color="black"
-            style="stroke"
-          />
-        </Canvas>
-      </View>
-    </GestureDetector>
+    <View
+      style={styles.canvas}
+      onLayout={e => (width.value = e.nativeEvent.layout.width)}
+    >
+      {/*
+        Always mounted: keeping the Skia Canvas alive avoids the GLSurface
+        re-initialisation that flashes (flickers) on Android when it is
+        unmounted/remounted (regression introduced by the Skia 2.4.x upgrade).
+      */}
+      <Canvas style={StyleSheet.absoluteFill}>
+        <Path path={fullPath} strokeWidth={1.5} color="black" style="stroke" />
+      </Canvas>
+
+      {/*
+        Conditionally mounted: unmounting the gesture layer on every hide/show
+        cycle gives the next stroke a fully reset RNGH handler + gesture state,
+        which is what prevents free-drawing, multitouch and stale start points.
+      */}
+      {enabled && (
+        <DrawingLayer
+          fullPath={fullPath}
+          width={width}
+          onStrokeStart={onStrokeStart}
+          onStrokeChanged={onStrokeChanged}
+          onStrokeEnd={onStrokeEnd}
+        />
+      )}
+    </View>
   );
 });
 

--- a/src/shared/ui/SketchCanvas/useDrawingGesture.ts
+++ b/src/shared/ui/SketchCanvas/useDrawingGesture.ts
@@ -12,7 +12,6 @@ import { Point } from './LineSketcher';
 
 type Options = {
   areaSize: SharedValue<number>;
-  enabled?: boolean;
 };
 
 type Callbacks = {
@@ -31,7 +30,7 @@ const findTouchById = (event: GestureTouchEvent, id?: number) => {
 };
 
 export function useDrawingGesture(
-  { areaSize, enabled = true }: Options,
+  { areaSize }: Options,
   { onTouchStart, onTouchProgress, onTouchEnd }: Callbacks,
 ) {
   const registeredTouch = useSharedValue<TouchData | null>(null);
@@ -247,14 +246,10 @@ export function useDrawingGesture(
         onTouchEnd(event, Date.now());
       });
 
-  const iosGesture = () => iosManualGesture().enabled(enabled);
+  const iosGesture = () => iosManualGesture();
 
   const androidGesture = () =>
-    Gesture.Exclusive(
-      androidPanGesture().enabled(enabled),
-      tapGesture().enabled(enabled),
-      longTapGesture().enabled(enabled),
-    );
+    Gesture.Exclusive(androidPanGesture(), tapGesture(), longTapGesture());
 
   const gesture = IS_IOS ? iosGesture() : androidGesture();
 


### PR DESCRIPTION
- [ ] Tests for the changes have been added
- [ ] Related documentation has been added / updated
- [ ] OSS packages added to Curious [open source credit page](https://mindlogger.atlassian.net/jira/servicedesk/projects/MLA/knowledge/articles/340623543?spaceKey=MLA)

### 📝 Description

🔗 [Jira Ticket M2-10920](https://mindlogger.atlassian.net/browse/M2-10920)
🔗 [Jira Ticket M2-10921](https://mindlogger.atlassian.net/browse/M2-10921)
🔗 [Jira Ticket M2-10922](https://mindlogger.atlassian.net/browse/M2-10922)

Fixes the Android flicker in AB Trails introduced by the Skia 2.0.2 → 2.4.x upgrade. The upgrade made Android's graphics surface slower to reinitialise, causing a white flash on every segment commit or error. The previous fix resolved the flash but broke gesture reset behaviour, causing free-drawing, multitouch and a stale start point error on iOS.

Changes include:

- Split `SketchCanvas` into a persistent canvas layer and a conditionally mounted gesture layer (`DrawingLayer`)
- Skia `Canvas` stays always mounted - no graphics surface teardown, no flash
- `GestureDetector` and all gesture state still unmount/remount on every hide/show cycle - preserving the original reset behaviour
- Removed `enabled` prop from `useDrawingGesture` - gating is handled by mount/unmount, not flag toggling

### 🪤 Peer Testing


- **Start an AB Trails activity and complete a segment**

    **Expected outcome:** No white flash/blink between segments on Android

- **Draw a line between points without touching them**

    **Expected outcome:** Free drawing is not possible

- **Draw with multiple fingers simultaneously**

    **Expected outcome:** Multitouch is ignored, only one finger tracked

- **Tap an incorrect node, wait for the error to dismiss, then tap the correct node (iOS)**

    **Expected outcome:** Correct node is accepted, no false "Incorrect Start Point" error

### ✏️ Notes

Supersedes the fix on `fix/abtrails-android-flicker`.
