### PR TITLE
fix: isiXhosa 'must be' translations, MFA duplicated period (M2-11028)

### DIFF
--- a/assets/translations/xh.json
+++ b/assets/translations/xh.json
@@ -177,7 +177,7 @@
     "subtitle": "Nceda ngenisa ikhowudi yokubuyisela i-akhawunti.",
     "continue": "Qhubeka",
     "back": "Emva",
-    "invalid_code_format": "Ikhowudi yokubuyisela must be ibekwifomathi XXXXX-XXXXX",
+    "invalid_code_format": "Ikhowudi yokubuyisela mayibe kwifomathi XXXXX-XXXXX",
     "placeholder": "XXXXX-XXXXX",
     "error": "Ikhowudi yokubuyisela engasebenziyo. Nceda zama kwakhona.",
     "success": "Isazisi siqinisekiswe ngempumelelo",
@@ -194,7 +194,7 @@
     "subtitle": "Nceda ngenisa ikhowudi yokuqinisekisa eboniswe kwi-app yakho yesiqinisekiso.",
     "verify": "Qhubeka",
     "placeholder": "Faka ikhowudi yokugqina",
-    "invalid_code_format": "Ikhowudi yokuqinisekisa must be inamanani ama-6",
+    "invalid_code_format": "Ikhowudi yokuqinisekisa mayibe ngamanani ama-6",
     "error": "Ikhowudi engasebenziyo",
     "success": "Uqinisekiso luphumelele",
     "use_recovery_code": "Andikwazi ukufikelela kwi-app yam yesiqinisekisi",
@@ -245,7 +245,7 @@
     "forgot_password": "Ingaba uyilibele iphasiwedi?",
     "what_is": "Yintoni i",
     "login_error": "Ukungena akuphumelelanga.",
-    "password_at_least_characters": "Igama lokugqithisa must be libe nonobumba abali-10"
+    "password_at_least_characters": "Igama lokugqithisa malibe nonobumba abali-10"
   },
   "login_form": {
     "login": "Ngena",
@@ -294,7 +294,7 @@
     "sign_up": "Bhalisa",
     "error": "Ukubhalisa akuphumelelanga: igama lomsebenzisi lisenokuba sele lisetyenziswa.",
     "new_user": "Umsebenzisi omtsha",
-    "username_validation_error": "Igama lomsebenzisi must be libe nonobumba aba-4 ubuncinane, liqale ngonobumba, kwaye lingaqulatha kuphela oonobumba, amanani, iidash, kunye namachaphaza.",
+    "username_validation_error": "Igama lomsebenzisi malibe nonobumba aba-4 ubuncinane, liqale ngonobumba, kwaye lingaqulatha kuphela oonobumba, amanani, iidash, kunye namachaphaza.",
     "email_validation_error": "Kubonakala ngathi le imeyile ayigqitywanga",
     "email_placeholder": "I-imeyile",
     "first_name": "Igama lakho",
@@ -382,9 +382,9 @@
   },
   "form_item": {
     "required": "Kufuneka",
-    "must_be": "Must be",
+    "must_be": "Malibe",
     "characters_or_less": "abalinganiswa okanye ngaphantsi",
-    "must_be_a_number": "Must be inani"
+    "must_be_a_number": "Mayibe linani"
   },
   "applet_about": {
     "loading": "iyalayisha",

--- a/src/features/mfa-verification/lib/useMfaErrorSync.ts
+++ b/src/features/mfa-verification/lib/useMfaErrorSync.ts
@@ -28,10 +28,17 @@ export const useMfaErrorSync = ({
   // Sync external API error to form field error, combining with attempts warning
   useEffect(() => {
     if (error) {
-      // Combine error with attempts warning if present
-      const combinedMessage = attemptsWarning
-        ? `${error} ${attemptsWarning}`
-        : error;
+      // Combine error with attempts warning if present. The warning starts with
+      // its own ". " separator, so drop the error's trailing period to avoid a
+      // doubled period.
+      let combinedMessage = error;
+      if (attemptsWarning) {
+        const trimmedError = error.trimEnd();
+        const errorBase = trimmedError.endsWith('.')
+          ? trimmedError.slice(0, -1)
+          : trimmedError;
+        combinedMessage = `${errorBase}${attemptsWarning}`;
+      }
 
       form.setError(fieldName, {
         type: 'manual',


### PR DESCRIPTION
- [ ] Tests for the changes have been added
- [ ] Related documentation has been added / updated
- [ ] OSS packages added to Curious [open source credit page](https://mindlogger.atlassian.net/jira/servicedesk/projects/MLA/knowledge/articles/340623543?spaceKey=MLA)

### 📝 Description

🔗 [Jira Ticket M2-11028](https://mindlogger.atlassian.net/browse/M2-11028)

Changes include:

- Fixed 6 isiXhosa strings that still contained untranslated English "must be" (MFA verification/recovery code format, login password length, sign-up username validation, form_item labels)
- Fixed MFA error message showing a doubled/misplaced period when combined with the "attempts remaining" warning (recovery and verification screens, all languages)

### 🪤 Peer Testing

- **Set app language to isiXhosa**, trigger any of the fixed validation messages (e.g. invalid MFA code format, short password, invalid username on sign-up).

    **Expected outcome:** No "must be" appears in the message; text is fully isiXhosa.

- **Trigger an MFA verification/recovery failure with ≤3 attempts remaining** (any language).

    **Expected outcome:** Error message shows a single, correctly-placed period before the "attempts remaining" text - no doubled or stray period.

