### PR TITLE
fix: Remove Android max version for exact alarm permission (M2-11048)

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -11,8 +11,7 @@
     <uses-permission android:name="android.permission.HIGH_SAMPLING_RATE_SENSORS" />
     <uses-permission
       android:name="android.permission.SCHEDULE_EXACT_ALARM"
-      android:maxSdkVersion="36"
-      tools:replace="android:maxSdkVersion" />
+      tools:remove="android:maxSdkVersion" />
     <uses-permission
       android:name="android.permission.USE_FULL_SCREEN_INTENT"
       tools:node="remove" />


### PR DESCRIPTION
### 📝 Description

🔗 [Jira Ticket M2-11048](https://mindlogger.atlassian.net/browse/M2-11048)

We have been requesting permissions to [set an exact alarm](https://developer.android.com/develop/background-work/services/alarms#exact) but had set Android 16 (API Level 36) as the max version, so users could not grant the permission on Android 17 (API Level 37).

Changes include:

- Remove `android:maxSdkVersion` on `SCHEDULE_EXACT_ALARM` permission

### 📸 Screenshots

#### Before: Cannot Toggle on Pixel 9 (Android 17)

<img width="360" height="808" alt="2026-08-19 Curious M2-11048 Before" src="https://github.com/user-attachments/assets/149a6282-51e2-4157-9354-8b53633ae29d" />

#### After: Toggle Off/On on Pixel 9 (Android 17)

<img width="360" height="808" alt="2026-08-19 Curious M2-11048 After Off" src="https://github.com/user-attachments/assets/52d6b60f-235b-490b-8082-6cf56f9495b6" />
<img width="360" height="808" alt="2026-08-19 Curious M2-11048 After On" src="https://github.com/user-attachments/assets/4d96a1c1-c27c-47eb-ba7c-e763f8b8b695" />

### ✅ Checklist

### Functionality

- [x] The feature behaves correctly in practice and fulfills the intended business purpose
- [x] The implementation accounts for edge cases, avoids subtle logical errors, and handles somewhat rare failure states (e.g. offline mode for mobile, 3rd party being down, etc)

### Testing

- [x] Verify there are automated tests added that meaningfully cover critical behavior and failure cases
- [x] Code coverage does not go down as result of this change
- [x] Test suite passes

### Security & Data Privacy

- [x] Verify there is no chance we would accidentally log PII to application logs
- [x] Verify this addition does not materially affect our security attack surface, and if so it has undergone security review
- [x] All inputs are sanitized
- [x] New dependencies are well maintained, have significant justification for being added to the project, and are documented in the Curious [open source credit page](https://mindlogger.atlassian.net/jira/servicedesk/projects/MLA/knowledge/articles/340623543?spaceKey=MLA)

### Logging/Monitoring

- [x] Logging is implemented for this change such that you could troubleshoot this feature in production
- [x] The change/feature is able to be monitored in production

### Performance

- [x] This change does not introduce n+1 queries or other performance issues within our expected scale (e.g. missing indexes on frequently queried columns, frequently updating tables that are accessed often)

### Readability

- [x] All commented out code is removed
- [x] Debugging code including extraneous log lines are removed
- [x] Code is easy to understand through naming and structure; comments explain intent or non‑obvious decisions

### Change Safety

- [x] ~~Backend changes are backwards compatible with old clients, or it is well known they are not and a deployment/rollout plan is in place. This include backend changes being compatible with old mobile app versions, as well as applet versioning within Curious.~~
- [x] ~~Destructive database migrations are rolled out in stages. For example, renaming a column means adding a new column and migrating the existing data to that columns in one deployment. Then monitoring to ensure that field isn’t used, and finally removing that old column in a separate deployment.~~
