### PR TITLE
Random MMKV Encrypt Key

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,6 +1,8 @@
 ENV=dev
 API_URL=http://localhost:8000
 MIXPANEL_TOKEN=
+# Legacy MMKV encryption key, only used to migrate old installs to the random
+# per-device key (and as a fallback when the hardware keystore is unavailable)
 STORE_ENCRYPTION_KEY=my-encryption-key
 LAUNCHDARKLY_MOBILE_KEY=my-env-mobile-key
 ONEUP_HEALTH_CLIENT_ID=

--- a/README.md
+++ b/README.md
@@ -166,7 +166,7 @@ The above scripts run the app using Debug configuration and for Curious's `dev`
 | `API_URL`                            | yes      | `http://localhost:8000`                                     | Curious Backend API base URL                                             |
 | `DEEP_LINK_PREFIXES`                 | yes      | `https://web-dev.cmiml.net`                                 | Deep link prefixes for the app, comma-delimited if multiple              |
 | `MIXPANEL_TOKEN`                     | no       | null                                                        | Mixpanel analytics token                                                 |
-| `STORE_ENCRYPTION_KEY`               | yes      | `my-encryption-key`                                         | Secure storage encryption key                                            |
+| `STORE_ENCRYPTION_KEY`               | yes      | `my-encryption-key`                                         | Legacy storage encryption key (migration/fallback only)                  |
 | `LAUNCHDARKLY_MOBILE_KEY`            | yes      | `my-env-mobile-key`                                         | LaunchDarkly mobile key, refer to Confluence for correct environment key |
 | `ONEUP_HEALTH_CLIENT_ID`             | yes\*    | null                                                        | 1UpHealth client ID                                                      |
 | `ONEUP_HEALTH_SYSTEM_SEARCH_API_URL` | yes\*    | `https://system-search.1up.health/api`                      | 1UpHealth System Search API URL                                          |

--- a/jest.setup.js
+++ b/jest.setup.js
@@ -1,6 +1,12 @@
 import { jest } from '@jest/globals';
 
-import { StorageInstanceManager } from '@app/shared/lib/storages/StorageInstanceManager';
+jest.mock('@app/shared/lib/storages/mmkvEncryptionKeyManager', () => ({
+  initializeStorageEncryption: jest.fn(() => Promise.resolve()),
+  getStorageEncryptionConfigSync: jest.fn(() => ({
+    encryptionKey: '0123456789abcdef0123456789abcdef',
+    encryptionType: 'AES-256',
+  })),
+}));
 
 jest.mock('@tamagui/animations-moti', () => ({
   createAnimations: jest.fn(() => undefined),
@@ -12,10 +18,4 @@ jest.mock('moti', () => {
   return {
     MotiView: props => <View {...props} />,
   };
-});
-
-global.beforeEach(() => {
-  jest
-    .spyOn(StorageInstanceManager.prototype, 'getStoreEncryptionKey')
-    .mockReturnValue('12345');
 });

--- a/jest.vendor-mocks.js
+++ b/jest.vendor-mocks.js
@@ -288,6 +288,8 @@ jest.mock('react-native-mmkv', () => {
   } = require('react-native-mmkv/lib/createMMKV/createMockMMKV');
   return {
     createMMKV: createMockMMKV,
+    existsMMKV: jest.fn(() => false),
+    deleteMMKV: jest.fn(() => true),
     useMMKVObject: jest.fn(() => [undefined, jest.fn()]),
     useMMKVString: jest.fn(() => [undefined, jest.fn()]),
     useMMKVNumber: jest.fn(() => [undefined, jest.fn()]),
@@ -296,3 +298,17 @@ jest.mock('react-native-mmkv', () => {
     useMMKV: jest.fn(),
   };
 });
+
+jest.mock('react-native-keychain', () => ({
+  getGenericPassword: jest.fn(() => Promise.resolve(false)),
+  setGenericPassword: jest.fn(() =>
+    Promise.resolve({ service: 'mock', storage: 'mock' }),
+  ),
+  resetGenericPassword: jest.fn(() => Promise.resolve(true)),
+  ACCESSIBLE: {
+    WHEN_UNLOCKED_THIS_DEVICE_ONLY: 'AccessibleWhenUnlockedThisDeviceOnly',
+  },
+  STORAGE_TYPE: {
+    AES_GCM_NO_AUTH: 'KeystoreAESGCM_NoAuth',
+  },
+}));

--- a/package.json
+++ b/package.json
@@ -138,6 +138,7 @@
     "react-native-get-random-values": "^1.10.0",
     "react-native-image-picker": "^7.1.0",
     "react-native-keyboard-aware-scroll-view": "^0.9.5",
+    "react-native-keychain": "^10.0.0",
     "react-native-linear-gradient": "^2.8.3",
     "react-native-localize": "~3.5.4",
     "react-native-markdown-display": "^7.0.2",

--- a/src/app/model/migrations/utils.ts
+++ b/src/app/model/migrations/utils.ts
@@ -1,11 +1,10 @@
 import { MMKV } from 'react-native-mmkv';
 
-import { STORE_ENCRYPTION_KEY } from '@app/shared/lib/constants';
-import { throwError } from '@app/shared/lib/services/errorService';
 import {
   createSecureStorage,
   createStorage,
 } from '@app/shared/lib/storages/createStorage';
+import { getStorageEncryptionConfigSync } from '@app/shared/lib/storages/mmkvEncryptionKeyManager';
 
 import { MigrationPrefix, SecureStoragesArray, Storages } from './types';
 
@@ -38,24 +37,20 @@ export const getMigrationStorageName = (storage: Storages): string => {
   return `${MigrationPrefix}--${storage}`;
 };
 
-const getStoreEncryptionKey = () => {
-  if (!STORE_ENCRYPTION_KEY) {
-    throwError(
-      '[createSecureStorage]: STORE_ENCRYPTION_KEY has not been provided',
-    );
-  }
-  return STORE_ENCRYPTION_KEY as string;
+const createSecureStorageWithDeviceKey = (storageName: string): MMKV => {
+  const { encryptionKey, encryptionType } = getStorageEncryptionConfigSync();
+  return createSecureStorage(storageName, encryptionKey, encryptionType);
 };
 
 export const createMigrationStorage = (storageName: Storages): MMKV => {
   const migrationStorageName = getMigrationStorageName(storageName);
   return SecureStoragesArray.includes(storageName)
-    ? createSecureStorage(migrationStorageName, getStoreEncryptionKey())
+    ? createSecureStorageWithDeviceKey(migrationStorageName)
     : createStorage(migrationStorageName);
 };
 
 export const createRegularStorage = (storageName: Storages): MMKV => {
   return SecureStoragesArray.includes(storageName)
-    ? createSecureStorage(storageName, getStoreEncryptionKey())
+    ? createSecureStorageWithDeviceKey(storageName)
     : createStorage(storageName);
 };

--- a/src/app/ui/AppProvider/StorageEncryptionProvider.tsx
+++ b/src/app/ui/AppProvider/StorageEncryptionProvider.tsx
@@ -1,0 +1,49 @@
+import { PropsWithChildren, useEffect, useState } from 'react';
+import { StyleSheet, View } from 'react-native';
+
+import { palette } from '@app/shared/lib/constants/palette';
+import { initializeStorageEncryption } from '@app/shared/lib/storages/mmkvEncryptionKeyManager';
+import { Spinner } from '@app/shared/ui/Spinner';
+
+/**
+ * Blocks the rest of the provider tree until the per-device MMKV encryption
+ * key has been resolved from the keychain (and legacy stores migrated, on
+ * the first launch after an update). Everything that touches secured MMKV
+ * stores mounts below this gate.
+ *
+ * Renders a plain-RN placeholder (not SplashScreen) because Tamagui and
+ * localization providers are not available above this point in the tree.
+ */
+export function StorageEncryptionProvider({ children }: PropsWithChildren) {
+  const [isReady, setIsReady] = useState(false);
+
+  useEffect(() => {
+    initializeStorageEncryption()
+      .then(() => setIsReady(true))
+      // Only reachable when the keychain is unavailable AND no legacy
+      // fallback key exists; the key manager has already logged details to
+      // Datadog. The user stays on the spinner. TODO: revisit when
+      // LEGACY_STORE_ENCRYPTION_KEY is removed, as this branch then becomes
+      // reachable on devices with a broken keystore.
+      .catch(console.error);
+  }, []);
+
+  if (!isReady) {
+    return (
+      <View style={styles.container}>
+        <Spinner />
+      </View>
+    );
+  }
+
+  return <>{children}</>;
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    backgroundColor: palette.surface,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+});

--- a/src/app/ui/AppProvider/index.tsx
+++ b/src/app/ui/AppProvider/index.tsx
@@ -22,6 +22,7 @@ import { NavigationProvider } from './NavigationProvider';
 import { ReactQueryProvider } from './ReactQueryProvider';
 import { ReduxProvider, reduxStore } from './ReduxProvider';
 import { SplashProvider } from './SplashProvider';
+import { StorageEncryptionProvider } from './StorageEncryptionProvider';
 import { StorageMigrationProvider } from './StorageMigrationProvider';
 import { SystemBootUpProvider } from './SystemBootUpProvider';
 import { TamaguiProvider } from './TamaguiProvider';
@@ -55,35 +56,37 @@ export const AppProvider: FC<PropsWithChildren> = ({ children }) => {
 
   return (
     <GestureHandlerRootView style={styles.gestureHandlerView}>
-      <SystemBootUpProvider onLoadingFinished={onLoadingFinished}>
-        <FeatureFlagsProvider>
-          <AnalyticsProvider>
-            <ReactQueryProvider>
-              <ReduxProvider>
-                <StorageMigrationProvider>
-                  <LocalizationProvider>
-                    <TamaguiProvider>
-                      <FontLanguageProvider>
-                        <NavigationProvider>
-                          <PortalProvider>
-                            <SafeAreaProvider>
-                              <SplashProvider isLoading={isBootingUp}>
-                                {children}
-                              </SplashProvider>
+      <StorageEncryptionProvider>
+        <SystemBootUpProvider onLoadingFinished={onLoadingFinished}>
+          <FeatureFlagsProvider>
+            <AnalyticsProvider>
+              <ReactQueryProvider>
+                <ReduxProvider>
+                  <StorageMigrationProvider>
+                    <LocalizationProvider>
+                      <TamaguiProvider>
+                        <FontLanguageProvider>
+                          <NavigationProvider>
+                            <PortalProvider>
+                              <SafeAreaProvider>
+                                <SplashProvider isLoading={isBootingUp}>
+                                  {children}
+                                </SplashProvider>
 
-                              <Toast config={ToastConfig} topOffset={0} />
-                            </SafeAreaProvider>
-                          </PortalProvider>
-                        </NavigationProvider>
-                      </FontLanguageProvider>
-                    </TamaguiProvider>
-                  </LocalizationProvider>
-                </StorageMigrationProvider>
-              </ReduxProvider>
-            </ReactQueryProvider>
-          </AnalyticsProvider>
-        </FeatureFlagsProvider>
-      </SystemBootUpProvider>
+                                <Toast config={ToastConfig} topOffset={0} />
+                              </SafeAreaProvider>
+                            </PortalProvider>
+                          </NavigationProvider>
+                        </FontLanguageProvider>
+                      </TamaguiProvider>
+                    </LocalizationProvider>
+                  </StorageMigrationProvider>
+                </ReduxProvider>
+              </ReactQueryProvider>
+            </AnalyticsProvider>
+          </FeatureFlagsProvider>
+        </SystemBootUpProvider>
+      </StorageEncryptionProvider>
     </GestureHandlerRootView>
   );
 };

--- a/src/shared/lib/constants/index.ts
+++ b/src/shared/lib/constants/index.ts
@@ -30,7 +30,28 @@ export const ONEUP_HEALTH_SYSTEM_SEARCH_API_URL =
   Config.ONEUP_HEALTH_SYSTEM_SEARCH_API_URL as string;
 export const MIXPANEL_TOKEN = Config.MIXPANEL_TOKEN;
 
-export const STORE_ENCRYPTION_KEY = Config.STORE_ENCRYPTION_KEY;
+/**
+ * Legacy build-time MMKV encryption key. Kept only to migrate (recrypt)
+ * stores created by older app versions to the random per-device key, and as
+ * a last-resort fallback when the hardware keystore is unavailable.
+ * TODO: Remove this env var and its usages once the install base has migrated to per-device keys.
+ */
+export const LEGACY_STORE_ENCRYPTION_KEY = Config.STORE_ENCRYPTION_KEY;
+
+// Keychain entry holding the random per-device MMKV encryption key
+export const STORAGE_ENCRYPTION_KEYCHAIN_SERVICE =
+  'org.mindlogger.mmkv-encryption-key';
+export const STORAGE_ENCRYPTION_KEYCHAIN_USERNAME = 'mmkv';
+
+/**
+ * Cipher for stores encrypted with the per-device key. AES-256 makes MMKV
+ * consume all 32 bytes of the hex-encoded key; the AES-128 default would
+ * only use the first 16 characters (64 bits of entropy).
+ */
+export const STORAGE_ENCRYPTION_TYPE = 'AES-256';
+
+// Id of the plain (unencrypted) MMKV store holding app-level flags
+export const SYSTEM_STORAGE_ID = 'system';
 
 export const LAUNCHDARKLY_MOBILE_KEY = Config.LAUNCHDARKLY_MOBILE_KEY as string;
 

--- a/src/shared/lib/services/BackgroundWorker.ts
+++ b/src/shared/lib/services/BackgroundWorker.ts
@@ -4,6 +4,8 @@ import {
   BackgroundTaskOptions,
   IBackgroundWorkerBuilder,
 } from './IBackgroundWorkerBuilder';
+import { getDefaultLogger } from './loggerInstance';
+import { initializeStorageEncryption } from '../storages/mmkvEncryptionKeyManager';
 
 const MINIMUM_ALLOWED_BG_TASK_INTERVAL_MINUTES = 15;
 
@@ -27,9 +29,22 @@ export function BackgroundWorkerBuilder(): IBackgroundWorkerBuilder {
         enableHeadless: true,
       },
       async taskId => {
-        await Promise.resolve(callback());
+        try {
+          // Tasks may run before the app UI has booted (e.g. the app was
+          // launched in the background), so the MMKV encryption key must be
+          // resolved first. This can fail while the device is still locked
+          // (the key is only readable after the first unlock) - in that
+          // case, skip this run and let the next scheduled background fetch retry.
+          await initializeStorageEncryption();
 
-        BackgroundFetch.finish(taskId);
+          await Promise.resolve(callback());
+        } catch (error) {
+          getDefaultLogger().warn(
+            `[BackgroundWorkerBuilder.setTask]: Error: ${String(error)}`,
+          );
+        } finally {
+          BackgroundFetch.finish(taskId);
+        }
       },
       onTimeout,
     ).catch(console.error);
@@ -44,9 +59,18 @@ export function BackgroundWorkerBuilder(): IBackgroundWorkerBuilder {
         return;
       }
 
-      await Promise.resolve(callback());
+      try {
+        // See the comment in setTask above.
+        await initializeStorageEncryption();
 
-      BackgroundFetch.finish(taskId);
+        await Promise.resolve(callback());
+      } catch (error) {
+        getDefaultLogger().warn(
+          `[BackgroundWorkerBuilder.setAndroidHeadlessTask]: Error: ${String(error)}`,
+        );
+      } finally {
+        BackgroundFetch.finish(taskId);
+      }
     }
 
     BackgroundFetch.registerHeadlessTask(headlessTask);

--- a/src/shared/lib/storages/StorageInstanceManager.ts
+++ b/src/shared/lib/storages/StorageInstanceManager.ts
@@ -1,9 +1,9 @@
 import { MMKV } from 'react-native-mmkv';
 
+import { SYSTEM_STORAGE_ID } from '../constants';
 import { createStorage, createSecureStorage } from './createStorage';
 import { IStorageInstanceManager } from './IStorageInstanceManager';
-import { STORE_ENCRYPTION_KEY } from '../constants';
-import { throwError } from '../services/errorService';
+import { getStorageEncryptionConfigSync } from './mmkvEncryptionKeyManager';
 
 export class StorageInstanceManager implements IStorageInstanceManager {
   private instances: Record<string, MMKV | null | undefined>;
@@ -27,7 +27,7 @@ export class StorageInstanceManager implements IStorageInstanceManager {
     this.instances = {};
     this.securedInstances = {};
 
-    this.getSystemStorage = this.getter('system');
+    this.getSystemStorage = this.getter(SYSTEM_STORAGE_ID);
     this.getAnalyticsStorage = this.getter('analytics-storage');
     this.getLocalizationStorage = this.getter('localization');
     this.getNotificationQueueStorage = this.getter('notification-queue');
@@ -56,28 +56,24 @@ export class StorageInstanceManager implements IStorageInstanceManager {
   }
 
   private securedGetter(storageName: string) {
-    const storeEncryptionKey = this.getStoreEncryptionKey();
-
-    if (!storeEncryptionKey) {
-      throwError(
-        '[createSecureStorage]: STORE_ENCRYPTION_KEY has not been provided',
-      );
-    }
-
     const getter = (): MMKV => {
       if (!this.securedInstances[storageName]) {
+        // Resolved lazily at first storage access: the per-device key is
+        // fetched asynchronously from the keychain during app bootstrap
+        // (see initializeStorageEncryption), before any secured storage
+        // consumer runs.
+        const { encryptionKey, encryptionType } =
+          getStorageEncryptionConfigSync();
+
         this.securedInstances[storageName] = createSecureStorage(
           storageName,
-          storeEncryptionKey as string,
+          encryptionKey,
+          encryptionType,
         );
       }
       return this.securedInstances[storageName] as MMKV;
     };
 
     return getter.bind(this);
-  }
-
-  private getStoreEncryptionKey(): string | undefined {
-    return STORE_ENCRYPTION_KEY;
   }
 }

--- a/src/shared/lib/storages/__tests__/mmkvEncryptionKeyManager.test.ts
+++ b/src/shared/lib/storages/__tests__/mmkvEncryptionKeyManager.test.ts
@@ -1,0 +1,386 @@
+import type * as KeyManagerModule from '../mmkvEncryptionKeyManager';
+
+// jest.setup.js mocks the key manager globally for all other tests; this
+// suite tests the real implementation.
+jest.unmock('@app/shared/lib/storages/mmkvEncryptionKeyManager');
+
+let mockLegacyKey: string | undefined;
+
+jest.mock('@app/shared/lib/constants', () => ({
+  ...jest.requireActual<Record<string, unknown>>('@app/shared/lib/constants'),
+  get LEGACY_STORE_ENCRYPTION_KEY() {
+    return mockLegacyKey;
+  },
+}));
+
+const mockLoggerError = jest.fn();
+
+jest.mock('@app/shared/lib/services/loggerInstance', () => ({
+  getDefaultLogger: () => ({
+    log: jest.fn(),
+    warn: jest.fn(),
+    error: mockLoggerError,
+  }),
+}));
+
+type MockStore = {
+  id: string;
+  data: Map<string, unknown>;
+  getBoolean: (key: string) => boolean | undefined;
+  set: (key: string, value: unknown) => void;
+  encrypt: jest.Mock;
+};
+
+type MockCreateCall = {
+  id: string;
+  encryptionKey?: string;
+  encryptionType?: string;
+};
+
+// Registry keyed by id, replicating the native behavior where reopening the
+// same id returns the cached instance.
+const mockMMKVState = {
+  stores: new Map<string, MockStore>(),
+  createCalls: [] as MockCreateCall[],
+  existingIds: new Set<string>(),
+  deletedIds: [] as string[],
+  failingEncryptIds: new Set<string>(),
+};
+
+jest.mock('react-native-mmkv', () => ({
+  createMMKV: (config: MockCreateCall): MockStore => {
+    mockMMKVState.createCalls.push({ ...config });
+
+    let store = mockMMKVState.stores.get(config.id);
+    if (!store) {
+      const data = new Map<string, unknown>();
+      store = {
+        id: config.id,
+        data,
+        getBoolean: (key: string) => {
+          const value = data.get(key);
+          return typeof value === 'boolean' ? value : undefined;
+        },
+        set: (key: string, value: unknown) => {
+          data.set(key, value);
+        },
+        encrypt: jest.fn(() => {
+          if (mockMMKVState.failingEncryptIds.has(config.id)) {
+            throw new Error(`Failed to recrypt ${config.id}`);
+          }
+        }),
+      };
+      mockMMKVState.stores.set(config.id, store);
+    }
+    return store;
+  },
+  existsMMKV: (id: string) => mockMMKVState.existingIds.has(id),
+  deleteMMKV: (id: string) => {
+    mockMMKVState.deletedIds.push(id);
+    mockMMKVState.stores.delete(id);
+    return true;
+  },
+}));
+
+type Constants = typeof import('@app/shared/lib/constants');
+
+type MockedKeychain = {
+  getGenericPassword: jest.Mock<
+    Promise<false | { password: string }>,
+    [unknown?]
+  >;
+  setGenericPassword: jest.Mock<
+    Promise<unknown>,
+    [string, string, Record<string, unknown>]
+  >;
+};
+
+// The key manager caches the resolved key in module scope, so every test
+// loads a fresh copy of the module (and of the mocked keychain it talks to).
+function setup() {
+  jest.resetModules();
+
+  const keychain = require('react-native-keychain') as MockedKeychain;
+  const mmkv = require('react-native-mmkv') as {
+    createMMKV: (config: MockCreateCall) => MockStore;
+  };
+  const constants = require('@app/shared/lib/constants') as Constants;
+  const manager =
+    require('../mmkvEncryptionKeyManager') as typeof KeyManagerModule;
+
+  return { keychain, mmkv, constants, manager };
+}
+
+function getSystemStore(): MockStore | undefined {
+  return mockMMKVState.stores.get('system');
+}
+
+function markerFor(manager: typeof KeyManagerModule, id: string): string {
+  return `${manager.STORAGE_ENCRYPTION_MIGRATION_MARKER_PREFIX}${id}`;
+}
+
+describe('mmkvEncryptionKeyManager', () => {
+  beforeEach(() => {
+    mockLegacyKey = undefined;
+    mockMMKVState.stores.clear();
+    mockMMKVState.createCalls.length = 0;
+    mockMMKVState.existingIds.clear();
+    mockMMKVState.deletedIds.length = 0;
+    mockMMKVState.failingEncryptIds.clear();
+  });
+
+  it('generates a 32-char hex key and persists it to the keychain on fresh install', async () => {
+    const { keychain, constants, manager } = setup();
+
+    await manager.initializeStorageEncryption();
+
+    expect(keychain.setGenericPassword).toHaveBeenCalledTimes(1);
+    expect(keychain.setGenericPassword).toHaveBeenCalledWith(
+      constants.STORAGE_ENCRYPTION_KEYCHAIN_USERNAME,
+      expect.stringMatching(/^[0-9a-f]{32}$/),
+      {
+        service: constants.STORAGE_ENCRYPTION_KEYCHAIN_SERVICE,
+        accessible: 'AccessibleWhenUnlockedThisDeviceOnly',
+        storage: 'KeystoreAESGCM_NoAuth',
+      },
+    );
+
+    const persistedKey = keychain.setGenericPassword.mock.calls[0][1];
+    expect(manager.getStorageEncryptionConfigSync()).toEqual({
+      encryptionKey: persistedKey,
+      encryptionType: 'AES-256',
+    });
+
+    // Nothing on disk to migrate: no store is ever opened with a key...
+    expect(
+      mockMMKVState.createCalls.filter(call => call.encryptionKey),
+    ).toHaveLength(0);
+
+    // ...but every store is marked migrated so it is never recrypted later.
+    const systemStore = getSystemStore();
+    for (const id of manager.SECURED_STORAGE_IDS) {
+      expect(systemStore?.data.get(markerFor(manager, id))).toBe(true);
+    }
+    expect(
+      systemStore?.data.get(manager.STORAGE_ENCRYPTION_MIGRATION_DONE_FLAG),
+    ).toBe(true);
+  });
+
+  it('reuses the existing keychain key and skips migration when already done', async () => {
+    const { keychain, mmkv, manager } = setup();
+
+    keychain.getGenericPassword.mockResolvedValue({ password: 'device-key' });
+    mmkv
+      .createMMKV({ id: 'system' })
+      .set(manager.STORAGE_ENCRYPTION_MIGRATION_DONE_FLAG, true);
+
+    await manager.initializeStorageEncryption();
+
+    expect(manager.getStorageEncryptionConfigSync()).toEqual({
+      encryptionKey: 'device-key',
+      encryptionType: 'AES-256',
+    });
+    expect(keychain.setGenericPassword).not.toHaveBeenCalled();
+    expect(
+      mockMMKVState.createCalls.filter(call => call.encryptionKey),
+    ).toHaveLength(0);
+  });
+
+  it('recrypts every legacy store to the new key on upgrade', async () => {
+    const { keychain, manager } = setup();
+
+    mockLegacyKey = 'legacy-env-key';
+    for (const id of manager.SECURED_STORAGE_IDS) {
+      mockMMKVState.existingIds.add(id);
+    }
+
+    await manager.initializeStorageEncryption();
+
+    const newKey = keychain.setGenericPassword.mock.calls[0][1];
+
+    for (const id of manager.SECURED_STORAGE_IDS) {
+      // Opened with the legacy key and NO encryptionType (legacy stores were
+      // created with the AES-128 default).
+      const openCall = mockMMKVState.createCalls.find(call => call.id === id);
+      expect(openCall).toEqual({ id, encryptionKey: 'legacy-env-key' });
+
+      const store = mockMMKVState.stores.get(id);
+      expect(store?.encrypt).toHaveBeenCalledWith(newKey, 'AES-256');
+
+      expect(getSystemStore()?.data.get(markerFor(manager, id))).toBe(true);
+    }
+    expect(
+      getSystemStore()?.data.get(
+        manager.STORAGE_ENCRYPTION_MIGRATION_DONE_FLAG,
+      ),
+    ).toBe(true);
+  });
+
+  it('wipes only the store that fails to recrypt and continues with the rest', async () => {
+    const { manager } = setup();
+
+    mockLegacyKey = 'legacy-env-key';
+    for (const id of manager.SECURED_STORAGE_IDS) {
+      mockMMKVState.existingIds.add(id);
+    }
+    mockMMKVState.failingEncryptIds.add('session-storage');
+
+    await manager.initializeStorageEncryption();
+
+    expect(mockMMKVState.deletedIds).toEqual(['session-storage']);
+    expect(mockLoggerError).toHaveBeenCalledWith(
+      expect.stringContaining('session-storage'),
+    );
+
+    // Other stores were still recrypted, and the failed store is marked so
+    // its (now wiped) replacement is never touched by migration again.
+    for (const id of manager.SECURED_STORAGE_IDS) {
+      if (id !== 'session-storage') {
+        expect(mockMMKVState.stores.get(id)?.encrypt).toHaveBeenCalled();
+      }
+      expect(getSystemStore()?.data.get(markerFor(manager, id))).toBe(true);
+    }
+    expect(
+      getSystemStore()?.data.get(
+        manager.STORAGE_ENCRYPTION_MIGRATION_DONE_FLAG,
+      ),
+    ).toBe(true);
+  });
+
+  it('resumes an interrupted migration, skipping stores already migrated', async () => {
+    const { keychain, mmkv, manager } = setup();
+
+    // A previous launch persisted the key and migrated the first two stores,
+    // then crashed before setting the done flag.
+    keychain.getGenericPassword.mockResolvedValue({ password: 'device-key' });
+    mockLegacyKey = 'legacy-env-key';
+
+    const [migratedA, migratedB, ...remaining] = manager.SECURED_STORAGE_IDS;
+    const systemStore = mmkv.createMMKV({ id: 'system' });
+    systemStore.set(markerFor(manager, migratedA), true);
+    systemStore.set(markerFor(manager, migratedB), true);
+
+    for (const id of manager.SECURED_STORAGE_IDS) {
+      mockMMKVState.existingIds.add(id);
+    }
+
+    await manager.initializeStorageEncryption();
+
+    expect(keychain.setGenericPassword).not.toHaveBeenCalled();
+
+    // Already-migrated stores must NOT be reopened with the legacy key:
+    // MMKV would CRC-fail and silently wipe them.
+    for (const id of [migratedA, migratedB]) {
+      expect(
+        mockMMKVState.createCalls.find(call => call.id === id),
+      ).toBeUndefined();
+    }
+    for (const id of remaining) {
+      expect(mockMMKVState.stores.get(id)?.encrypt).toHaveBeenCalledWith(
+        'device-key',
+        'AES-256',
+      );
+    }
+    expect(
+      getSystemStore()?.data.get(
+        manager.STORAGE_ENCRYPTION_MIGRATION_DONE_FLAG,
+      ),
+    ).toBe(true);
+  });
+
+  it('shares a single initialization run between concurrent callers', async () => {
+    const { keychain, manager } = setup();
+
+    const first = manager.initializeStorageEncryption();
+    const second = manager.initializeStorageEncryption();
+
+    expect(second).toBe(first);
+    await first;
+
+    expect(keychain.getGenericPassword).toHaveBeenCalledTimes(1);
+    expect(keychain.setGenericPassword).toHaveBeenCalledTimes(1);
+  });
+
+  it('retries the keychain read once before giving up', async () => {
+    const { keychain, manager } = setup();
+
+    keychain.getGenericPassword
+      .mockRejectedValueOnce(new Error('transient keystore error'))
+      .mockResolvedValueOnce({ password: 'device-key' });
+
+    await manager.initializeStorageEncryption();
+
+    expect(keychain.getGenericPassword).toHaveBeenCalledTimes(2);
+    expect(keychain.setGenericPassword).not.toHaveBeenCalled();
+    expect(manager.getStorageEncryptionConfigSync().encryptionKey).toBe(
+      'device-key',
+    );
+  });
+
+  it('falls back to the legacy key without setting markers when the keychain is unavailable', async () => {
+    const { keychain, manager } = setup();
+
+    mockLegacyKey = 'legacy-env-key';
+    keychain.getGenericPassword.mockRejectedValue(new Error('keystore broken'));
+
+    await expect(
+      manager.initializeStorageEncryption(),
+    ).resolves.toBeUndefined();
+
+    // Legacy fallback: no encryptionType, replicating the exact legacy
+    // MMKV configuration.
+    const config = manager.getStorageEncryptionConfigSync();
+    expect(config.encryptionKey).toBe('legacy-env-key');
+    expect(config.encryptionType).toBeUndefined();
+
+    expect(mockLoggerError).toHaveBeenCalledWith(
+      expect.stringContaining('Keychain unavailable'),
+    );
+
+    // Markers untouched so the next launch retries the keychain + migration.
+    expect(
+      getSystemStore()?.data.get(
+        manager.STORAGE_ENCRYPTION_MIGRATION_DONE_FLAG,
+      ),
+    ).toBeUndefined();
+    expect(keychain.setGenericPassword).not.toHaveBeenCalled();
+  });
+
+  it('rejects when the keychain is unavailable and no legacy key exists, then allows a retry', async () => {
+    const { keychain, manager } = setup();
+
+    keychain.getGenericPassword.mockRejectedValue(new Error('keystore broken'));
+
+    await expect(manager.initializeStorageEncryption()).rejects.toThrow(
+      'keystore broken',
+    );
+
+    // The failed promise is discarded, so a later call retries and succeeds
+    // once the keychain recovers.
+    keychain.getGenericPassword.mockResolvedValue(false);
+
+    await manager.initializeStorageEncryption();
+
+    expect(manager.getStorageEncryptionConfigSync()).toEqual({
+      encryptionKey: expect.stringMatching(/^[0-9a-f]{32}$/) as unknown,
+      encryptionType: 'AES-256',
+    });
+  });
+
+  it('reports an error when the config is read before initialization', () => {
+    const { manager } = setup();
+
+    // throwError logs in __DEV__ (which is true under jest) instead of
+    // throwing.
+    const consoleErrorSpy = jest
+      .spyOn(console, 'error')
+      .mockImplementation(() => {});
+
+    const config = manager.getStorageEncryptionConfigSync();
+
+    expect(consoleErrorSpy).toHaveBeenCalledWith(
+      expect.stringContaining('has not been initialized'),
+    );
+    expect(config).toBeUndefined();
+  });
+});

--- a/src/shared/lib/storages/createStorage.ts
+++ b/src/shared/lib/storages/createStorage.ts
@@ -1,11 +1,42 @@
-import { createMMKV } from 'react-native-mmkv';
+import { createMMKV, deleteMMKV } from 'react-native-mmkv';
 
+import { STORAGE_ENCRYPTION_TYPE } from '../constants';
 import { AsyncStorage } from './AsyncStorage';
 import { registerMMKVStorage } from './ReactotronMMKVTracker';
 import { SyncStorage } from './SyncStorage';
 
-export function createSecureStorage(id: string, encryptionKey: string) {
-  const storage = createMMKV({ id, encryptionKey });
+// Resolved lazily to avoid a require cycle: loggerInstance -> fileService ->
+// systemRecordInstance -> storageInstanceManagerInstance -> this module.
+const getLogger = () =>
+  (
+    require('../services/loggerInstance') as typeof import('../services/loggerInstance')
+  ).getDefaultLogger();
+
+function createEncryptedMMKV(
+  id: string,
+  encryptionKey: string,
+  encryptionType?: typeof STORAGE_ENCRYPTION_TYPE,
+) {
+  try {
+    return createMMKV({ id, encryptionKey, encryptionType });
+  } catch (error) {
+    // The store cannot be opened with the current key (e.g. files restored
+    // from a backup made on another device). Data is unrecoverable without
+    // the original key, so recreate the store empty instead of crashing.
+    getLogger().error(
+      `[createSecureStorage] Failed to open encrypted storage "${id}", recreating it: ${String(error)}`,
+    );
+    deleteMMKV(id);
+    return createMMKV({ id, encryptionKey, encryptionType });
+  }
+}
+
+export function createSecureStorage(
+  id: string,
+  encryptionKey: string,
+  encryptionType?: typeof STORAGE_ENCRYPTION_TYPE,
+) {
+  const storage = createEncryptedMMKV(id, encryptionKey, encryptionType);
   registerMMKVStorage(id, storage);
   return storage;
 }
@@ -28,8 +59,12 @@ export function createAsyncStorage(id: string) {
   return new AsyncStorage(mmkv);
 }
 
-export function createSecureAsyncStorage(id: string, encryptionKey: string) {
-  const mmkv = createMMKV({ id, encryptionKey });
+export function createSecureAsyncStorage(
+  id: string,
+  encryptionKey: string,
+  encryptionType?: typeof STORAGE_ENCRYPTION_TYPE,
+) {
+  const mmkv = createEncryptedMMKV(id, encryptionKey, encryptionType);
   registerMMKVStorage(id, mmkv);
   return new AsyncStorage(mmkv);
 }

--- a/src/shared/lib/storages/mmkvEncryptionKeyManager.ts
+++ b/src/shared/lib/storages/mmkvEncryptionKeyManager.ts
@@ -1,0 +1,240 @@
+import * as Keychain from 'react-native-keychain';
+import { createMMKV, deleteMMKV, existsMMKV } from 'react-native-mmkv';
+
+import {
+  LEGACY_STORE_ENCRYPTION_KEY,
+  STORAGE_ENCRYPTION_KEYCHAIN_SERVICE,
+  STORAGE_ENCRYPTION_KEYCHAIN_USERNAME,
+  STORAGE_ENCRYPTION_TYPE,
+  SYSTEM_STORAGE_ID,
+} from '../constants';
+import { throwError } from '../services/errorService';
+
+// --- Migration-only constants -----------------------------------------------
+// Everything in this block exists solely for the legacy-key recrypt migration
+// and can be deleted together with recryptSecuredStorages() once
+// LEGACY_STORE_ENCRYPTION_KEY is removed.
+
+// Flags in the plain 'system' MMKV store tracking the recrypt migration
+export const STORAGE_ENCRYPTION_MIGRATION_DONE_FLAG =
+  'encryptionKeyMigrationDone';
+export const STORAGE_ENCRYPTION_MIGRATION_MARKER_PREFIX =
+  'encryptionKeyMigrated:';
+
+/**
+ * Every encrypted MMKV store that may exist on disk under the legacy
+ * build-time key and must be recrypted with the per-device key.
+ */
+export const SECURED_STORAGE_IDS = [
+  'navigation-storage',
+  'session-storage',
+  'upload_queue-storage',
+  'activity_progress-storage',
+  'user-info',
+  'user-private-key',
+  'mfa-token-storage',
+  // Encrypted store created by the redux migration utilities, see
+  // getMigrationStorageName in src/app/model/migrations/utils.ts
+  // (MigrationPrefix + '--' + Storages.ActivityProgress).
+  'migration----activity_progress-storage',
+];
+// ----------------------------------------------------------------------------
+
+// Resolved lazily to avoid a require cycle: loggerInstance -> fileService ->
+// systemRecordInstance -> storageInstanceManagerInstance ->
+// StorageInstanceManager -> this module.
+const getLogger = () =>
+  (
+    require('../services/loggerInstance') as typeof import('../services/loggerInstance')
+  ).getDefaultLogger();
+
+// Polyfilled by react-native-get-random-values (imported in index.js).
+declare const crypto: {
+  getRandomValues: <T extends Uint8Array>(array: T) => T;
+};
+
+export type StorageEncryptionConfig = {
+  encryptionKey: string;
+  /**
+   * STORAGE_ENCRYPTION_TYPE for the per-device random key. Left undefined
+   * in legacy fallback mode to replicate the exact MMKV configuration that
+   * legacy stores were created with (AES-128 default).
+   */
+  encryptionType?: typeof STORAGE_ENCRYPTION_TYPE;
+};
+
+let cachedConfig: StorageEncryptionConfig | undefined;
+let initPromise: Promise<void> | undefined;
+
+function generateEncryptionKey(): string {
+  const bytes = crypto.getRandomValues(new Uint8Array(16));
+  // 32-char hex string = 32-byte MMKV key, used with AES-256.
+  return Array.from(bytes, byte => byte.toString(16).padStart(2, '0')).join('');
+}
+
+async function readKeyFromKeychain(): Promise<string | null> {
+  const read = async () => {
+    const result = await Keychain.getGenericPassword({
+      service: STORAGE_ENCRYPTION_KEYCHAIN_SERVICE,
+    });
+    return result === false ? null : result.password;
+  };
+
+  try {
+    return await read();
+  } catch {
+    // Single retry for transient keystore failures.
+    return await read();
+  }
+}
+
+async function saveKeyToKeychain(key: string): Promise<void> {
+  const write = async () => {
+    const result = await Keychain.setGenericPassword(
+      STORAGE_ENCRYPTION_KEYCHAIN_USERNAME,
+      key,
+      {
+        service: STORAGE_ENCRYPTION_KEYCHAIN_SERVICE,
+        accessible: Keychain.ACCESSIBLE.WHEN_UNLOCKED_THIS_DEVICE_ONLY,
+        storage: Keychain.STORAGE_TYPE.AES_GCM_NO_AUTH,
+      },
+    );
+    if (result === false) {
+      throw new Error(
+        '[mmkvEncryptionKeyManager] Keychain rejected the encryption key',
+      );
+    }
+  };
+
+  try {
+    await write();
+  } catch {
+    // Single retry for transient keystore failures.
+    await write();
+  }
+}
+
+/**
+ * Re-encrypts all secured stores from the legacy build-time key to the
+ * per-device key. Idempotent and crash-resumable: each processed store is
+ * marked in the plain 'system' store. Markers are mandatory because MMKV
+ * does not throw on a wrong key - it fails CRC checks and silently loads
+ * the store as empty, so recrypting an already-migrated store again would
+ * wipe it.
+ */
+function recryptSecuredStorages(newKey: string): void {
+  // Direct createMMKV (instead of StorageInstanceManager) to avoid an
+  // import cycle; MMKV caches native instances by id, so this is the same
+  // underlying store.
+  const systemStorage = createMMKV({ id: SYSTEM_STORAGE_ID });
+  const legacyKey = LEGACY_STORE_ENCRYPTION_KEY;
+
+  for (const id of SECURED_STORAGE_IDS) {
+    const marker = `${STORAGE_ENCRYPTION_MIGRATION_MARKER_PREFIX}${id}`;
+    if (systemStorage.getBoolean(marker)) {
+      continue;
+    }
+
+    if (legacyKey && existsMMKV(id)) {
+      try {
+        // Legacy stores were created without encryptionType (AES-128
+        // default), so the migration open must not pass one.
+        const storage = createMMKV({ id, encryptionKey: legacyKey });
+        storage.encrypt(newKey, STORAGE_ENCRYPTION_TYPE);
+      } catch (error) {
+        getLogger().error(
+          `[mmkvEncryptionKeyManager] Failed to recrypt storage "${id}", wiping it: ${String(error)}`,
+        );
+        deleteMMKV(id);
+      }
+    }
+
+    systemStorage.set(marker, true);
+  }
+
+  systemStorage.set(STORAGE_ENCRYPTION_MIGRATION_DONE_FLAG, true);
+}
+
+async function initialize(): Promise<void> {
+  if (cachedConfig) {
+    return;
+  }
+
+  // The catch must cover ONLY the keychain operations: falling back to the
+  // legacy key because of a recrypt error would open already-recrypted
+  // stores with the wrong key (CRC failure -> silent wipe).
+  let resolvedKey: string;
+  try {
+    const existingKey = await readKeyFromKeychain();
+
+    if (existingKey) {
+      resolvedKey = existingKey;
+    } else {
+      resolvedKey = generateEncryptionKey();
+      // Persist before recrypting: if the app crashes mid-migration, the
+      // next launch can read the key back and resume where it left off.
+      await saveKeyToKeychain(resolvedKey);
+    }
+  } catch (error) {
+    getLogger().error(
+      `[mmkvEncryptionKeyManager] Keychain unavailable, falling back to legacy key: ${String(error)}`,
+    );
+
+    if (!LEGACY_STORE_ENCRYPTION_KEY) {
+      throw error;
+    }
+
+    // Hardware keystore unavailable (rare; mostly buggy Android keystore
+    // implementations). Fall back to the legacy build-time key so the app
+    // stays usable. Migration markers are intentionally NOT set, so the
+    // next launch retries the keychain and migrates when it recovers.
+    cachedConfig = { encryptionKey: LEGACY_STORE_ENCRYPTION_KEY };
+    return;
+  }
+
+  const systemStorage = createMMKV({ id: SYSTEM_STORAGE_ID });
+  if (!systemStorage.getBoolean(STORAGE_ENCRYPTION_MIGRATION_DONE_FLAG)) {
+    // Covers both the first launch after an update and resuming a
+    // migration interrupted by a crash on a previous launch.
+    recryptSecuredStorages(resolvedKey);
+  }
+
+  cachedConfig = {
+    encryptionKey: resolvedKey,
+    encryptionType: STORAGE_ENCRYPTION_TYPE,
+  };
+}
+
+/**
+ * Resolves the per-device MMKV encryption key, generating and persisting it
+ * to the iOS Keychain / Android Keystore on first launch, and migrating any
+ * stores encrypted with the legacy build-time key.
+ *
+ * Must complete before any secured MMKV store is accessed. Safe to call
+ * from multiple entry points (app boot, headless tasks) - concurrent calls
+ * share a single initialization run.
+ */
+export function initializeStorageEncryption(): Promise<void> {
+  if (!initPromise) {
+    initPromise = initialize().catch((error: unknown) => {
+      // Allow subsequent calls to retry.
+      initPromise = undefined;
+      throw error;
+    });
+  }
+  return initPromise;
+}
+
+/**
+ * Synchronous accessor for the resolved encryption config, for use by the
+ * lazy storage getters. Requires initializeStorageEncryption() to have
+ * completed.
+ */
+export function getStorageEncryptionConfigSync(): StorageEncryptionConfig {
+  if (!cachedConfig) {
+    throwError(
+      '[mmkvEncryptionKeyManager] Storage encryption has not been initialized',
+    );
+  }
+  return cachedConfig as StorageEncryptionConfig;
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -9136,6 +9136,11 @@ react-native-keyboard-aware-scroll-view@^0.9.5:
     prop-types "^15.6.2"
     react-native-iphone-x-helper "^1.0.3"
 
+react-native-keychain@^10.0.0:
+  version "10.0.0"
+  resolved "https://registry.yarnpkg.com/react-native-keychain/-/react-native-keychain-10.0.0.tgz#1de6f54d27b2376deaac4d51883c066f53b7be7b"
+  integrity sha512-YzPKSAnSzGEJ12IK6CctNLU79T1W15WDrElRQ+1/FsOazGX9ucFPTQwgYe8Dy8jiSEDJKM4wkVa3g4lD2Z+Pnw==
+
 react-native-linear-gradient@^2.8.3:
   version "2.8.3"
   resolved "https://registry.npmjs.org/react-native-linear-gradient/-/react-native-linear-gradient-2.8.3.tgz"


### PR DESCRIPTION
- [x] Tests for the changes have been added
- [x] Related documentation has been added/updated

### 📝 Description

Replaces the build-time MMKV encryption key (`STORE_ENCRYPTION_KEY` from `.env`, which was identical for every install and at build time was embedded in the binary) with a random per-device key generated at first launch and stored in iOS Keychain / Android Keystore using react-native-keychain. Existing users are migrated by recrypting all secured stores using the legacy STORE_ENCRYPTION_KEY.

<!-- Contributions are welcome! If there is a corresponding      -->
<!-- JIRA ticket, link to it by replacing `#` with ticket number -->

🔗 [Jira Ticket M2-10992](https://mindlogger.atlassian.net/browse/M2-10992)

Changes include:

- At launch in mmkvEncryptionKeyManager.ts, we resolve the key: read it from the keychain/store or generate a 32-hex random key and persist it before migrating (recrypting).  Then we recrypt all encrypted stores with our new random key.
- Recrypted stores are flagged as migrated in the plain `system` store after each store finishes recryption. A store that fails to recrypt (e.g. very rare, but a corrupted store) is wiped and logged to Datadog for our reference.
- The StorageEncryptionProvider acts as a gate ensuring that the encryption key has been resolved before any part of the app can touch encrypted stores.
- Both BackgroundWorker handlers (the in-app fetch callback and the Android headless task - app killed) await key resolution before running. If the device has not yet been unlocked after a reboot, we skip the run and let the next scheduled fetch retry.
- In the very rare case that the device has a broken keystore, we fall back to the legacy env key with a Datadog error and retry again later.  This fallback is set just in case this happens; we'll have logged it and be able to see which devices are having this issue, if any.

### 🪤 Peer Testing

  Requires `yarn install` + `yarn pods`

**Upgrade path:**
1. Check out `dev`, build & run on device/sim
2. Log in, start an activity, stop partway, close the app
3. Check out this branch, `yarn install` + `yarn pods`
4. Rebuild & run — do NOT uninstall the app first
5. Confirm: still logged in, activity resumes where you left off

**Fresh install:**
1. Uninstall the app
2. Build & run this branch
3. Log in, kill the app, relaunch
4. Confirm: still logged in

### ✏️ Notes

- The Legacy key is retained for now for the duration of the migration window. This needs to be removed once a sufficient percentage of devices has migrated.
- Failures in background tasks are now logged to Datadog so we know if our changes cause issues in production.
